### PR TITLE
feat(chains): expose upsamplePrompt + opt-in I2I + Flux 2 prompt DocC

### DIFF
--- a/Sources/Flux2Chains/Flux2MaskedInpaintingChain.swift
+++ b/Sources/Flux2Chains/Flux2MaskedInpaintingChain.swift
@@ -25,7 +25,29 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
     /// load cost each time.
     public let pipeline: Flux2Pipeline
 
-    /// Inputs.
+    /// Text describing the **full** target image, **not** just the edit.
+    ///
+    /// FLUX.2 has no negative prompts and no dedicated edit instruction
+    /// channel — the prompt is the only steering signal for the in-mask
+    /// region. Follow the BFL prompting guidelines
+    /// (<https://docs.bfl.ml/guides/prompting_guide_flux2>):
+    ///
+    /// - **Structure**: *Subject + Action + Style + Context*. Word order
+    ///   matters: FLUX.2 weighs leading tokens more.
+    /// - **Length**: ~30–80 words. Describe the **whole** scene including
+    ///   the kept surroundings so the model has lighting/perspective cues
+    ///   for the inpainted region.
+    /// - **No negatives**: describe what you want, never what to avoid.
+    ///
+    /// Short prompts like `"a duck"` give the model no spatial / lighting /
+    /// integration cues and produce floating, mismatched subjects. Prefer:
+    /// *"A mallard duck standing on grey weathered concrete pavement at the
+    /// base of a rough limestone wall, soft midday sunlight from the upper
+    /// left casting a clear cast shadow on the ground, scattered grass
+    /// clippings around, naturalistic photography, shallow depth of field."*
+    ///
+    /// For dynamic prompt expansion at inference time, set
+    /// ``upsamplePrompt`` to `true`.
     public let prompt: String
     public let image: CGImage
     /// Grayscale mask, same dimensions as `image` (resized otherwise).
@@ -34,15 +56,41 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
     /// Optional reference image(s) for the transformer to attend to in
     /// addition to the prompt. When provided, the chain switches generation
     /// from `.textToImage` to `.imageToImage(referenceImages)` while still
-    /// applying the RePaint blend. Use this for *outpainting* where you want
-    /// the painted strips to genuinely continue the visual content of the
-    /// keep region — pass the extended canvas itself as the reference so the
-    /// model sees what it should match. For pure intra-image inpainting this
-    /// is unnecessary and adds compute.
+    /// applying the RePaint blend.
+    ///
+    /// **When to use:** for outpainting / scene extension. Pass the
+    /// original (un-extended) image so the transformer's attention
+    /// continues the kept content into the new strips (see
+    /// `Flux2OutpaintingChain`).
+    ///
+    /// **When NOT to use:** for "replace object X with object Y" inpainting.
+    /// Passing the source image (which still contains X under the mask)
+    /// makes the model attend to X's pixels and bleed its texture/colour
+    /// into Y — empirically verified on cat → duck (the duck inherits the
+    /// tabby's grey-striped head). Leave nil and rely on a descriptive
+    /// Flux 2-style prompt; see ``prompt``.
     public let referenceImages: [CGImage]?
+    /// When `referenceImages` is nil, auto-condition the transformer on
+    /// ``image`` itself.
+    ///
+    /// Default `false`. **This is intentional for the common case of
+    /// object replacement**: feeding the source as a reference lets the
+    /// to-be-replaced subject leak into the result via attention. Enable
+    /// only when the goal is *repair* or *scene extension* and the masked
+    /// region is empty / neutral — in that scenario the reference gives
+    /// the model the lighting / perspective / palette context it needs to
+    /// integrate the new content.
+    public let useImageAsReference: Bool
     public let steps: Int
     public let guidance: Float
     public let seed: UInt64?
+    /// When `true`, the active text encoder rewrites the prompt with an
+    /// internal vision-language model (Qwen3.5 VLM in this framework)
+    /// before encoding. Useful when the caller supplies a short edit
+    /// instruction rather than a full Flux 2-style descriptive prompt.
+    /// Cost: one extra VLM forward pass per call. Default `false` to
+    /// preserve the caller's exact wording.
+    public let upsamplePrompt: Bool
     /// Optional progress callback forwarded to `generateWithResult`.
     public let onProgress: Flux2ProgressCallback?
 
@@ -68,13 +116,21 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
     ///   - referenceImages: When non-nil and non-empty, the chain switches to
     ///     `.imageToImage` so the transformer attends to these references in
     ///     addition to the prompt. Used by `Flux2OutpaintingChain` to make
