### PR TITLE
fix: Robust VLM JSON extraction for training scoring

### DIFF
--- a/Sources/Flux2Core/Training/Loop/SimpleLoRATrainer.swift
+++ b/Sources/Flux2Core/Training/Loop/SimpleLoRATrainer.swift
@@ -2096,6 +2096,10 @@ public final class SimpleLoRATrainer {
                     temperature: 0
                 )
 
+                // Debug: print raw VLM response for diagnosis
+                print("    [VLM Raw] ref=\(refImage.lastPathComponent) val=\(imageName)")
+                print("    [VLM Raw] response: \(result.text.prefix(500))")
+
                 let (sceneScore, styleScore, sceneReason, styleReason) = parseVLMScores(result.text)
 
                 // Compare vs baseline if enabled
@@ -2115,6 +2119,7 @@ public final class SimpleLoRATrainer {
                             maxTokens: 300,
                             temperature: 0
                         )
+                        print("    [VLM Raw baseline] response: \(blResult.text.prefix(500))")
                         let (blScene, blStyle, _, _) = parseVLMScores(blResult.text)
                         baselineScene = blScene
                         baselineStyle = blStyle

--- a/Sources/FluxTextEncoders/Model/Qwen35/Qwen35VLM.swift
+++ b/Sources/FluxTextEncoders/Model/Qwen35/Qwen35VLM.swift
@@ -185,11 +185,23 @@ public class Qwen35VLM {
         }
 
         let totalTime = Date().timeIntervalSince(startTime)
-        var outputText = tokenizer.decode(tokens: generatedTokens)
+        let rawText = tokenizer.decode(tokens: generatedTokens)
+        var outputText = rawText
 
-        // Strip thinking tags and everything before </think>
-        if let thinkEnd = outputText.range(of: "</think>") {
-            outputText = String(outputText[thinkEnd.upperBound...])
+        // Strip thinking tags — but preserve JSON content
+        // If the response contains a JSON object, extract it regardless of position
+        if let jsonStart = rawText.lastIndex(of: "{"), let jsonEnd = rawText.lastIndex(of: "}"), jsonStart < jsonEnd {
+            // There's a JSON object — check if it's a score JSON
+            let jsonCandidate = String(rawText[jsonStart...jsonEnd])
+            if jsonCandidate.contains("score") {
+                // It's a score JSON — use it directly (don't strip it away)
+                outputText = jsonCandidate
+            } else if let thinkEnd = rawText.range(of: "</think>") {
+                outputText = String(rawText[thinkEnd.upperBound...])
+            }
+        } else if let thinkEnd = rawText.range(of: "</think>") {
+            // No JSON found — strip thinking as before
+            outputText = String(rawText[thinkEnd.upperBound...])
         }
         // Strip end-of-turn token
         outputText = outputText.replacingOccurrences(of: "<|im_end|>", with: "")


### PR DESCRIPTION
## Summary

- VLM `generate()` now extracts JSON containing "score" from raw text before stripping thinking tags
- Added `[VLM Raw]` debug logging in training scoring to show reference/validation image names and raw VLM response
- Confirmed through testing that 0/100 scores for person-specific LoRA baselines are correct (the base model generates a random face, not the training subject)

## Test plan

- [x] 270 tests, 0 failures
- [x] Verified with real training: VLM correctly outputs JSON after `</think>` tag
- [x] Parsing extracts `scene_score` and `style_score` from JSON successfully
- [x] Debug logs show full raw VLM response for diagnosis

🤖 Generated with [Claude Code](https://claude.com/claude-code)