### PR TITLE
Expose kleinEncoderPath override on Flux2Pipeline

### DIFF
--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
@@ -96,6 +96,14 @@ public class Flux2Pipeline: @unchecked Sendable {
     /// Model downloader
     private var downloader: Flux2ModelDownloader?
 
+    /// Optional override for the Klein text encoder (Qwen3) directory.
+    /// When non-nil, `loadTextEncoder()` loads weights/tokenizer from this
+    /// path instead of fetching the curated Qwen3 variant from the Hub.
+    /// Useful for swapping in alternate Qwen3 encoders such as
+    /// abliterated/uncensored builds while keeping the rest of the pipeline
+    /// unchanged.
+    private let kleinEncoderPath: URL?
+
     /// LoRA adapter manager
     private var loraManager: LoRAManager?
 
@@ -122,11 +130,17 @@ public class Flux2Pipeline: @unchecked Sendable {
     ///   - quantization: Quantization configuration
     ///   - memoryOptimization: Memory optimization settings (nil = auto-detect based on system RAM)
     ///   - hfToken: HuggingFace token for model downloads
+    ///   - kleinEncoderPath: Optional local directory containing a Qwen3
+    ///     text encoder (`config.json`, `tokenizer.json`, `*.safetensors`).
+    ///     When set, the Klein text encoder loads from this path instead
+    ///     of resolving and downloading the curated Qwen3 variant. Has no
+    ///     effect when `model` is `.dev` (which uses the Mistral encoder).
     public init(
         model: Flux2Model = .dev,
         quantization: Flux2QuantizationConfig = .balanced,
         memoryOptimization: MemoryOptimizationConfig? = nil,
-        hfToken: String? = nil
+        hfToken: String? = nil,
+        kleinEncoderPath: URL? = nil
     ) {
         self.model = model
         self.quantization = quantization
@@ -135,6 +149,7 @@ public class Flux2Pipeline: @unchecked Sendable {
         )
         self.scheduler = FlowMatchEulerScheduler()
         self.downloader = hfToken != nil ? Flux2ModelDownloader(hfToken: hfToken) : Flux2ModelDownloader()
+        self.kleinEncoderPath = kleinEncoderPath
     }
 
     // MARK: - Model Loading
@@ -204,11 +219,11 @@ public class Flux2Pipeline: @unchecked Sendable {
 
         case .klein4B, .klein4BBase:
             kleinEncoder = KleinTextEncoder(variant: .klein4B, quantization: mistralQuant)
-            try await kleinEncoder!.load()
+            try await kleinEncoder!.load(from: kleinEncoderPath)
 
         case .klein9B, .klein9BBase:
             kleinEncoder = KleinTextEncoder(variant: .klein9B, quantization: mistralQuant)
-            try await kleinEncoder!.load()
+            try await kleinEncoder!.load(from: kleinEncoderPath)
         }
 
         memoryManager.logMemoryState()


### PR DESCRIPTION
## Summary

Adds an optional `kleinEncoderPath: URL?` parameter to `Flux2Pipeline.init` and threads it to the already-public `KleinTextEncoder.load(from: URL?)` hook so callers can load Klein's Qwen3 text encoder from a local directory instead of downloading the curated variant from the Hub.

The path-based load is already implemented end-to-end inside the package — `FluxTextEncoders.loadKleinModel(variant:from:)` accepts a directory of `config.json` + `tokenizer.json` + `*.safetensors`, and `Qwen3ForCausalLM.load(from:)` reads any precision the safetensors carry. The only thing missing was a way to pass the path through `Flux2Pipeline.loadTextEncoder()`. This PR plumbs that one parameter through.

**Backward compatible:** default `nil` preserves the existing auto-download behavior. No call sites need to change.

## Why

Lets hosting apps swap in alternate Qwen3 encoders for Klein 4B/9B without forking the package. Concrete use case: feeding [`ponpoke/flux2-klein-9b-uncensored-text-encoder`](https://huggingface.co/ponpoke/flux2-klein-9b-uncensored-text-encoder) (an abliterated Qwen3-8B build) into Klein 9B so refusal directions in the encoder weights stop distorting NSFW prompt embeddings. The architecture matches the curated `qwen3_8B_8bit` variant exactly, so the rest of the pipeline (transformer, VAE, scheduler, LoRA fusion) is unaffected.

The same hook generalizes to any Qwen3-arch encoder a user wants to plug in — different quantizations, fine-tunes, etc.

## Diff

3 substantive line changes plus a stored property and docstrings:

- New `private let kleinEncoderPath: URL?` stored property on `Flux2Pipeline`
- New `kleinEncoderPath: URL? = nil` parameter on `Flux2Pipeline.init` (last position, defaulted)
- `kleinEncoder!.load()` -> `kleinEncoder!.load(from: kleinEncoderPath)` at the two Klein branches in `loadTextEncoder()`

Has no effect when `model == .dev` (Dev uses the Mistral encoder, which has its own loader).

## Test plan

- [x] `swift build` passes against the package on its own (verified locally on macOS 15, Xcode 17F42, Swift 6.0)
- [ ] `swift test` against the existing test target
- [ ] Smoke generate with `kleinEncoderPath` pointing at a local Qwen3-8B safetensors directory and confirm the FLUX library uses those weights (no Hub fetch)
- [ ] Smoke generate with `kleinEncoderPath: nil` and confirm existing auto-download path is unchanged

## Notes

Filed as draft because I wanted upstream eyes on the API shape before promoting it. Happy to:
- Rename the parameter (e.g. `kleinTextEncoderPath`, `customKleinEncoderURL`)
- Move it under a separate `Flux2EncoderConfig` struct if you'd prefer to avoid `init` parameter creep
- Add tests if you can point me at any in-tree fixtures for Klein encoder loading

Whatever shape lands upstream, I'll follow.

Made with [Cursor](https://cursor.com)