### PR TITLE
feat: Add enableThinking parameter to VLM, disable for scoring

### DIFF
--- a/Sources/Flux2CLI/TestQwen35.swift
+++ b/Sources/Flux2CLI/TestQwen35.swift
@@ -35,6 +35,9 @@ struct TestQwen35: AsyncParsableCommand {
     @Option(name: .long, help: "Maximum tokens to generate")
     var maxTokens: Int = 512
 
+    @Flag(name: .long, help: "Disable thinking mode (faster, direct response)")
+    var noThink: Bool = false
+
     @Option(name: .long, help: "Temperature (0 = greedy)")
     var temperature: Float = 0.7
 
@@ -137,6 +140,7 @@ struct TestQwen35: AsyncParsableCommand {
                 image: img,
                 prompt: prompt,
                 systemPrompt: effectiveSystemPrompt,
+                enableThinking: !noThink,
                 maxTokens: maxTokens,
                 temperature: temperature
             ) { token in
@@ -148,6 +152,7 @@ struct TestQwen35: AsyncParsableCommand {
             result = try FluxTextEncoders.shared.generateWithQwen35(
                 prompt: prompt,
                 systemPrompt: effectiveSystemPrompt,
+                enableThinking: !noThink,
                 maxTokens: maxTokens,
                 temperature: temperature
             ) { token in

--- a/Sources/Flux2Core/Training/LoRAEvaluator.swift
+++ b/Sources/Flux2Core/Training/LoRAEvaluator.swift
@@ -247,6 +247,7 @@ public class LoRAEvaluator {
             images: [referenceImage, baselineImage],
             prompt: "Compare these two images for LoRA training evaluation.",
             systemPrompt: comparisonSystemPrompt,
+            enableThinking: false,
             maxTokens: 300,
             temperature: 0
         )

--- a/Sources/Flux2Core/Training/Loop/SimpleLoRATrainer.swift
+++ b/Sources/Flux2Core/Training/Loop/SimpleLoRATrainer.swift
@@ -2092,6 +2092,7 @@ public final class SimpleLoRATrainer {
                     images: [refCG, valCG],
                     prompt: "Compare these two images for LoRA training evaluation.",
                     systemPrompt: Self.vlmTrainingScoringPrompt,
+                    enableThinking: false,
                     maxTokens: 300,
                     temperature: 0
                 )
@@ -2116,6 +2117,7 @@ public final class SimpleLoRATrainer {
                             images: [refCG, blCG],
                             prompt: "Compare these two images for LoRA training evaluation.",
                             systemPrompt: Self.vlmTrainingScoringPrompt,
+                            enableThinking: false,
                             maxTokens: 300,
                             temperature: 0
                         )

--- a/Sources/FluxTextEncoders/FluxTextEncoders.swift
+++ b/Sources/FluxTextEncoders/FluxTextEncoders.swift
@@ -434,6 +434,7 @@ public final class FluxTextEncoders: @unchecked Sendable {
         image: CGImage,
         prompt: String,
         systemPrompt: String? = nil,
+        enableThinking: Bool = true,
         maxTokens: Int = 512,
         temperature: Float = 0.7,
         onToken: ((String) -> Bool)? = nil
@@ -443,6 +444,7 @@ public final class FluxTextEncoders: @unchecked Sendable {
         }
         return try vlm.generate(
             image: image, prompt: prompt, systemPrompt: systemPrompt,
+            enableThinking: enableThinking,
             maxTokens: maxTokens, temperature: temperature,
             onToken: onToken
         )
@@ -471,6 +473,7 @@ public final class FluxTextEncoders: @unchecked Sendable {
     public func generateWithQwen35(
         prompt: String,
         systemPrompt: String? = nil,
+        enableThinking: Bool = true,
         maxTokens: Int = 512,
         temperature: Float = 0.7,
         onToken: ((String) -> Bool)? = nil
@@ -480,6 +483,7 @@ public final class FluxTextEncoders: @unchecked Sendable {
         }
         return try vlm.generate(
             image: nil, prompt: prompt, systemPrompt: systemPrompt,
+            enableThinking: enableThinking,
             maxTokens: maxTokens, temperature: temperature,
             onToken: onToken
         )
@@ -527,6 +531,7 @@ public final class FluxTextEncoders: @unchecked Sendable {
             image: image,
             prompt: prompt,
             systemPrompt: Self.fluxImageDescriptionSystemPrompt,
+            enableThinking: false,
             maxTokens: maxTokens,
             temperature: 0,
             onToken: onToken
@@ -603,6 +608,7 @@ public final class FluxTextEncoders: @unchecked Sendable {
             images: [reference, generated],
             prompt: "Compare these two images.",
             systemPrompt: Self.fluxImageComparisonSystemPrompt,
+            enableThinking: false,
             maxTokens: 300,
             temperature: 0,
             onToken: onToken

--- a/Sources/FluxTextEncoders/Model/Qwen35/Qwen35VLM.swift
+++ b/Sources/FluxTextEncoders/Model/Qwen35/Qwen35VLM.swift
@@ -106,6 +106,7 @@ public class Qwen35VLM {
         image: CGImage?,
         prompt: String,
         systemPrompt: String? = nil,
+        enableThinking: Bool = true,
         maxTokens: Int = 512,
         temperature: Float = 0.7,
         topP: Float = 0.9,
@@ -114,6 +115,7 @@ public class Qwen35VLM {
         let images: [CGImage] = image.map { [$0] } ?? []
         return try generateMultiImage(
             images: images, prompt: prompt, systemPrompt: systemPrompt,
+            enableThinking: enableThinking,
             maxTokens: maxTokens, temperature: temperature, topP: topP, onToken: onToken
         )
     }
@@ -123,6 +125,7 @@ public class Qwen35VLM {
         images: [CGImage],
         prompt: String,
         systemPrompt: String? = nil,
+        enableThinking: Bool = true,
         maxTokens: Int = 512,
         temperature: Float = 0.7,
         topP: Float = 0.9,
@@ -135,7 +138,7 @@ public class Qwen35VLM {
         let tokenCounts = imageResults.map { $0.numTokens }
 
         // Build token sequence with N vision blocks
-        let tokenIds = buildTokenSequence(prompt: prompt, systemPrompt: systemPrompt, imageTokenCounts: tokenCounts)
+        let tokenIds = buildTokenSequence(prompt: prompt, systemPrompt: systemPrompt, enableThinking: enableThinking, imageTokenCounts: tokenCounts)
         var inputIds = MLXArray(tokenIds.map { Int32($0) }).reshaped([1, tokenIds.count])
 
         // Build merged embeddings (text + vision)
@@ -220,7 +223,7 @@ public class Qwen35VLM {
     // MARK: - Private
 
     /// Build token sequence for N images + text prompt
-    private func buildTokenSequence(prompt: String, systemPrompt: String? = nil, imageTokenCounts: [Int]) -> [Int] {
+    private func buildTokenSequence(prompt: String, systemPrompt: String? = nil, enableThinking: Bool = true, imageTokenCounts: [Int]) -> [Int] {
         let sysMsg = systemPrompt ?? "You are a helpful assistant."
         var formatted = "<|im_start|>system\n\(sysMsg)<|im_end|>\n"
         formatted += "<|im_start|>user\n"
@@ -232,7 +235,12 @@ public class Qwen35VLM {
             formatted += "<|vision_end|>"
         }
 
-        formatted += prompt
+        // Append /no_think to disable thinking mode (saves tokens and time)
+        if !enableThinking {
+            formatted += prompt + " /no_think"
+        } else {
+            formatted += prompt
+        }
         formatted += "<|im_end|>\n"
         formatted += "<|im_start|>assistant\n"
 


### PR DESCRIPTION
## Summary

- New `enableThinking` parameter on VLM `generate()`/`generateMultiImage()` (default: true)
- Appends `/no_think` to user prompt when disabled — VLM responds directly without reasoning
- Disabled thinking for all scoring/comparison APIs (faster, no wasted tokens on reasoning):
  - `describeImageForFlux()` 
  - `compareImagesForFlux()`
  - LoRA training VLM scoring
  - LoRA evaluator comparison
- CLI: `--no-think` flag for `flux2 test-qwen35`

## Test plan
- [x] 270 tests, 0 failures
- [x] `--flux-describe --no-think` produces direct description without thinking block

🤖 Generated with [Claude Code](https://claude.com/claude-code)