### PR TITLE
feat: Return upsampled prompt in generation result

### DIFF
--- a/Sources/Flux2Core/Loading/KleinTextEncoder.swift
+++ b/Sources/Flux2Core/Loading/KleinTextEncoder.swift
@@ -114,6 +114,16 @@ public class KleinTextEncoder: @unchecked Sendable {
     ///           Klein 4B: [1, 512, 7680]
     ///           Klein 9B: [1, 512, 12288]
     public func encode(_ prompt: String, upsample: Bool = false) throws -> MLXArray {
+        let (embeddings, _) = try encodeWithPrompt(prompt, upsample: upsample)
+        return embeddings
+    }
+
+    /// Encode a text prompt to Klein embeddings and return the used prompt
+    /// - Parameters:
+    ///   - prompt: Text prompt to encode
+    ///   - upsample: Whether to enhance the prompt before encoding (default: false)
+    /// - Returns: Tuple of (embeddings tensor, used prompt string)
+    public func encodeWithPrompt(_ prompt: String, upsample: Bool = false) throws -> (embeddings: MLXArray, usedPrompt: String) {
         guard FluxTextEncoders.shared.isKleinLoaded else {
             throw Flux2Error.modelNotLoaded("Klein text encoder not loaded")
         }
@@ -136,7 +146,7 @@ public class KleinTextEncoder: @unchecked Sendable {
 
         Flux2Debug.log("Embeddings shape: \(embeddings.shape)")
 
-        return embeddings
+        return (embeddings: embeddings, usedPrompt: finalPrompt)
     }
 
     // MARK: - Memory Management

--- a/Sources/Flux2Core/Loading/MistralEncoder.swift
+++ b/Sources/Flux2Core/Loading/MistralEncoder.swift
@@ -398,6 +398,16 @@ public class Flux2TextEncoder: @unchecked Sendable {
     ///   - upsample: Whether to enhance the prompt before encoding (default: false)
     /// - Returns: Embeddings tensor [1, 512, 15360]
     public func encode(_ prompt: String, upsample: Bool = false) throws -> MLXArray {
+        let (embeddings, _) = try encodeWithPrompt(prompt, upsample: upsample)
+        return embeddings
+    }
+
+    /// Encode a text prompt to Flux.2 embeddings and return the used prompt
+    /// - Parameters:
+    ///   - prompt: Text prompt to encode
+    ///   - upsample: Whether to enhance the prompt before encoding (default: false)
+    /// - Returns: Tuple of (embeddings tensor [1, 512, 15360], used prompt string)
+    public func encodeWithPrompt(_ prompt: String, upsample: Bool = false) throws -> (embeddings: MLXArray, usedPrompt: String) {
         guard FluxTextEncoders.shared.isModelLoaded else {
             throw Flux2Error.modelNotLoaded("Text encoder not loaded")
         }
@@ -420,7 +430,7 @@ public class Flux2TextEncoder: @unchecked Sendable {
 
         Flux2Debug.log("Embeddings shape: \(embeddings.shape)")
 
-        return embeddings
+        return (embeddings: embeddings, usedPrompt: finalPrompt)
     }
 
     // MARK: - Memory Management

--- a/Tests/Flux2CoreTests/Flux2CoreTests.swift
+++ b/Tests/Flux2CoreTests/Flux2CoreTests.swift
@@ -708,3 +708,128 @@ final class EmpiricalMuTests: XCTestCase {
         XCTAssertNotEqual(mu50, mu20)
     }
 }
+
+// MARK: - Generation Result Tests
+
+final class GenerationResultTests: XCTestCase {
+
+    func testGenerationResultInitialization() {
+        // Create a minimal test image (1x1 pixel)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+        guard let context = CGContext(
+            data: nil,
+            width: 1,
+            height: 1,
+            bitsPerComponent: 8,
+            bytesPerRow: 4,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        ), let testImage = context.makeImage() else {
+            XCTFail("Failed to create test image")
+            return
+        }
+
+        let result = Flux2GenerationResult(
+            image: testImage,
+            usedPrompt: "enhanced: a beautiful sunset",
+            wasUpsampled: true,
+            originalPrompt: "a beautiful sunset"
+        )
+
+        XCTAssertEqual(result.usedPrompt, "enhanced: a beautiful sunset")
+        XCTAssertEqual(result.originalPrompt, "a beautiful sunset")
+        XCTAssertTrue(result.wasUpsampled)
+        XCTAssertEqual(result.image.width, 1)
+        XCTAssertEqual(result.image.height, 1)
+    }
+
+    func testGenerationResultNoUpsampling() {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+        guard let context = CGContext(
+            data: nil,
+            width: 1,
+            height: 1,
+            bitsPerComponent: 8,
+            bytesPerRow: 4,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        ), let testImage = context.makeImage() else {
+            XCTFail("Failed to create test image")
+            return
+        }
+
+        let prompt = "a cat sitting on a chair"
+        let result = Flux2GenerationResult(
+            image: testImage,
+            usedPrompt: prompt,
+            wasUpsampled: false,
+            originalPrompt: prompt
+        )
+
+        XCTAssertFalse(result.wasUpsampled)
+        XCTAssertEqual(result.usedPrompt, result.originalPrompt)
+    }
+
+    func testGenerationResultPromptDifference() {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+        guard let context = CGContext(
+            data: nil,
+            width: 1,
+            height: 1,
+            bitsPerComponent: 8,
+            bytesPerRow: 4,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        ), let testImage = context.makeImage() else {
+            XCTFail("Failed to create test image")
+            return
+        }
+
+        let original = "cat"
+        let enhanced = "A majestic orange tabby cat sitting gracefully on a velvet chair, soft lighting, detailed fur"
+
+        let result = Flux2GenerationResult(
+            image: testImage,
+            usedPrompt: enhanced,
+            wasUpsampled: true,
+            originalPrompt: original
+        )
+
+        XCTAssertTrue(result.wasUpsampled)
+        XCTAssertNotEqual(result.usedPrompt, result.originalPrompt)
+        XCTAssertTrue(result.usedPrompt.count > result.originalPrompt.count)
+    }
+
+    func testGenerationResultSendable() {
+        // Verify Flux2GenerationResult conforms to Sendable
+        // This test ensures the struct can be safely passed across concurrency boundaries
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+        guard let context = CGContext(
+            data: nil,
+            width: 1,
+            height: 1,
+            bitsPerComponent: 8,
+            bytesPerRow: 4,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        ), let testImage = context.makeImage() else {
+            XCTFail("Failed to create test image")
+            return
+        }
+
+        let result = Flux2GenerationResult(
+            image: testImage,
+            usedPrompt: "test prompt",
+            wasUpsampled: false,
+            originalPrompt: "test prompt"
+        )
+
+        // If this compiles, the type is Sendable
+        let _: any Sendable = result
+        XCTAssertTrue(true)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `Flux2GenerationResult` struct to return both the generated image and prompt metadata
- Allows users to see what prompt was actually used when upsampling is enabled
- Backward compatible - existing API unchanged

## Changes

### New API
```swift
public struct Flux2GenerationResult: Sendable {
    public let image: CGImage
    public let usedPrompt: String      // Final prompt after upsampling
    public let wasUpsampled: Bool      // Whether prompt was enhanced
    public let originalPrompt: String  // User's original input
}

// New methods
func generateWithResult(...) async throws -> Flux2GenerationResult
func generateTextToImageWithResult(...) async throws -> Flux2GenerationResult
func generateImageToImageWithResult(...) async throws -> Flux2GenerationResult
```

### Text Encoder Updates
- Added `encodeWithPrompt()` to both `Flux2TextEncoder` and `KleinTextEncoder`
- Returns tuple of (embeddings, usedPrompt)

## Test plan
- [x] Added 4 unit tests for `Flux2GenerationResult`
- [x] All tests pass
- [x] Build succeeds

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)