### PR TITLE
docs: Update README with documentation index and fix stale values

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -16,7 +16,7 @@ This directory contains example images and documentation for the Flux.2 Swift ML
 |---------|------------|----------|----------|
 | Parameters | 32B | 4B | 9B |
 | Text Encoder | Mistral Small 3.2 | Qwen3-4B | Qwen3-8B |
-| Default Steps | 50 | 4 (distilled) | 4 (distilled) |
+| Default Steps | 28 | 4 (distilled) | 4 (distilled) |
 | Transformer (qint8) | ~33GB | ~4GB | ~9GB |
 | 1024x1024 Time | ~35 min | ~26s | ~56s |
 | License | Non-commercial | **Apache 2.0** | Non-commercial |

--- a/docs/examples/comparison.md
+++ b/docs/examples/comparison.md
@@ -8,7 +8,7 @@ A side-by-side comparison of all Flux.2 model variants.
 |---------|------------|----------|----------|
 | **Parameters** | 32B | 4B | 9B |
 | **Text Encoder** | Mistral Small 3.2 | Qwen3-4B | Qwen3-8B |
-| **Default Steps** | 50 | 4 (distilled) | 4 (distilled) |
+| **Default Steps** | 28 | 4 (distilled) | 4 (distilled) |
 | **Default Guidance** | 4.0 | 1.0 | 1.0 |
 | **VRAM Usage (qint8)** | ~33GB | ~4GB | ~9GB |
 | **License** | Non-commercial | Apache 2.0 | Non-commercial |


### PR DESCRIPTION
## Summary

- Add **On-the-fly Quantization** section with measured memory table (bf16/qint8/int4)
- Replace flat doc list with structured **Documentation** section indexing all guides, examples, benchmarks, and training examples
- Update **memory requirements** table with int4/qint8/bf16 columns
- Remove stale info: "Klein 9B: Only bf16 available", unchecked gradient checkpointing roadmap item, outdated roadmap
- Fix Dev default steps **50 → 28** in `comparison.md` and `examples/README.md`

## Test plan

- [x] All links verified against existing files
- [x] No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)