### PR TITLE
feat: Expose maxReferenceImages per model for I2I

### DIFF
--- a/Sources/Flux2App/ViewModels/ImageGenerationViewModel.swift
+++ b/Sources/Flux2App/ViewModels/ImageGenerationViewModel.swift
@@ -113,7 +113,7 @@ class ImageGenerationViewModel: ObservableObject {
 
     /// Add a reference image from URL
     func addReferenceImage(from url: URL) {
-        guard referenceImages.count < 3 else { return }
+        guard referenceImages.count < selectedModel.maxReferenceImages else { return }
 
         guard let nsImage = NSImage(contentsOf: url),
               let cgImage = nsImage.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
@@ -132,7 +132,7 @@ class ImageGenerationViewModel: ObservableObject {
 
     /// Add a reference image from NSImage (drag & drop)
     func addReferenceImage(from nsImage: NSImage) {
-        guard referenceImages.count < 3 else { return }
+        guard referenceImages.count < selectedModel.maxReferenceImages else { return }
 
         guard let cgImage = nsImage.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
             errorMessage = "Failed to process dropped image"

--- a/Sources/Flux2App/Views/ImageToImageView.swift
+++ b/Sources/Flux2App/Views/ImageToImageView.swift
@@ -94,9 +94,9 @@ struct ImageToImageView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-            // Drop zone with image slots
+            // Drop zone with image slots (dynamic based on model)
             HStack(spacing: 12) {
-                ForEach(0..<3, id: \.self) { index in
+                ForEach(0..<viewModel.selectedModel.maxReferenceImages, id: \.self) { index in
                     if index < viewModel.referenceImages.count {
                         // Show existing image
                         ReferenceImageSlot(
@@ -457,7 +457,7 @@ struct ImageToImageView: View {
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
-                    .disabled(viewModel.referenceImages.count >= 3)
+                    .disabled(viewModel.referenceImages.count >= viewModel.selectedModel.maxReferenceImages)
                 }
 
                 Button(action: {
@@ -582,7 +582,7 @@ struct ImageToImageView: View {
         panel.canChooseDirectories = false
 
         if panel.runModal() == .OK {
-            for url in panel.urls.prefix(3 - viewModel.referenceImages.count) {
+            for url in panel.urls.prefix(viewModel.selectedModel.maxReferenceImages - viewModel.referenceImages.count) {
                 viewModel.addReferenceImage(from: url)
             }
         }

--- a/Sources/Flux2CLI/Flux2CLI.swift
+++ b/Sources/Flux2CLI/Flux2CLI.swift
@@ -421,12 +421,13 @@ struct ImageToImage: AsyncParsableCommand {
             actualGuidance = guidance ?? loraOverrides?.guidance ?? 1.0
         }
 
-        // Validate image count (1-3 reference images)
-        guard !images.isEmpty && images.count <= 3 else {
+        // Validate image count (model-specific limit)
+        let maxImages = modelVariant.maxReferenceImages
+        guard !images.isEmpty && images.count <= maxImages else {
             if images.isEmpty {
-                throw ValidationError("Please provide 1-3 reference images with --images")
+                throw ValidationError("Please provide 1-\(maxImages) reference images with --images")
             } else {
-                throw ValidationError("Maximum 3 reference images allowed")
+                throw ValidationError("Maximum \(maxImages) reference images allowed for \(modelVariant.displayName)")
             }
         }
 

--- a/Sources/Flux2Core/Configuration/Flux2Config.swift
+++ b/Sources/Flux2Core/Configuration/Flux2Config.swift
@@ -100,6 +100,15 @@ public enum Flux2Model: String, CaseIterable, Sendable {
         case .klein9B: return 62    // ~62 seconds
         }
     }
+
+    /// Maximum number of reference images for I2I generation
+    /// Source: https://docs.bfl.ai/flux_2/flux2_image_editing
+    public var maxReferenceImages: Int {
+        switch self {
+        case .dev: return 6         // Limited by memory
+        case .klein4B, .klein9B: return 4
+        }
+    }
 }
 
 // MARK: - Transformer Configuration

--- a/Sources/Flux2Core/Configuration/ModelRegistry.swift
+++ b/Sources/Flux2Core/Configuration/ModelRegistry.swift
@@ -104,6 +104,11 @@ public enum ModelRegistry {
             modelType.defaultGuidance
         }
 
+        /// Maximum number of reference images for I2I (delegates to modelType)
+        public var maxReferenceImages: Int {
+            modelType.maxReferenceImages
+        }
+
         public var quantization: TransformerQuantization {
             switch self {
             case .bf16, .klein4B_bf16, .klein9B_bf16: return .bf16

--- a/Tests/Flux2CoreTests/Flux2CoreTests.swift
+++ b/Tests/Flux2CoreTests/Flux2CoreTests.swift
@@ -494,6 +494,17 @@ final class ModelRegistryTests: XCTestCase {
         XCTAssertEqual(ModelRegistry.TransformerVariant.klein4B_bf16.defaultSteps, 4)
         XCTAssertEqual(ModelRegistry.TransformerVariant.klein4B_bf16.defaultGuidance, 1.0)
     }
+
+    func testTransformerVariantMaxReferenceImages() {
+        // Dev variants: 6 images (delegates to modelType)
+        XCTAssertEqual(ModelRegistry.TransformerVariant.bf16.maxReferenceImages, 6)
+        XCTAssertEqual(ModelRegistry.TransformerVariant.qint8.maxReferenceImages, 6)
+
+        // Klein variants: 4 images
+        XCTAssertEqual(ModelRegistry.TransformerVariant.klein4B_bf16.maxReferenceImages, 4)
+        XCTAssertEqual(ModelRegistry.TransformerVariant.klein4B_8bit.maxReferenceImages, 4)
+        XCTAssertEqual(ModelRegistry.TransformerVariant.klein9B_bf16.maxReferenceImages, 4)
+    }
 }
 
 // MARK: - Flux2Model Tests
@@ -521,6 +532,15 @@ final class Flux2ModelTests: XCTestCase {
         XCTAssertTrue(Flux2Model.klein4B.license.contains("Apache"))
         XCTAssertTrue(Flux2Model.klein4B.isCommercialUseAllowed)
         XCTAssertFalse(Flux2Model.dev.isCommercialUseAllowed)
+    }
+
+    func testMaxReferenceImages() {
+        // Dev supports up to 6 reference images (memory limited)
+        XCTAssertEqual(Flux2Model.dev.maxReferenceImages, 6)
+
+        // Klein models support up to 4 reference images
+        XCTAssertEqual(Flux2Model.klein4B.maxReferenceImages, 4)
+        XCTAssertEqual(Flux2Model.klein9B.maxReferenceImages, 4)
     }
 }
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -7,7 +7,7 @@ The `flux2` command-line tool provides access to Flux.2 image generation on Mac 
 | Command | Description |
 |---------|-------------|
 | `t2i` | Text-to-Image generation (default) |
-| `i2i` | Image-to-Image generation with 1-3 reference images |
+| `i2i` | Image-to-Image generation (up to 4 images for Klein, 6 for Dev) |
 | `download` | Download required models |
 | `info` | Show system and model information |
 

--- a/docs/Flux2App.md
+++ b/docs/Flux2App.md
@@ -5,7 +5,7 @@ A complete SwiftUI demo application showcasing all Flux.2 Swift MLX capabilities
 ## Features
 
 - **Text-to-Image (T2I)**: Generate images from text prompts
-- **Image-to-Image (I2I)**: Transform images with up to 3 reference images
+- **Image-to-Image (I2I)**: Transform images with multiple reference images (up to 4 for Klein, 6 for Dev)
 - **Chat**: Interactive conversations with Mistral 24B and Qwen3
 - **Vision (VLM)**: Analyze images with Mistral Pixtral
 - **FLUX.2 Tools**: Extract embeddings and upsample prompts
@@ -95,7 +95,7 @@ Download and manage text encoders and diffusion models:
 ### Image-to-Image
 
 1. Select **Image Generation > Image to Image**
-2. Drop 1-3 reference images
+2. Drop reference images (up to 4 for Klein, 6 for Dev)
 3. Adjust **Strength** (0.0 = preserve original, 1.0 = full transformation)
 4. Enter a prompt describing the desired changes
 5. Optionally add **Interpret Images** for VLM-based semantic understanding


### PR DESCRIPTION
## Summary
- Added `maxReferenceImages` property to `Flux2Model` enum
- Klein models: 4 reference images max
- Dev model: 6 reference images max (memory limited)
- TransformerVariant delegates to modelType for consistency

## Changes

### API
- `Flux2Model.maxReferenceImages: Int` - Maximum reference images for I2I
- `ModelRegistry.TransformerVariant.maxReferenceImages: Int` - Delegates to modelType

### CLI
- Dynamic validation based on selected model instead of hardcoded 3
- Better error messages with model name

### App
- ViewModel uses `selectedModel.maxReferenceImages` for image limit
- UI shows dynamic number of image slots based on model

### Docs
- Updated CLI.md and Flux2App.md with correct limits

## Source
Based on [BFL Documentation](https://docs.bfl.ai/flux_2/flux2_image_editing)

## Test plan
- [x] Build succeeds
- [x] Tests pass (2 new tests for maxReferenceImages)
- [x] CLI validates correctly per model
- [x] App shows correct number of slots

Fixes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)