### PR TITLE
docs: Fix incorrect hardware information

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -141,6 +141,8 @@ The prompt upsampling feature uses Mistral to enhance the original prompt with m
 
 ## Hardware
 
-- **Machine:** Mac Studio M2 Ultra
-- **RAM:** 192GB Unified Memory
+- **Machine:** MacBook Pro 14" (Nov 2023)
+- **Chip:** Apple M3 Max
+- **RAM:** 96 GB Unified Memory
+- **macOS:** Tahoe 26.2
 - **Quantization:** 8-bit text encoder + qint8 transformer (~60GB peak)


### PR DESCRIPTION
## Summary

Fix incorrect hardware specifications in the documentation.

### Changes

| Field | Before | After |
|-------|--------|-------|
| Machine | Mac Studio M2 Ultra | MacBook Pro 14" (Nov 2023) |
| Chip | (implied M2 Ultra) | Apple M3 Max |
| RAM | 192GB | 96 GB |
| macOS | (not specified) | Tahoe 26.2 |

### Files Changed

- `docs/examples/README.md`

Fixes #7

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)