### PR TITLE
fix: Use MLX.Memory.clearCache() for proper GPU memory cleanup

### DIFF
--- a/Sources/Flux2Core/Utils/MemoryManager.swift
+++ b/Sources/Flux2Core/Utils/MemoryManager.swift
@@ -81,9 +81,7 @@ public final class Flux2MemoryManager: @unchecked Sendable {
     /// Clear GPU cache
     /// Call this between phases or periodically during generation
     public func clearCache() {
-        // Evaluate empty array to sync GPU
-        eval([])
-
+        MLX.Memory.clearCache()
         Flux2Debug.log("GPU cache cleared")
     }
 


### PR DESCRIPTION
## Summary
- Fixed `clearCache()` in MemoryManager.swift to use `MLX.Memory.clearCache()` instead of `eval([])`
- `eval([])` only syncs the GPU but doesn't free memory
- Now aligns with MistralGenerator and Qwen3Generator implementations

## Changes
- `Sources/Flux2Core/Utils/MemoryManager.swift`: Replace `eval([])` with `MLX.Memory.clearCache()`

## Test plan
- [x] Build succeeds
- [x] Existing tests pass
- [x] Memory cleanup now properly frees GPU cache

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)