### PR TITLE
refactor: Quiet logs by default, opt-in verbosity via --verbose

### DIFF
--- a/Sources/Flux2CLI/Flux2CLI.swift
+++ b/Sources/Flux2CLI/Flux2CLI.swift
@@ -79,8 +79,8 @@ struct TextToImage: AsyncParsableCommand {
     @Option(name: .long, help: "Transformer quantization: bf16, qint8, int4")
     var transformerQuant: String = "qint8"
 
-    @Flag(name: .long, help: "Enable debug logs (verbose output)")
-    var debug: Bool = false
+    @Flag(name: .long, help: "Show detailed logs (model loading, config, VLM interpretation)")
+    var verbose: Bool = false
 
     @Flag(name: .long, help: "Enable performance profiling")
     var profile: Bool = false
@@ -119,11 +119,13 @@ struct TextToImage: AsyncParsableCommand {
         // Configure custom models directory
         configureModelsDirectory(modelsDir)
 
-        // Configure debug logging
-        if debug {
+        // Configure logging verbosity
+        if verbose {
             Flux2Debug.enableDebugMode()
+            FluxDebug.isEnabled = true
         } else {
             Flux2Debug.setNormalMode()
+            FluxDebug.isEnabled = false
         }
 
         // Configure profiling
@@ -206,7 +208,7 @@ struct TextToImage: AsyncParsableCommand {
             }
         }
 
-        if debug {
+        if verbose {
             print("Configuration:")
             print("  Model: \(modelVariant.displayName)")
             print("  Text encoder: \(textQuantization.displayName)")
@@ -224,41 +226,37 @@ struct TextToImage: AsyncParsableCommand {
             interpretImagePaths.append(path)
         }
 
-        print("Generating image...")
-        print("  Prompt: \"\(prompt)\"")
-        if !interpretImagePaths.isEmpty {
-            print("  Interpret images: \(interpretImagePaths.count) (VLM will analyze and enrich prompt)")
-            for path in interpretImagePaths {
-                print("    - \(path)")
-            }
-        }
-        if upsamplePrompt {
-            print("  Prompt upsampling: enabled (will enhance prompt with visual details)")
-        }
-        if let loraConfig = loraConfig {
-            print("  LoRA: \(loraConfig.name) (scale: \(loraConfig.effectiveScale))")
-            if let overrides = loraConfig.schedulerOverrides, overrides.hasOverrides {
-                if overrides.customSigmas != nil {
-                    print("    - Custom sigmas: \(overrides.customSigmas!.count) values")
-                }
-                if let recSteps = overrides.numSteps, steps == nil {
-                    print("    - Using recommended steps: \(recSteps)")
-                }
-                if let recGuidance = overrides.guidance, guidance == nil {
-                    print("    - Using recommended guidance: \(recGuidance)")
+        print("Generating \(width)x\(height), \(actualSteps) steps, guidance \(actualGuidance)\(seed.map { ", seed \($0)" } ?? "")...")
+        if verbose {
+            print("  Prompt: \"\(prompt)\"")
+            if !interpretImagePaths.isEmpty {
+                print("  Interpret images: \(interpretImagePaths.count) (VLM will analyze and enrich prompt)")
+                for path in interpretImagePaths {
+                    print("    - \(path)")
                 }
             }
+            if upsamplePrompt {
+                print("  Prompt upsampling: enabled (will enhance prompt with visual details)")
+            }
+            if let loraConfig = loraConfig {
+                print("  LoRA: \(loraConfig.name) (scale: \(loraConfig.effectiveScale))")
+                if let overrides = loraConfig.schedulerOverrides, overrides.hasOverrides {
+                    if overrides.customSigmas != nil {
+                        print("    - Custom sigmas: \(overrides.customSigmas!.count) values")
+                    }
+                    if let recSteps = overrides.numSteps, steps == nil {
+                        print("    - Using recommended steps: \(recSteps)")
+                    }
+                    if let recGuidance = overrides.guidance, guidance == nil {
+                        print("    - Using recommended guidance: \(recGuidance)")
+                    }
+                }
+            }
+            if let checkpointInterval = checkpoint {
+                print("  Checkpoints: every \(checkpointInterval) step(s)")
+            }
+            print()
         }
-        print("  Size: \(width)x\(height)")
-        print("  Steps: \(actualSteps)")
-        print("  Guidance: \(actualGuidance)")
-        if let seed = seed {
-            print("  Seed: \(seed)")
-        }
-        if let checkpointInterval = checkpoint {
-            print("  Checkpoints: every \(checkpointInterval) step(s)")
-        }
-        print()
 
         // Parse VAE variant
         guard let vaeVar = ModelRegistry.VAEVariant(rawValue: vaeVariant) else {
@@ -282,7 +280,9 @@ struct TextToImage: AsyncParsableCommand {
         if let loraConfig = loraConfig {
             do {
                 let info = try pipeline.loadLoRA(loraConfig)
-                print("LoRA loaded: \(info.numLayers) layers, rank \(info.rank), \(String(format: "%.1f", info.memorySizeMB)) MB")
+                if verbose {
+                    print("LoRA loaded: \(info.numLayers) layers, rank \(info.rank), \(String(format: "%.1f", info.memorySizeMB)) MB")
+                }
                 if info.targetModel != .unknown {
                     if info.targetModel.rawValue != modelVariant.rawValue {
                         print("⚠️  Warning: LoRA was trained for \(info.targetModel.rawValue), but using \(modelVariant.rawValue)")
@@ -322,7 +322,9 @@ struct TextToImage: AsyncParsableCommand {
                 atPath: checkpointDir!,
                 withIntermediateDirectories: true
             )
-            print("Checkpoints will be saved to: \(checkpointDir!)")
+            if verbose {
+                print("Checkpoints will be saved to: \(checkpointDir!)")
+            }
         } else {
             checkpointDir = nil
         }
@@ -408,6 +410,9 @@ struct ImageToImage: AsyncParsableCommand {
     @Flag(name: .long, help: "Show detailed performance profiling")
     var profile: Bool = false
 
+    @Flag(name: .long, help: "Show detailed logs (model loading, config, VLM interpretation)")
+    var verbose: Bool = false
+
     @Option(name: .long, help: "Model variant: dev (32B), klein-4b (4B, Apache 2.0), klein-9b (9B), klein-9b-kv (9B, KV-cached I2I)")
     var model: String = "dev"
 
@@ -443,6 +448,15 @@ struct ImageToImage: AsyncParsableCommand {
 
         // Configure custom models directory
         configureModelsDirectory(modelsDir)
+
+        // Configure logging verbosity
+        if verbose {
+            Flux2Debug.enableDebugMode()
+            FluxDebug.isEnabled = true
+        } else {
+            Flux2Debug.setNormalMode()
+            FluxDebug.isEnabled = false
+        }
 
         // Parse model variant
         guard let modelVariant = Flux2Model(rawValue: model) else {
@@ -516,7 +530,9 @@ struct ImageToImage: AsyncParsableCommand {
                 throw ValidationError("Failed to load image: \(path)")
             }
             refImages.append(image)
-            print("Loaded reference image: \(path) (\(image.width)x\(image.height))")
+            if verbose {
+                print("Loaded reference image: \(path) (\(image.width)x\(image.height))")
+            }
         }
 
         // Validate interpret image paths exist (VLM will load them directly)
@@ -526,24 +542,21 @@ struct ImageToImage: AsyncParsableCommand {
                 throw ValidationError("Interpret image not found: \(path)")
             }
             interpretImagePaths.append(path)
-            print("Will interpret image: \(path) [VLM analysis]")
+            if verbose {
+                print("Will interpret image: \(path) [VLM analysis]")
+            }
         }
-
-        print("Mode: Image-to-Image (Flux.2 conditioning)")
 
         // Show output dimensions
         let outputWidth = width ?? refImages[0].width
         let outputHeight = height ?? refImages[0].height
-        print("Output size: \(outputWidth)x\(outputHeight)")
 
-        // Note: Flux.2 I2I uses conditioning mode, not SD-style noise injection
-        // The reference image provides visual context to the transformer
-        // Strength parameter is accepted for API compatibility but doesn't skip timesteps
-        print("Steps: \(actualSteps)")
-        print("Guidance: \(actualGuidance)")
-
-        if upsamplePrompt {
-            print("Prompt upsampling: enabled")
+        print("I2I \(outputWidth)x\(outputHeight), \(actualSteps) steps, guidance \(actualGuidance), \(refImages.count) ref image(s)\(seed.map { ", seed \($0)" } ?? "")...")
+        if verbose {
+            print("  Prompt: \"\(prompt)\"")
+            if upsamplePrompt {
+                print("  Prompt upsampling: enabled")
+            }
         }
 
         // Parse quantization
@@ -571,7 +584,7 @@ struct ImageToImage: AsyncParsableCommand {
         }
 
         // Print LoRA info if specified
-        if let loraConfig = loraConfig {
+        if verbose, let loraConfig = loraConfig {
             print("LoRA: \(loraConfig.name) (scale: \(loraConfig.effectiveScale))")
             if let overrides = loraConfig.schedulerOverrides, overrides.hasOverrides {
                 if overrides.customSigmas != nil {
@@ -608,7 +621,9 @@ struct ImageToImage: AsyncParsableCommand {
         if let loraConfig = loraConfig {
             do {
                 let info = try pipeline.loadLoRA(loraConfig)
-                print("LoRA loaded: \(info.numLayers) layers, rank \(info.rank), \(String(format: "%.1f", info.memorySizeMB)) MB")
+                if verbose {
+                    print("LoRA loaded: \(info.numLayers) layers, rank \(info.rank), \(String(format: "%.1f", info.memorySizeMB)) MB")
+                }
                 if info.targetModel != .unknown {
                     if info.targetModel.rawValue != modelVariant.rawValue {
                         print("⚠️  Warning: LoRA was trained for \(info.targetModel.rawValue), but using \(modelVariant.rawValue)")
@@ -628,12 +643,12 @@ struct ImageToImage: AsyncParsableCommand {
                 atPath: checkpointDir!,
                 withIntermediateDirectories: true
             )
-            print("Checkpoints will be saved to: \(checkpointDir!)")
+            if verbose {
+                print("Checkpoints will be saved to: \(checkpointDir!)")
+            }
         } else {
             checkpointDir = nil
         }
-
-        print("Generating image...")
 
         let image = try await pipeline.generateImageToImage(
             prompt: prompt,

--- a/Sources/Flux2CLI/TrainLoRACommand.swift
+++ b/Sources/Flux2CLI/TrainLoRACommand.swift
@@ -222,6 +222,7 @@ struct TrainLoRA: AsyncParsableCommand {
         // Configure logging
         if verbose {
             Flux2Debug.enableDebugMode()
+            FluxDebug.isEnabled = true
         }
 
         // Determine if using YAML config or CLI args

--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
@@ -852,8 +852,7 @@ public class Flux2Pipeline: @unchecked Sendable {
                         """
 
                         Flux2Debug.log("Prompt enriched with \(descriptions.count) VLM description(s)")
-                        print("[VLM-Interpret] Enriched prompt:\n\(enrichedPrompt)")
-                        fflush(stdout)
+                        Flux2Debug.info("[VLM-Interpret] Enriched prompt:\n\(enrichedPrompt)")
                     }
 
                     profiler.end("1b. VLM Interpretation")
@@ -888,8 +887,7 @@ public class Flux2Pipeline: @unchecked Sendable {
                         """
 
                         Flux2Debug.log("Prompt enriched with \(descriptions.count) VLM description(s)")
-                        print("[VLM-Interpret] Enriched prompt:\n\(enrichedPrompt)")
-                        fflush(stdout)
+                        Flux2Debug.info("[VLM-Interpret] Enriched prompt:\n\(enrichedPrompt)")
                     }
 
                     // Step 4: Unload Mistral

--- a/Sources/Flux2Core/Utils/Flux2Debug.swift
+++ b/Sources/Flux2Core/Utils/Flux2Debug.swift
@@ -20,8 +20,8 @@ public enum Flux2Debug {
         }
     }
 
-    /// Minimum log level to display (default: info - show progress and above)
-    nonisolated(unsafe) public static var minLevel: Level = .info
+    /// Minimum log level to display (default: warning - quiet mode, use enableDebugMode() for verbose)
+    nonisolated(unsafe) public static var minLevel: Level = .warning
 
     /// Enable debug mode (shows all logs including verbose)
     public static func enableDebugMode() {

--- a/Sources/FluxTextEncoders/FluxTextEncoders.swift
+++ b/Sources/FluxTextEncoders/FluxTextEncoders.swift
@@ -186,54 +186,54 @@ public final class FluxTextEncoders: @unchecked Sendable {
     ///   - modelPath: Local path to Qwen3 model
     @MainActor
     public func loadKleinModel(variant: KleinVariant, from modelPath: String) async throws {
-        print("[Klein] Loading Qwen3 model for \(variant.displayName)")
-        print("[Klein] Model path: \(modelPath)")
+        FluxDebug.info("[Klein] Loading Qwen3 model for \(variant.displayName)")
+        FluxDebug.info("[Klein] Model path: \(modelPath)")
 
         // Verify path exists
         let fileManager = FileManager.default
         guard fileManager.fileExists(atPath: modelPath) else {
-            print("[Klein] ERROR: Path does not exist: \(modelPath)")
+            FluxDebug.error("[Klein] Path does not exist: \(modelPath)")
             throw FluxEncoderError.invalidInput("Model path does not exist: \(modelPath)")
         }
 
         // Check for required files
         let configPath = "\(modelPath)/config.json"
         let tokenizerPath = "\(modelPath)/tokenizer.json"
-        print("[Klein] config.json exists: \(fileManager.fileExists(atPath: configPath))")
-        print("[Klein] tokenizer.json exists: \(fileManager.fileExists(atPath: tokenizerPath))")
+        FluxDebug.info("[Klein] config.json exists: \(fileManager.fileExists(atPath: configPath))")
+        FluxDebug.info("[Klein] tokenizer.json exists: \(fileManager.fileExists(atPath: tokenizerPath))")
 
         // Load Qwen3 model
-        print("[Klein] Loading model weights...")
+        FluxDebug.info("[Klein] Loading model weights...")
         qwen3Model = try Qwen3ForCausalLM.load(from: modelPath)
-        print("[Klein] Model weights loaded successfully")
+        FluxDebug.info("[Klein] Model weights loaded successfully")
 
         // CRITICAL: Limit GPU cache to prevent memory accumulation during repeated inference
         // This is essential for training where encode() is called many times
         // Without this limit, the GPU cache grows unbounded
         Memory.cacheLimit = 512 * 1024 * 1024  // 512 MB cache limit
-        print("[Klein] GPU cache limit set to 512 MB")
+        FluxDebug.info("[Klein] GPU cache limit set to 512 MB")
 
         // Enable AGGRESSIVE memory optimization to prevent computation graph accumulation
         // Use aggressive preset: eval every 4 layers with cache clearing
         qwen3Model?.model.memoryConfig = .aggressive
-        print("[Klein] Memory optimization enabled (aggressive: eval every 4 layers + cache clear)")
+        FluxDebug.info("[Klein] Memory optimization enabled (aggressive: eval every 4 layers + cache clear)")
 
         // Load tokenizer using HuggingFace Tokenizers library
         // Use from(modelFolder:) for local paths (not from(pretrained:) which treats path as Hub ID)
-        print("[Klein] Loading tokenizer from local path...")
+        FluxDebug.info("[Klein] Loading tokenizer from local path...")
         let modelFolderURL = URL(fileURLWithPath: modelPath)
         qwen3Tokenizer = try await AutoTokenizer.from(modelFolder: modelFolderURL)
-        print("[Klein] Tokenizer loaded successfully")
+        FluxDebug.info("[Klein] Tokenizer loaded successfully")
 
         // Create Klein embedding extractor and Qwen3 generator
         if let model = qwen3Model, let tokenizer = qwen3Tokenizer {
             kleinExtractor = KleinEmbeddingExtractor(model: model, tokenizer: tokenizer, variant: variant)
             qwen3Generator = Qwen3Generator(model: model, tokenizer: tokenizer)
             loadedKleinVariant = variant
-            print("[Klein] Extractor and generator created")
+            FluxDebug.info("[Klein] Extractor and generator created")
         }
 
-        print("[Klein] Klein model loaded successfully for \(variant.displayName)")
+        FluxDebug.info("[Klein] Klein model loaded successfully for \(variant.displayName)")
     }
     
     /// Load Qwen3 model for Klein embeddings with automatic download
@@ -262,13 +262,13 @@ public final class FluxTextEncoders: @unchecked Sendable {
             throw FluxEncoderError.invalidInput("Qwen3 model variant not found: \(modelVariant)")
         }
 
-        print("[Klein] Loading variant: \(modelVariant), repoId: \(modelInfo.repoId)")
+        FluxDebug.info("[Klein] Loading variant: \(modelVariant), repoId: \(modelInfo.repoId)")
 
         // Download model (or get existing path)
         let downloader = TextEncoderModelDownloader(hfToken: hfToken)
         let modelPath = try await downloader.downloadQwen3(modelInfo, progress: progress)
 
-        print("[Klein] Model path resolved: \(modelPath.path)")
+        FluxDebug.info("[Klein] Model path resolved: \(modelPath.path)")
 
         // Load from downloaded path
         try await loadKleinModel(variant: variant, from: modelPath.path)
@@ -298,8 +298,8 @@ public final class FluxTextEncoders: @unchecked Sendable {
     /// This replaces the standard Qwen3 text encoder with Qwen3-VL (language component only)
     @MainActor
     public func loadKleinVLModel(variant: KleinVariant, from modelPath: String) async throws {
-        print("[Klein-VL] Loading Qwen3-VL model for \(variant.displayName)")
-        print("[Klein-VL] Model path: \(modelPath)")
+        FluxDebug.info("[Klein-VL] Loading Qwen3-VL model for \(variant.displayName)")
+        FluxDebug.info("[Klein-VL] Model path: \(modelPath)")
 
         let fileManager = FileManager.default
         guard fileManager.fileExists(atPath: modelPath) else {
@@ -307,19 +307,19 @@ public final class FluxTextEncoders: @unchecked Sendable {
         }
 
         // Load Qwen3-VL model (language component only — skips visual.* weights)
-        print("[Klein-VL] Loading model weights (language only, skipping vision encoder)...")
+        FluxDebug.info("[Klein-VL] Loading model weights (language only, skipping vision encoder)...")
         qwen3VLModel = try Qwen3VLForCausalLM.load(from: modelPath)
-        print("[Klein-VL] Model weights loaded successfully")
+        FluxDebug.info("[Klein-VL] Model weights loaded successfully")
 
         Memory.cacheLimit = 512 * 1024 * 1024
         qwen3VLModel?.model.memoryConfig = .aggressive
-        print("[Klein-VL] Memory optimization enabled")
+        FluxDebug.info("[Klein-VL] Memory optimization enabled")
 
         // Load tokenizer
-        print("[Klein-VL] Loading tokenizer...")
+        FluxDebug.info("[Klein-VL] Loading tokenizer...")
         let modelFolderURL = URL(fileURLWithPath: modelPath)
         qwen3VLTokenizer = try await AutoTokenizer.from(modelFolder: modelFolderURL)
-        print("[Klein-VL] Tokenizer loaded")
+        FluxDebug.info("[Klein-VL] Tokenizer loaded")
 
         // Create VL embedding extractor and generator
         if let model = qwen3VLModel, let tokenizer = qwen3VLTokenizer {
@@ -327,10 +327,10 @@ public final class FluxTextEncoders: @unchecked Sendable {
             qwen3VLGenerator = Qwen3VLGenerator(model: model, tokenizer: tokenizer)
             loadedKleinVariant = variant
             isKleinVLMode = true
-            print("[Klein-VL] VL extractor and generator created")
+            FluxDebug.info("[Klein-VL] VL extractor and generator created")
         }
 
-        print("[Klein-VL] Klein VL model loaded successfully for \(variant.displayName)")
+        FluxDebug.info("[Klein-VL] Klein VL model loaded successfully for \(variant.displayName)")
     }
 
     /// Load Qwen3-VL model for Klein VL embeddings with automatic download
@@ -361,13 +361,13 @@ public final class FluxTextEncoders: @unchecked Sendable {
             throw FluxEncoderError.invalidInput("Qwen3-VL model variant not found: \(modelVariant)")
         }
 
-        print("[Klein-VL] Loading variant: \(modelVariant), repoId: \(modelInfo.repoId)")
+        FluxDebug.info("[Klein-VL] Loading variant: \(modelVariant), repoId: \(modelInfo.repoId)")
 
         // Download model (or get existing path)
         let downloader = TextEncoderModelDownloader(hfToken: hfToken)
         let modelPath = try await downloader.downloadQwen3VL(modelInfo, progress: progress)
 
-        print("[Klein-VL] Model path resolved: \(modelPath.path)")
+        FluxDebug.info("[Klein-VL] Model path resolved: \(modelPath.path)")
 
         // Load from downloaded path
         try await loadKleinVLModel(variant: variant, from: modelPath.path)
@@ -406,12 +406,12 @@ public final class FluxTextEncoders: @unchecked Sendable {
     /// Load Qwen3.5 VLM from local path
     @MainActor
     public func loadQwen35VLM(from modelPath: String) async throws {
-        print("[Qwen3.5] Loading VLM from \(modelPath)...")
+        FluxDebug.info("[Qwen3.5] Loading VLM from \(modelPath)...")
 
         Memory.cacheLimit = 512 * 1024 * 1024
         qwen35VLM = try await Qwen35VLM.load(from: modelPath)
 
-        print("[Qwen3.5] VLM loaded successfully")
+        FluxDebug.info("[Qwen3.5] VLM loaded successfully")
     }
 
     /// Unload Qwen3.5 VLM

--- a/Sources/FluxTextEncoders/Utils/FluxDebug.swift
+++ b/Sources/FluxTextEncoders/Utils/FluxDebug.swift
@@ -8,6 +8,13 @@ import Foundation
 public enum FluxDebug {
     nonisolated(unsafe) public static var isEnabled = false
 
+    /// Verbose info logging (shown when isEnabled = true, no file:line prefix)
+    public static func info(_ message: String) {
+        guard isEnabled else { return }
+        print(message)
+        fflush(stdout)
+    }
+
     public static func log(_ message: String, file: String = #file, line: Int = #line) {
         guard isEnabled else { return }
         let filename = URL(fileURLWithPath: file).lastPathComponent


### PR DESCRIPTION
## Summary
The CLI was drowning the user in chatty progress prints on every run — model loading, config dump, dimensions, LoRA info, VLM enrichment. Poor signal-to-noise when watching a real generation. This PR keeps only the essential output by default; the rest moves behind `--verbose`.

## What changed
- `Flux2Debug.minLevel` default flipped from `.info` → `.warning`. Errors and warnings still surface without any flag.
- All `[Klein] / [Klein-VL] / [Qwen3.5] / [VLM-Interpret]` status `print()`s routed through `FluxDebug.info` / `Flux2Debug.info` (silenced by default).
- New `FluxDebug.info(_:)` — like `log()` but without the `file:line` prefix; suited for user-facing status messages.
- `TextToImage`: `--debug` renamed to `--verbose`.
- `ImageToImage`: new `--verbose` flag (was lacking any verbosity toggle).
- Default output condensed to a single synthesis line per run:
  - T2I: `Generating WxH, N steps, guidance G, seed S...`
  - I2I: `I2I WxH, N steps, guidance G, K ref image(s), seed S...`
- LoRA target-model mismatch warnings (`⚠️  Warning: LoRA was trained for X but using Y`) remain unconditional — that's the kind of signal we always want surfaced.

## ⚠️ Breaking change
`flux2 text-to-image --debug` is no longer recognized — use `--verbose` instead. Scripts that passed `--debug` will need a one-token edit. Worth a CHANGELOG line on the next release.

## Test plan
- [x] `xcodebuild -scheme Flux2CLI -configuration Release -destination 'platform=macOS' build` → BUILD SUCCEEDED
- [ ] Manual: `flux2 text-to-image --prompt "..."` (no `--verbose`) → only synthesis line + warnings
- [ ] Manual: `flux2 text-to-image --prompt "..." --verbose` → full Klein/Pipeline/VLM trace
- [ ] Manual: same for `image-to-image` with the new `--verbose`

🤖 Generated with [Claude Code](https://claude.com/claude-code)