### PR TITLE
fix: Pass vaeVariant: .smallDecoder in LoRA training & evaluation

### DIFF
--- a/Sources/Flux2Core/Training/LoRAEvaluator.swift
+++ b/Sources/Flux2Core/Training/LoRAEvaluator.swift
@@ -182,7 +182,12 @@ public class LoRAEvaluator {
         // === Step 3: Generate baseline image with base model ===
         onProgress?("[3/5] Generating baseline image (\(width)x\(height), seed=\(seed))...")
 
-        let pipeline = Flux2Pipeline(model: model, quantization: quantization, hfToken: hfToken)
+        let pipeline = Flux2Pipeline(
+            model: model,
+            quantization: quantization,
+            vaeVariant: .smallDecoder,
+            hfToken: hfToken
+        )
 
         let steps = model.defaultSteps
         let guidance = model.defaultGuidance

--- a/Sources/Flux2Core/Training/Loop/SimpleLoRATrainer.swift
+++ b/Sources/Flux2Core/Training/Loop/SimpleLoRATrainer.swift
@@ -1754,7 +1754,8 @@ public final class SimpleLoRATrainer {
         let inferenceQuantization: Flux2QuantizationConfig = .balanced
         let pipeline = Flux2Pipeline(
             model: inferenceModel,
-            quantization: inferenceQuantization
+            quantization: inferenceQuantization,
+            vaeVariant: .smallDecoder
         )
 
         // Generate images for each validation prompt
@@ -1867,7 +1868,8 @@ public final class SimpleLoRATrainer {
         let inferenceQuantization: Flux2QuantizationConfig = .balanced
         var pipeline: Flux2Pipeline? = Flux2Pipeline(
             model: inferenceModel,
-            quantization: inferenceQuantization
+            quantization: inferenceQuantization,
+            vaeVariant: .smallDecoder
         )
 
         // Load LoRA from checkpoint we just saved


### PR DESCRIPTION
## Summary
Fixes #79 and an adjacent latent bug in the training loop:

- `LoRAEvaluator.evaluate()` (Sources/Flux2Core/Training/LoRAEvaluator.swift:185)
- `SimpleLoRATrainer` baseline generation (Sources/Flux2Core/Training/Loop/SimpleLoRATrainer.swift:1755)
- `SimpleLoRATrainer` per-checkpoint validation (Sources/Flux2Core/Training/Loop/SimpleLoRATrainer.swift:1868)

All three call sites instantiated `Flux2Pipeline` without specifying `vaeVariant`, silently inheriting the constructor's `.standard` default. Users who have migrated to the small decoder VAE (the recommended path) crashed with `VAE weights not found for variant: standard`.

Each call site now passes `vaeVariant: .smallDecoder` explicitly.

## Why minimal
Did not flip the `Flux2Pipeline.init` default itself — that's a wider API behaviour change worth tracking separately. This PR only touches the LoRA training/evaluation paths reported as broken.

Other call sites (`Flux2CLI/CompareEncoders.swift`, `Flux2CLI/ProfileCommand.swift`, `Flux2App/ViewModels/ImageGenerationViewModel.swift`) are also affected but out of scope here — they're dev/profiling/internal paths, not the training+evaluation flow consumed by FluxForge Studio.

## Test plan
- [x] `xcodebuild -scheme Flux2CLI -configuration Release -destination 'platform=macOS' build` → BUILD SUCCEEDED (after both edits)
- [ ] Manual: run a LoRA training+evaluation pass on a machine with only the small decoder VAE on disk and confirm no crash (FluxForge Studio team to verify on their side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)