-    ///     the model continue the kept region. Pass `nil` for plain T2I
-    ///     RePaint inpainting.
+    ///     the model continue the kept region. Pass `nil` for the chain to
+    ///     decide based on ``useImageAsReference``.
+    ///   - useImageAsReference: When `referenceImages` is `nil`, auto-pass
+    ///     ``image`` itself as the I2I reference. Default `false` — for
+    ///     "replace object X with object Y" inpainting the source-as-ref
+    ///     bleeds X into Y via attention. Enable for *repair / extend*
+    ///     workflows where the masked region is empty.
     ///   - steps: Denoising step count. `4` matches klein distilled defaults.
     ///   - guidance: Classifier-free guidance scale. `1.0` for distilled
     ///     klein; raise to ≈ 3.5 with `.klein9BBase` or `.klein4BBase` to
     ///     trigger the classical CFG path on the underlying pipeline.
     ///   - seed: Random seed for reproducibility. `nil` for non-deterministic.
+    ///   - upsamplePrompt: Rewrite the prompt via the bundled VLM before
+    ///     encoding. Useful when the caller supplies a short edit
+    ///     instruction. Default `false`.
     ///   - maxPixels: Cap on the working resolution. Larger inputs are scaled
     ///     down (aspect preserved) before being clamped to a multiple of 32.
     ///   - onProgress: Forwarded to the pipeline's denoising loop.
@@ -84,9 +140,11 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
         image: CGImage,
         mask: CGImage,
         referenceImages: [CGImage]? = nil,
+        useImageAsReference: Bool = false,
         steps: Int = 4,
         guidance: Float = 1.0,
         seed: UInt64? = nil,
+        upsamplePrompt: Bool = false,
         maxPixels: Int = 1024 * 1024,
         onProgress: Flux2ProgressCallback? = nil
     ) {
@@ -95,9 +153,11 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
         self.image = image
         self.mask = mask
         self.referenceImages = referenceImages
+        self.useImageAsReference = useImageAsReference
         self.steps = steps
         self.guidance = guidance
         self.seed = seed
+        self.upsamplePrompt = upsamplePrompt
         self.maxPixels = maxPixels
         self.onProgress = onProgress
     }
@@ -156,6 +216,8 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
         let mode: Flux2GenerationMode
         if let refs = referenceImages, !refs.isEmpty {
             mode = .imageToImage(images: refs)
+        } else if useImageAsReference {
+            mode = .imageToImage(images: [image])
         } else {
             mode = .textToImage
         }
@@ -169,7 +231,7 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
             steps: steps,
             guidance: guidance,
             seed: seed,
-            upsamplePrompt: false,
+            upsamplePrompt: upsamplePrompt,
             precomputedEmbeddings: nil,
             checkpointInterval: nil,
             onProgress: onProgress,

