### PR TITLE
fix: Klein base models load transformer weights from transformer/ subfolder

### DIFF
--- a/Sources/Flux2Core/Configuration/ModelRegistry.swift
+++ b/Sources/Flux2Core/Configuration/ModelRegistry.swift
@@ -62,9 +62,12 @@ public enum ModelRegistry {
                 return "transformer"
             case .qint8:
                 return "flux-2-dev/transformer/qint8"
-            case .klein4B_bf16, .klein4B_8bit, .klein4B_base_bf16, .klein9B_bf16, .klein9B_base_bf16, .klein9B_kv_bf16:
-                // Klein models have transformer weights in root folder
+            case .klein4B_bf16, .klein4B_8bit, .klein9B_bf16, .klein9B_kv_bf16:
+                // Klein distilled/community models have transformer weights in root folder
                 return nil
+            case .klein4B_base_bf16, .klein9B_base_bf16:
+                // Klein base models (official BFL repos) use diffusers layout with transformer/ subfolder
+                return "transformer"
             }
         }
 


### PR DESCRIPTION
## Summary
Klein base models (`klein4B_base_bf16`, `klein9B_base_bf16`) come from the official Black Forest Labs repositories, which use the **diffusers layout** — transformer weights live under a `transformer/` subfolder. The distilled and community Klein variants (`klein4B_bf16`, `klein4B_8bit`, `klein9B_bf16`, `klein9B_kv_bf16`) keep weights at the repo root.

The previous code lumped all Klein variants into the same `case` returning `nil` (root-folder layout), which was correct for the distilled/community variants but wrong for the base variants. Splitting the case restores the correct lookup for both layouts.

## What changed
`Sources/Flux2Core/Configuration/ModelRegistry.swift:62` — split the catch-all `case` into two:
- Distilled/community Klein variants → `nil` (root)
- Base Klein variants → `"transformer"` (subfolder)

## Origin
Spotted while reviewing the `refactor/verbose-logging` WIP — orthogonal to that refactor, but the diff was bundled in the same working tree. Surfaced into its own PR for proper review.

## Test plan
- [x] `xcodebuild -scheme Flux2CLI -configuration Release -destination 'platform=macOS' build` → BUILD SUCCEEDED
- [ ] Manual: attempt to load `klein4B_base_bf16` and `klein9B_base_bf16` and confirm transformer weights are found at `transformer/` rather than the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)