### PR TITLE
perf: Load transformer as native MLX QuantizedLinear to halve GPU memory

### DIFF
--- a/Sources/Flux2CLI/TrainLoRACommand.swift
+++ b/Sources/Flux2CLI/TrainLoRACommand.swift
@@ -519,8 +519,8 @@ struct TrainLoRA: AsyncParsableCommand {
             memoryOptimization: .aggressive  // Use aggressive memory mode for training
         )
 
-        let weights = try Flux2WeightLoader.loadWeights(from: modelPath)
-        try Flux2WeightLoader.applyTransformerWeights(weights, to: transformer)
+        var weights = try Flux2WeightLoader.loadWeights(from: modelPath)
+        try Flux2WeightLoader.applyTransformerWeights(&weights, to: transformer)
         eval(transformer.parameters())
 
         return transformer

--- a/Sources/Flux2Core/Training/LoRATrainingHelper.swift
+++ b/Sources/Flux2Core/Training/LoRATrainingHelper.swift
@@ -432,8 +432,8 @@ extension LoRATrainingHelper {
         Flux2Debug.log("[LoRATrainingHelper] Loading transformer with aggressive memory optimization")
 
         // Load weights
-        let weights = try Flux2WeightLoader.loadWeights(from: weightsPath)
-        try Flux2WeightLoader.applyTransformerWeights(weights, to: transformer)
+        var weights = try Flux2WeightLoader.loadWeights(from: weightsPath)
+        try Flux2WeightLoader.applyTransformerWeights(&weights, to: transformer)
 
         // Force evaluation to materialize weights
         eval(transformer.parameters())

--- a/Sources/Flux2Core/Transformer/Flux2Embeddings.swift
+++ b/Sources/Flux2Core/Transformer/Flux2Embeddings.swift
@@ -143,14 +143,14 @@ public class Flux2TimestepGuidanceEmbeddings: Module, @unchecked Sendable {
 
 /// Pooled text embedding projection for conditioning
 public class PooledTextProjection: Module, @unchecked Sendable {
-    let linear: Linear
+    @ModuleInfo var linear: Linear
 
     /// Initialize pooled text projection
     /// - Parameters:
     ///   - inputDim: Input dimension from text encoder
     ///   - outputDim: Output dimension (time embed dim)
     public init(inputDim: Int = 768, outputDim: Int = 6144) {
-        self.linear = Linear(inputDim, outputDim)
+        self._linear = ModuleInfo(wrappedValue: Linear(inputDim, outputDim))
     }
 
     public func callAsFunction(_ pooledEmbedding: MLXArray) -> MLXArray {

--- a/Sources/Flux2Core/Transformer/Flux2FeedForward.swift
+++ b/Sources/Flux2Core/Transformer/Flux2FeedForward.swift
@@ -9,7 +9,7 @@ import MLXNN
 /// Used in some transformer variants
 /// Optimized with kernel fusion for the gating operation
 public class GEGLU: Module, @unchecked Sendable {
-    let proj: Linear
+    @ModuleInfo var proj: Linear
     let dim: Int
     let innerDim: Int
 
@@ -22,7 +22,7 @@ public class GEGLU: Module, @unchecked Sendable {
         self.dim = dim
         self.innerDim = innerDim
         // Projects to 2x inner_dim for gate and value
-        self.proj = Linear(dim, innerDim * 2, bias: bias)
+        self._proj = ModuleInfo(wrappedValue: Linear(dim, innerDim * 2, bias: bias))
     }
 
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
@@ -113,9 +113,9 @@ public class Flux2FeedForward: Module, @unchecked Sendable {
 public class Flux2FeedForwardSplit: Module, @unchecked Sendable {
     let dim: Int
     let innerDim: Int
-    let linearGate: Linear
-    let linearUp: Linear
-    let linearDown: Linear
+    @ModuleInfo var linearGate: Linear
+    @ModuleInfo var linearUp: Linear
+    @ModuleInfo var linearDown: Linear
 
     public init(
         dim: Int,
@@ -125,9 +125,9 @@ public class Flux2FeedForwardSplit: Module, @unchecked Sendable {
         self.dim = dim
         self.innerDim = innerDim ?? (dim * 4)
 
-        self.linearGate = Linear(dim, self.innerDim, bias: bias)
-        self.linearUp = Linear(dim, self.innerDim, bias: bias)
-        self.linearDown = Linear(self.innerDim, dim, bias: bias)
+        self._linearGate = ModuleInfo(wrappedValue: Linear(dim, self.innerDim, bias: bias))
+        self._linearUp = ModuleInfo(wrappedValue: Linear(dim, self.innerDim, bias: bias))
+        self._linearDown = ModuleInfo(wrappedValue: Linear(self.innerDim, dim, bias: bias))
     }
 
     public func callAsFunction(_ x: MLXArray) -> MLXArray {

--- a/Sources/Flux2Core/Transformer/Flux2Modulation.swift
+++ b/Sources/Flux2Core/Transformer/Flux2Modulation.swift
@@ -125,13 +125,13 @@ public func applyGate(_ residual: MLXArray, gate: MLXArray) -> MLXArray {
 public class AdaLayerNormContinuous: Module, @unchecked Sendable {
     let dim: Int
     let norm: LayerNorm
-    let linear: Linear
+    @ModuleInfo var linear: Linear
 
     public init(dim: Int, eps: Float = 1e-6) {
         self.dim = dim
         self.norm = LayerNorm(dimensions: dim, eps: eps, affine: false)
         // Projects conditioning to shift and scale (no bias to match checkpoint)
-        self.linear = Linear(dim, dim * 2, bias: false)
+        self._linear = ModuleInfo(wrappedValue: Linear(dim, dim * 2, bias: false))
     }
 
     /// Apply adaptive layer norm

--- a/Sources/Flux2Core/Transformer/Flux2ParallelAttention.swift
+++ b/Sources/Flux2Core/Transformer/Flux2ParallelAttention.swift
@@ -184,19 +184,19 @@ public class Flux2ParallelSelfAttentionSplit: Module, @unchecked Sendable {
     let mlpHiddenDim: Int
 
     // Separate projections (var for LoRA injection)
-    var toQ: Linear
-    var toK: Linear
-    var toV: Linear
-    var mlpGate: Linear
-    var mlpUp: Linear
+    @ModuleInfo var toQ: Linear
+    @ModuleInfo var toK: Linear
+    @ModuleInfo var toV: Linear
+    @ModuleInfo var mlpGate: Linear
+    @ModuleInfo var mlpUp: Linear
 
     // QK normalization
     let normQ: RMSNorm
     let normK: RMSNorm
 
     // Separate output projections (var for LoRA injection)
-    var toAttnOut: Linear
-    var mlpDown: Linear
+    @ModuleInfo var toAttnOut: Linear
+    @ModuleInfo var mlpDown: Linear
 
     public init(
         dim: Int,
@@ -210,17 +210,17 @@ public class Flux2ParallelSelfAttentionSplit: Module, @unchecked Sendable {
         self.innerDim = numHeads * headDim
         self.mlpHiddenDim = Int(Float(dim) * mlpRatio)
 
-        self.toQ = Linear(dim, innerDim, bias: false)
-        self.toK = Linear(dim, innerDim, bias: false)
-        self.toV = Linear(dim, innerDim, bias: false)
-        self.mlpGate = Linear(dim, mlpHiddenDim, bias: false)
-        self.mlpUp = Linear(dim, mlpHiddenDim, bias: false)
+        self._toQ = ModuleInfo(wrappedValue: Linear(dim, innerDim, bias: false))
+        self._toK = ModuleInfo(wrappedValue: Linear(dim, innerDim, bias: false))
+        self._toV = ModuleInfo(wrappedValue: Linear(dim, innerDim, bias: false))
+        self._mlpGate = ModuleInfo(wrappedValue: Linear(dim, mlpHiddenDim, bias: false))
+        self._mlpUp = ModuleInfo(wrappedValue: Linear(dim, mlpHiddenDim, bias: false))
 
         self.normQ = RMSNorm(dim: headDim)
         self.normK = RMSNorm(dim: headDim)
 
-        self.toAttnOut = Linear(innerDim, dim, bias: false)
-        self.mlpDown = Linear(mlpHiddenDim, dim, bias: false)
+        self._toAttnOut = ModuleInfo(wrappedValue: Linear(innerDim, dim, bias: false))
+        self._mlpDown = ModuleInfo(wrappedValue: Linear(mlpHiddenDim, dim, bias: false))
     }
 
     public func callAsFunction(

--- a/Sources/Flux2Core/Utils/MemoryManager.swift
+++ b/Sources/Flux2Core/Utils/MemoryManager.swift
@@ -113,19 +113,25 @@ public final class Flux2MemoryManager: @unchecked Sendable {
             }
         }
 
+        let metalActiveMB = MLX.Memory.activeMemory / 1_048_576
+        let metalPeakMB = MLX.Memory.peakMemory / 1_048_576
+        let metalCacheMB = MLX.Memory.cacheMemory / 1_048_576
+
         if result == KERN_SUCCESS {
             let usedMB = info.resident_size / 1_048_576
-            let physicalMB = physicalMemory / 1_048_576
 
             return """
             Memory Usage:
-              Resident: \(usedMB) MB
-              Physical: \(physicalMB) MB (\(physicalMemoryGB) GB)
-              Estimated Available: ~\(estimatedAvailableMemoryGB) GB
+              Metal GPU — active: \(metalActiveMB) MB, peak: \(metalPeakMB) MB, cache: \(metalCacheMB) MB
+              Process Resident: \(usedMB) MB | System RAM: \(physicalMemoryGB) GB
             """
         }
 
-        return "Memory info unavailable"
+        return """
+        Memory Usage:
+          Metal GPU — active: \(metalActiveMB) MB, peak: \(metalPeakMB) MB, cache: \(metalCacheMB) MB
+          Process info unavailable | System RAM: \(physicalMemoryGB) GB
+        """
     }
 
     /// Log current memory state


### PR DESCRIPTION
## Summary

- Call `quantize(model:)` after loading quanto qint8 weights to convert Linear to QuantizedLinear (8-bit, groupSize=64), halving GPU memory
- Adapt `mergeLoRAWeights()` for QuantizedLinear via dequant-merge-requant path
- Use inout weight mapping to free raw entries progressively (peak 98GB to 71GB)
- Add Metal GPU stats to memory logging

## Measured results (Dev qint8, 96GB M2 Ultra)

| Metric | Before | After | Gain |
|--------|--------|-------|------|
| Active memory | 60 GB | 32 GB | -47% |
| Loading peak | 98 GB | 71 GB | -28% |
| LoRA merge peak | 75 GB | 51 GB | -32% |

## Test plan

- [x] Dev qint8 without LoRA — correct image, 32GB active
- [x] Dev qint8 + Turbo LoRA (170 layers) — correct image, 51GB peak merge
- [ ] Unit tests pass

Generated with Claude Code