--- a/Sources/Flux2Chains/Flux2OutpaintingChain.swift
+++ b/Sources/Flux2Chains/Flux2OutpaintingChain.swift
@@ -46,15 +46,24 @@ public struct Flux2OutpaintingChain: Flux2Chain {
     public let left: Int
     public let right: Int
 
-    /// Text prompt describing the **full** extended scene. Mention the
-    /// content of the keep region too — the transformer attends to the
-    /// I2I reference but the prompt is still its main steering signal.
+    /// Text prompt describing the **full** extended scene.
+    ///
+    /// Follow the BFL prompting guidelines
+    /// (<https://docs.bfl.ml/guides/prompting_guide_flux2>): *Subject +
+    /// Action + Style + Context*, 30–80 words, leading words weigh more.
+    /// Mention the content of the keep region too — the transformer
+    /// attends to the I2I reference but the prompt is still its main
+    /// steering signal. No negative prompts.
     public let prompt: String
 
     /// FLUX.2 generation parameters. Defaults target distilled klein.
     public let steps: Int
     public let guidance: Float
     public let seed: UInt64?
+    /// Rewrite the prompt via the bundled VLM before encoding. Useful
+    /// when the caller passes a short instruction rather than a full
+    /// Flux 2-style descriptive prompt. Default `false`.
+    public let upsamplePrompt: Bool
     public let onProgress: Flux2ProgressCallback?
 
     /// Width of the soft transition band, in pixels of the canvas. The band
@@ -87,6 +96,9 @@ public struct Flux2OutpaintingChain: Flux2Chain {
     ///   - steps: Denoising step count. `4` matches klein distilled defaults.
     ///   - guidance: Classifier-free guidance scale.
     ///   - seed: Random seed for reproducibility. `nil` for non-deterministic.
+    ///   - upsamplePrompt: Rewrite the prompt via the bundled VLM before
+    ///     encoding. Useful when the caller passes a short instruction
+    ///     rather than a full descriptive Flux 2 prompt. Default `false`.
     ///   - transitionPixels: Width of the soft transition band, in pixels of
     ///     the keep region. The band lives *inside* the keep so the strips
     ///     themselves carry mask = 1.0 (pure paint, no seed contamination).
@@ -105,6 +117,7 @@ public struct Flux2OutpaintingChain: Flux2Chain {
         steps: Int = 4,
         guidance: Float = 1.0,
         seed: UInt64? = nil,
+        upsamplePrompt: Bool = false,
         transitionPixels: Int = 32,
         maxPixels: Int = 4 * 1024 * 1024,
         onProgress: Flux2ProgressCallback? = nil
@@ -119,6 +132,7 @@ public struct Flux2OutpaintingChain: Flux2Chain {
         self.steps = steps
         self.guidance = guidance
         self.seed = seed
+        self.upsamplePrompt = upsamplePrompt
         self.transitionPixels = transitionPixels
         self.maxPixels = maxPixels
         self.onProgress = onProgress
@@ -199,9 +213,11 @@ public struct Flux2OutpaintingChain: Flux2Chain {
             image: canvas,
             mask: mask,
             referenceImages: [image],  // I2I conditioning continues the scene
+            useImageAsReference: false,  // explicit refs already supplied
             steps: steps,
             guidance: guidance,
             seed: seed,
+            upsamplePrompt: upsamplePrompt,
             maxPixels: max(maxPixels, canvasW * canvasH),
             onProgress: onProgress
         )

--- a/Tests/Flux2ChainsTests/Flux2MaskedInpaintingChainTests.swift
+++ b/Tests/Flux2ChainsTests/Flux2MaskedInpaintingChainTests.swift
@@ -30,6 +30,10 @@ final class Flux2MaskedInpaintingChainTests: XCTestCase {
         XCTAssertNil(chain.seed)
         XCTAssertNil(chain.referenceImages,
                      "Reference images default to nil so the chain picks the .textToImage mode")
+        XCTAssertFalse(chain.useImageAsReference,
+                       "Auto I2I conditioning is OFF by default — feeding the source as ref bleeds the to-be-replaced subject into the result via attention. Enable only for repair / scene-extension.")
+        XCTAssertFalse(chain.upsamplePrompt,
+                       "Default off — caller's wording wins unless they explicitly opt into VLM rewriting")
     }
 
     func testInitForwardsExplicitArguments() {
@@ -43,9 +47,11 @@ final class Flux2MaskedInpaintingChainTests: XCTestCase {
             image: img,
             mask: img,
             referenceImages: [refA, refB],
+            useImageAsReference: true,
             steps: 25,
             guidance: 3.5,
             seed: 1234,
+            upsamplePrompt: true,
             maxPixels: 2_400_000
         )
         XCTAssertEqual(chain.prompt, "hello")
@@ -54,12 +60,15 @@ final class Flux2MaskedInpaintingChainTests: XCTestCase {
         XCTAssertEqual(chain.seed, 1234)
         XCTAssertEqual(chain.maxPixels, 2_400_000)
         XCTAssertEqual(chain.referenceImages?.count, 2)
+        XCTAssertTrue(chain.useImageAsReference)
+        XCTAssertTrue(chain.upsamplePrompt)
     }
 
     func testEmptyReferenceImagesArrayBehavesLikeNil() async {
         // The chain treats nil and [] the same way for the mode switch: both
-        // mean "no reference, run as T2I". We surface this through the
-        // public property — the actual switch happens inside `run()`.
+        // mean "no explicit ref" → run() falls back to useImageAsReference.
+        // We surface this through the public property — the actual switch
+        // happens inside `run()`.
         let pipeline = Flux2Pipeline(model: .klein9B)
         let img = solid(width: 32, height: 32)
         let chain = Flux2MaskedInpaintingChain(
@@ -71,6 +80,24 @@ final class Flux2MaskedInpaintingChainTests: XCTestCase {
         )
         XCTAssertEqual(chain.referenceImages?.count, 0,
                        "Empty arrays survive init verbatim — the chain's run() decides what to do with them")
+    }
+
+    func testRepairModeOptsIntoAutoReference() {
+        // The opt-in path for callers who DO want the chain to feed
+        // `image` as I2I context — typically when the masked region is
+        // empty (scene extension / repair, not subject replacement).
+        let pipeline = Flux2Pipeline(model: .klein9B)
+        let img = solid(width: 32, height: 32)
+        let chain = Flux2MaskedInpaintingChain(
+            pipeline: pipeline,
+            prompt: "x",
+            image: img,
+            mask: img,
+            useImageAsReference: true
+        )
+        XCTAssertTrue(chain.useImageAsReference)
+        XCTAssertNil(chain.referenceImages,
+                     "Opt-in keeps refs nil — run() falls back to wrapping `image` itself")
     }
 
     // MARK: - Helpers

--- a/Tests/Flux2ChainsTests/Flux2OutpaintingChainTests.swift
+++ b/Tests/Flux2ChainsTests/Flux2OutpaintingChainTests.swift
@@ -242,6 +242,7 @@ final class Flux2OutpaintingChainTests: XCTestCase {
             top: 16, bottom: 32, left: 48, right: 0,
             prompt: "hello",
             steps: 7, guidance: 2.5, seed: 99,
+            upsamplePrompt: true,
             transitionPixels: 16, maxPixels: 500_000
         )
         XCTAssertEqual(chain.top, 16)
@@ -252,8 +253,17 @@ final class Flux2OutpaintingChainTests: XCTestCase {
         XCTAssertEqual(chain.steps, 7)
         XCTAssertEqual(chain.guidance, 2.5)
         XCTAssertEqual(chain.seed, 99)
+        XCTAssertTrue(chain.upsamplePrompt)
         XCTAssertEqual(chain.transitionPixels, 16)
         XCTAssertEqual(chain.maxPixels, 500_000)
+    }
+
+    func testUpsamplePromptDefaultsOff() {
+        let pipeline = Flux2Pipeline(model: .klein9B)
+        let img = makeSolidImage(width: 32, height: 32, value: 50)
+        let chain = Flux2OutpaintingChain(pipeline: pipeline, image: img, prompt: "x")
+        XCTAssertFalse(chain.upsamplePrompt,
+                       "Off by default — caller's exact wording is preserved unless they opt in")
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary

While reviewing the cat→duck inpainting output the user produced, three issues surfaced:

1. **`upsamplePrompt` was hardcoded `false`** in `Flux2MaskedInpaintingChain.swift:172` — hosts couldn't opt into the bundled VLM prompt rewriting even though everything else in the framework supports it. Now exposed on both chains (default still `false` for back-compat).

2. **No prompt guidance.** A short instruction like `"a duck"` gives FLUX.2 no spatial / lighting / scene cues and produces oversized, floating, mismatched subjects. DocC on `prompt` now documents BFL's prompting style (Subject+Action+Style+Context, 30–80 words, leading words weigh more, no negatives) with a concrete example. Links:
   - https://docs.bfl.ml/guides/prompting_guide_flux2
   - https://github.com/black-forest-labs/flux2/blob/main/docs/flux2_with_prompt_upsampling.md

3. **New `useImageAsReference: Bool = false` opt-in.** Empirical testing on the cat→duck case showed that auto-feeding the source image as an I2I reference *hurts* "replace X with Y" inpainting: the source still contains X under the mask, and the transformer's attention bleeds X's texture into Y (the duck inherited the tabby's grey-striped head). Keeping the default at `false` preserves the old behavior; the flag is there for *repair / scene-extension* workflows where the masked region is empty.

## Empirical validation

On the user's IMG_1848 (840×1120 working res), klein-9b distilled, 4 steps, seed 42, mask = soft ellipse over the cat:

| Variant | Time | Result |
|---|---|---|
| **T2I + Flux 2 prompt (default)** | 53 s | ✅ clean mallard, integrated shadow, correct scale |
| `useImageAsReference: true` + same prompt | 116 s | ❌ tabby cat texture bleeds into the duck's head |
| Manual masked-out reference + same prompt | 115 s | ❌ two ducks compose weirdly |

→ For object replacement, **the dominant fix is a properly structured Flux 2 prompt**, not the chain architecture.

## Test plan

- [x] `xcodebuild test -only-testing:Flux2ChainsTests` — 27/27 pass
- [x] Added `testRepairModeOptsIntoAutoReference` covering the opt-in path
- [x] Added `testUpsamplePromptDefaultsOff` on the outpainting chain
- [x] Updated `testDefaultsTargetKleinDistilled` to assert the new defaults
- [x] Manual E2E via `sharp-cli inpaint` on a 840×1120 cat photo with the new DocC-recommended prompt

## Follow-ups (not in this PR)

- Mask convention: support alpha-channel masks as an alternative to grayscale (where `alpha=0` ⇒ inpaint, `alpha=1` ⇒ keep) so callers can pass an "image with a hole erased" rather than maintaining a separate grayscale image. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)