### PR TITLE
fix: Use correct Qwen3.5 chat template for thinking control

### DIFF
--- a/Sources/FluxTextEncoders/Model/Qwen35/Qwen35VLM.swift
+++ b/Sources/FluxTextEncoders/Model/Qwen35/Qwen35VLM.swift
@@ -235,14 +235,18 @@ public class Qwen35VLM {
             formatted += "<|vision_end|>"
         }
 
-        // Append /no_think to disable thinking mode (saves tokens and time)
-        if !enableThinking {
-            formatted += prompt + " /no_think"
-        } else {
-            formatted += prompt
-        }
+        formatted += prompt
         formatted += "<|im_end|>\n"
         formatted += "<|im_start|>assistant\n"
+
+        // Qwen3.5 thinking control via chat template (NOT /no_think which is Qwen3 only)
+        // enable_thinking=false: add empty <think></think> to skip reasoning
+        // enable_thinking=true: add opening <think> to let model reason
+        if !enableThinking {
+            formatted += "<think>\n\n</think>\n\n"
+        } else {
+            formatted += "<think>\n"
+        }
 
         return tokenizer.encode(text: formatted)
     }


### PR DESCRIPTION
## Summary

Qwen3.5 does NOT support `/no_think` (that's Qwen3 only). Fixed to use the official chat template method:
- `enable_thinking=false`: empty `<think>\n\n</think>\n\n` block forces direct response
- `enable_thinking=true`: opening `<think>\n` tag lets model reason

Reference: [Qwen3.5 chat_template.jinja](https://huggingface.co/mlx-community/Qwen3.5-4B-MLX-4bit/blob/main/chat_template.jinja)

## Test plan
- [x] 270 tests, 0 failures
- [x] With thinking: model reasons before answering
- [x] Without thinking: direct answer, no reasoning tokens wasted

🤖 Generated with [Claude Code](https://claude.com/claude-code)