### PR TITLE
fix: Reduce log verbosity — remove VLM debug prints

### DIFF
--- a/Sources/Flux2Core/Training/Loop/SimpleLoRATrainer.swift
+++ b/Sources/Flux2Core/Training/Loop/SimpleLoRATrainer.swift
@@ -2097,9 +2097,8 @@ public final class SimpleLoRATrainer {
                     temperature: 0
                 )
 
-                // Debug: print raw VLM response for diagnosis
-                print("    [VLM Raw] ref=\(refImage.lastPathComponent) val=\(imageName)")
-                print("    [VLM Raw] response: \(result.text.prefix(500))")
+                Flux2Debug.log("[VLM] ref=\(refImage.lastPathComponent) val=\(imageName)")
+                Flux2Debug.log("[VLM] response: \(result.text.prefix(200))")
 
                 let (sceneScore, styleScore, sceneReason, styleReason) = parseVLMScores(result.text)
 
@@ -2121,7 +2120,7 @@ public final class SimpleLoRATrainer {
                             maxTokens: 300,
                             temperature: 0
                         )
-                        print("    [VLM Raw baseline] response: \(blResult.text.prefix(500))")
+                        Flux2Debug.log("[VLM] baseline response: \(blResult.text.prefix(200))")
                         let (blScene, blStyle, _, _) = parseVLMScores(blResult.text)
                         baselineScene = blScene
                         baselineStyle = blStyle
