### PR TITLE
fix: Default vaeVariant to .smallDecoder across SDK + CLI (follow-up to #80)

### DIFF
--- a/Sources/Flux2CLI/Flux2CLI.swift
+++ b/Sources/Flux2CLI/Flux2CLI.swift
@@ -103,8 +103,8 @@ struct TextToImage: AsyncParsableCommand {
     @Option(name: .long, help: "LoRA config JSON file (alternative to --lora, includes scheduler overrides)")
     var loraConfigPath: String?
 
-    @Option(name: .long, help: "VAE variant: standard (default), small-decoder (distilled, ~1.4x faster)")
-    var vaeVariant: String = "standard"
+    @Option(name: .long, help: "VAE variant: small-decoder (default, distilled, ~1.4x faster), standard")
+    var vaeVariant: String = "small-decoder"
 
     @Option(name: .long, help: "Memory profile: auto (default), conservative, balanced, performance")
     var memoryProfile: String = "auto"
@@ -426,8 +426,8 @@ struct ImageToImage: AsyncParsableCommand {
     @Option(name: .long, help: "LoRA config JSON file (alternative to --lora, includes scheduler overrides)")
     var loraConfigPath: String?
 
-    @Option(name: .long, help: "VAE variant: standard (default), small-decoder (distilled, ~1.4x faster)")
-    var vaeVariant: String = "standard"
+    @Option(name: .long, help: "VAE variant: small-decoder (default, distilled, ~1.4x faster), standard")
+    var vaeVariant: String = "small-decoder"
 
     @Option(name: .long, help: "Memory profile: auto (default), conservative, balanced, performance")
     var memoryProfile: String = "auto"
@@ -704,8 +704,8 @@ struct Download: AsyncParsableCommand {
     @Flag(name: .long, help: "Only download VAE")
     var vaeOnly: Bool = false
 
-    @Option(name: .long, help: "VAE variant to download: standard (default), small-decoder")
-    var vaeVariant: String = "standard"
+    @Option(name: .long, help: "VAE variant to download: small-decoder (default), standard")
+    var vaeVariant: String = "small-decoder"
 
     @Option(name: .long, help: "Custom models directory (for sandboxed apps or custom storage)")
     var modelsDir: String?

--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
@@ -131,7 +131,7 @@ public class Flux2Pipeline: @unchecked Sendable {
         model: Flux2Model = .dev,
         quantization: Flux2QuantizationConfig = .balanced,
         memoryOptimization: MemoryOptimizationConfig? = nil,
-        vaeVariant: ModelRegistry.VAEVariant = .standard,
+        vaeVariant: ModelRegistry.VAEVariant = .smallDecoder,
         hfToken: String? = nil
     ) {
         self.model = model


### PR DESCRIPTION
## Summary
Follow-up to #80. The previous PR explicitly fixed `LoRAEvaluator` and `SimpleLoRATrainer` (the call sites the FluxForge Studio team had hit). This PR addresses the **root cause** so the remaining call sites stop falling into the same trap.

## What changed
- `Sources/Flux2Core/Pipeline/Flux2Pipeline.swift:134` — `vaeVariant` default flipped from `.standard` → `.smallDecoder`. This is the public SDK constructor; flipping its default is the load-bearing change.
- `Sources/Flux2CLI/Flux2CLI.swift:107, 430, 708` — three `--vae-variant` CLI options flipped from `"standard"` → `"small-decoder"`, with help text updated to reflect the new default.

## Why flip rather than patch each call site
After PR #80, five remaining call sites were still inheriting `.standard` implicitly:

- `Flux2CLI/CompareEncoders.swift:164`
- `Flux2CLI/ProfileCommand.swift:140, 219, 380`
- `Flux2App/ViewModels/ImageGenerationViewModel.swift:226`

Patching each of them mechanically would have left the broken default in the SDK constructor and meant the next new caller falls into the same trap. Flipping the default at the source covers all five call sites in a single change and aligns the SDK with the post-migration reality (small-decoder is the recommended on-disk variant).

## Behavioural impact
API-compatible (no signature change), but the *runtime* behaviour shifts: callers who relied on the implicit `.standard` will now get `.smallDecoder` unless they pass `vaeVariant: .standard` explicitly. The CLI help text reflects the new default so the change is discoverable.

## Out of scope
`Flux2App/ViewModels/ModelManager.swift:376/412` (`downloadVAE` / `deleteVAE`) keep `.standard` defaults — those are model-management primitives where the variant should remain an explicit choice rather than implicitly defaulting; flipping them would change which weights get downloaded/deleted by callers that rely on the default. Worth a separate look only if a user-visible regression surfaces.

## Test plan
- [x] `xcodebuild -scheme Flux2CLI -configuration Release -destination 'platform=macOS' build` → BUILD SUCCEEDED
- [ ] Manual: run `flux2 text-to-image ...` without `--vae-variant` on a machine with only `small-decoder` on disk and confirm no crash
- [ ] Manual: run `flux2 download --vae-only` and confirm it now grabs the small-decoder by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)