@@ -2207,7 +2206,7 @@ public final class SimpleLoRATrainer {
             if let data = jsonStr.data(using: .utf8),
                let parsed = try? JSONDecoder().decode(ScoreJSON.self, from: data),
                let scene = parsed.scene_score, let style = parsed.style_score {
-                print("    [VLM Parse] JSON success: scene=\(scene), style=\(style)")
+                Flux2Debug.log("[VLM] Parsed: scene=\(scene), style=\(style)")
                 return (
                     scene: min(100, max(0, scene)),
                     style: min(100, max(0, style)),
@@ -2215,7 +2214,7 @@ public final class SimpleLoRATrainer {
                     styleReason: parsed.style_reason ?? ""
                 )
             } else {
-                print("    [VLM Parse] JSON failed on: \(jsonStr.prefix(100))...")
+                Flux2Debug.log("[VLM] JSON parse failed: \(jsonStr.prefix(100))")
             }
         }
 
@@ -2233,7 +2232,7 @@ public final class SimpleLoRATrainer {
             if let data = jsonStr.data(using: .utf8),
                let parsed = try? JSONDecoder().decode(ScoreJSON.self, from: data),
                let scene = parsed.scene_score, let style = parsed.style_score {
-                print("    [VLM Parse] JSON success (from raw): scene=\(scene), style=\(style)")
+                Flux2Debug.log("[VLM] Parsed (raw): scene=\(scene), style=\(style)")
                 return (
                     scene: min(100, max(0, scene)),
                     style: min(100, max(0, style)),
@@ -2248,9 +2247,9 @@ public final class SimpleLoRATrainer {
         let styleScore = extractScore100(from: text, keyword: "style")
 
         if sceneScore >= 0 || styleScore >= 0 {
-            print("    [VLM Parse] Regex fallback: scene=\(sceneScore), style=\(styleScore)")
+            Flux2Debug.log("[VLM] Regex fallback: scene=\(sceneScore), style=\(styleScore)")
         } else {
-            print("    [VLM Parse] FAILED - no scores found in: \(text.prefix(200))...")
+            print("  Warning: VLM score parsing failed")
         }
 
         return (scene: max(0, sceneScore), style: max(0, styleScore), sceneReason: "", styleReason: "")

--- a/Sources/FluxTextEncoders/Model/Qwen35/Qwen35VLM.swift
+++ b/Sources/FluxTextEncoders/Model/Qwen35/Qwen35VLM.swift
@@ -329,9 +329,8 @@ extension Qwen35VLM {
                 ?? remapped.removeValue(forKey: "pos_embed.weight")
             if let posEmbed = posEmbed {
                 visionEncoder.posEmbedStorage = posEmbed
-                print("[Qwen3.5-Vision] Set pos_embed: \(posEmbed.shape)")
             } else {
-                print("[Qwen3.5-Vision] WARNING: pos_embed not found!")
+                print("[Qwen3.5] WARNING: pos_embed not found in vision weights")
             }
 
             // Handle class_token if present
@@ -340,15 +339,12 @@ extension Qwen35VLM {
             // patch_embed.proj is now a native Conv3d — weights [1024, 2, 16, 16, 3] load directly
             // No reshape needed
 
-            print("[Qwen3.5-Vision] Remapped \(remapped.count) weight keys, sample: \(remapped.keys.sorted().prefix(5))")
             let visionParams = ModuleParameters.unflattened(remapped)
             do {
                 try visionEncoder.update(parameters: visionParams, verify: .noUnusedKeys)
-                print("[Qwen3.5-Vision] Weights applied successfully (strict)")
             } catch {
-                print("[Qwen3.5-Vision] Warning: \(error)")
+                FluxDebug.log("[Qwen3.5] Vision weight loading warning: \(error)")
                 try visionEncoder.update(parameters: visionParams, verify: .none)
-                print("[Qwen3.5-Vision] Weights applied (relaxed)")
             }
             eval(visionEncoder)
         }

--- a/Sources/FluxTextEncoders/Model/Qwen35/Qwen35VisionEncoder.swift
+++ b/Sources/FluxTextEncoders/Model/Qwen35/Qwen35VisionEncoder.swift
@@ -276,25 +276,14 @@ public class Qwen35VisionEncoder: Module {
         // 2. Add interpolated 2D position embeddings (also in merge order)
         let posEmb = interpolatePositionEmbeddings(gridH: gridH, gridW: gridW)
         eval(posEmb)
-        print("[Swift-ViT] posEmb: \(posEmb.shape), mean=\(MLX.mean(posEmb).item(Float.self)), norm=\(MLX.sqrt(MLX.mean(posEmb*posEmb)).item(Float.self))")
-        print("[Swift-ViT] posEmb first5: \(posEmb.reshaped([-1])[0..<5].asArray(Float.self))")
         hidden = hidden + posEmb.reshaped([1, -1, config.hiddenSize])
 
         // 3. Rotary 2D position embeddings (in merge order)
         let rotaryEmb = compute2DRotaryEmb(gridH: gridH, gridW: gridW, mergeSize: mergeSize)
-        eval(rotaryEmb)
-        print("[Swift-ViT] rotary: \(rotaryEmb.shape), mean=\(MLX.mean(rotaryEmb).item(Float.self))")
-        print("[Swift-ViT] rotary patch[0] first8: \(rotaryEmb[0][0..<8].asArray(Float.self))")
-        print("[Swift-ViT] rotary patch[1] full: \(rotaryEmb[1].asArray(Float.self))")
-        print("[Swift-ViT] rotary patch[2] first8: \(rotaryEmb[2][0..<8].asArray(Float.self))")
 
         // 4. Transformer blocks
-        for (i, block) in blocks.enumerated() {
+        for block in blocks {
             hidden = block(hidden, rotaryPosEmb: rotaryEmb)
-            if i == 0 {
-                eval(hidden)
-                print("[Swift-ViT] after block 0: mean=\(MLX.mean(hidden).item(Float.self)), norm=\(MLX.sqrt(MLX.mean(hidden*hidden)).item(Float.self))")
-            }
         }
 
         // 5. Spatial merger (patches already in merge order)


### PR DESCRIPTION
## Summary

Remove verbose debug prints from VLM vision encoder and training scoring:
- `[Swift-ViT]` posEmb/rotary tensor dumps: removed entirely
- `[Qwen3.5-Vision]` weight loading details: moved to FluxDebug
- `[VLM Raw/Parse]` scoring diagnostics: moved to Flux2Debug (debug only)
- Only VLM parse failures remain as visible prints

## Test plan
- [x] 279 tests, 0 failures
- [x] No remaining `[Swift-ViT]`, `[VLM Raw]`, `[VLM Parse]` direct prints

🤖 Generated with [Claude Code](https://claude.com/claude-code)