### PR TITLE
feat(cli): bring inpaint / outpaint into Flux2CLI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -68,6 +68,7 @@ let package = Package(
             name: "Flux2CLI",
             dependencies: [
                 "Flux2Core",
+                "Flux2Chains",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Yams", package: "Yams"),
             ]

--- a/Sources/Flux2CLI/Flux2CLI.swift
+++ b/Sources/Flux2CLI/Flux2CLI.swift
@@ -26,6 +26,8 @@ struct Flux2CLI: AsyncParsableCommand {
         subcommands: [
             TextToImage.self,
             ImageToImage.self,
+            Inpaint.self,
+            Outpaint.self,
             Download.self,
             Info.self,
             Profile.self,

--- a/Sources/Flux2CLI/InpaintCommand.swift
+++ b/Sources/Flux2CLI/InpaintCommand.swift
@@ -1,0 +1,143 @@
+// InpaintCommand.swift — `flux2 inpaint` (RePaint-style masked inpainting)
+// Copyright 2025 Vincent Gourbin
+//
+// Drives `Flux2MaskedInpaintingChain` from the framework. Moved here from
+// the sibling `sharp-cli` (where it originally landed for historical
+// reasons) so that all pure-Flux2 chain commands live next to the chains
+// themselves.
+
+import Foundation
+import ArgumentParser
+import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
+import Flux2Core
+import Flux2Chains
+
+struct Inpaint: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "inpaint",
+        abstract: "RePaint-style masked inpainting: regenerate the white-masked region of an image with a text prompt"
+    )
+
+    @Option(name: .long, help: "Root of the FluxForge Studio Models directory.")
+    var modelsDir: String = "/Users/vincent/Pictures/FluxforgeStudio/Models"
+
+    @Option(name: .long, help: "FLUX.2 model: klein-9b (distilled, default) | klein-9b-base | klein-9b-kv | dev | klein-4b | klein-4b-base.")
+    var fluxModel: String = "klein-9b"
+
+    @Option(name: [.short, .long], help: "Input image to inpaint.")
+    var image: String
+
+    @Option(name: [.short, .long], help: "Grayscale mask, same dimensions as image. WHITE = inpaint (will be replaced), BLACK = keep (preserved by RePaint blend).")
+    var mask: String
+
+    @Option(name: [.short, .long], help: "Text prompt describing the desired full image (the model regenerates everything, the mask just forces the original back outside the painted region).")
+    var prompt: String
+
+    @Option(name: [.short, .long], help: "Output PNG path.")
+    var output: String
+
+    @Option(name: .long, help: "Optional path(s) to reference image(s) — when set, the chain runs in I2I mode so the transformer attends to these while still respecting the RePaint mask. Repeat for multiple references. Useful for outpainting where you want the new strips to continue the existing scene.")
+    var reference: [String] = []
+
+    @Option(name: .long, help: "Denoising steps for FLUX.2 (4 for distilled klein, 25-28 for base/dev).")
+    var steps: Int = 4
+    @Option(name: .long, help: "Guidance scale (1.0 for distilled, 3.5 for base, 4.0 for dev).")
+    var guidance: Float = 1.0
+    @Option(name: .long, help: "Random seed (omit for non-deterministic).")
+    var seed: UInt64?
+    @Option(name: .long, help: "Maximum total pixel count for the working resolution. Defaults to 1024² (≈ 1 048 576).")
+    var maxPixels: Int = 1024 * 1024
+
+    func run() async throws {
+        @Sendable func logErr(_ msg: String) {
+            FileHandle.standardError.write(Data((msg + "\n").utf8))
+        }
+
+        ModelRegistry.customModelsDirectory = URL(fileURLWithPath: modelsDir)
+
+        guard let imageCG = Self.loadCGImage(at: image) else {
+            throw ValidationError("Could not decode image at \(image)")
+        }
+        guard let maskCG = Self.loadCGImage(at: mask) else {
+            throw ValidationError("Could not decode mask at \(mask)")
+        }
+        logErr("Image: \(image) (\(imageCG.width)×\(imageCG.height))")
+        logErr("Mask : \(mask) (\(maskCG.width)×\(maskCG.height))")
+        logErr("Prompt: \(prompt)")
+
+        let modelChoice: Flux2Model
+        switch fluxModel.lowercased() {
+        case "klein-9b", "klein9b":               modelChoice = .klein9B
+        case "klein-9b-base", "klein9b-base":     modelChoice = .klein9BBase
+        case "klein-9b-kv", "klein9b-kv":         modelChoice = .klein9BKV
+        case "klein-4b", "klein4b":               modelChoice = .klein4B
+        case "klein-4b-base", "klein4b-base":     modelChoice = .klein4BBase
+        case "dev":                               modelChoice = .dev
+        default:
+            throw ValidationError("Unsupported --flux-model '\(fluxModel)'.")
+        }
+
+        let pipeline = Flux2Pipeline(
+            model: modelChoice,
+            quantization: .memoryEfficient,
+            vaeVariant: .smallDecoder
+        )
+        let loadStart = Date()
+        try await pipeline.loadModels()
+        logErr("✓ Flux2 pipeline ready in \(String(format: "%.1fs", Date().timeIntervalSince(loadStart)))")
+
+        let referenceCGs: [CGImage]? = reference.isEmpty ? nil : try reference.map { p in
+            guard let img = Self.loadCGImage(at: p) else {
+                throw ValidationError("Could not decode reference image at \(p)")
+            }
+            logErr("Reference: \(p) (\(img.width)×\(img.height))")
+            return img
+        }
+        if referenceCGs != nil { logErr("I2I+RePaint mode enabled") }
+
+        let chain = Flux2MaskedInpaintingChain(
+            pipeline: pipeline,
+            prompt: prompt,
+            image: imageCG,
+            mask: maskCG,
+            referenceImages: referenceCGs,
+            steps: steps,
+            guidance: guidance,
+            seed: seed,
+            maxPixels: maxPixels,
+            onProgress: { step, total in
+                logErr("  step \(step)/\(total)")
+            }
+        )
+
+        let runStart = Date()
+        let result = try await chain.run()
+        logErr("✓ Inpainting done in \(String(format: "%.1fs", Date().timeIntervalSince(runStart)))")
+        try Self.savePNG(result.image, to: output)
+        logErr("✓ Inpainted image → \(output)")
+    }
+
+    private static func loadCGImage(at path: String) -> CGImage? {
+        let url = URL(fileURLWithPath: path)
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else { return nil }
+        return CGImageSourceCreateImageAtIndex(source, 0, nil)
+    }
+
+    private static func savePNG(_ image: CGImage, to path: String) throws {
+        let url = URL(fileURLWithPath: path)
+        guard let dest = CGImageDestinationCreateWithURL(
+            url as CFURL,
+            UTType.png.identifier as CFString,
+            1,
+            nil
+        ) else {
+            throw ValidationError("Could not create PNG destination at \(path)")
+        }
+        CGImageDestinationAddImage(dest, image, nil)
+        guard CGImageDestinationFinalize(dest) else {
+            throw ValidationError("Failed to write PNG at \(path)")
+        }
+    }
+}

--- a/Sources/Flux2CLI/OutpaintCommand.swift
+++ b/Sources/Flux2CLI/OutpaintCommand.swift
@@ -1,0 +1,142 @@
+// OutpaintCommand.swift — `flux2 outpaint` (Flux2OutpaintingChain wrapper)
+// Copyright 2025 Vincent Gourbin
+//
+// One-liner outpainting:
+//   flux2 outpaint -i in.jpg -o out.png --left 384 --right 384 \
+//                  --prompt "..."
+//
+// Mirrors the Black Forest Labs `flux_outpainting` API surface: caller
+// passes paddings in pixels per side + a prompt; the chain handles the
+// canvas/mask/seed/inference internally.
+
+import Foundation
+import ArgumentParser
+import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
+import Flux2Core
+import Flux2Chains
+
+struct Outpaint: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "outpaint",
+        abstract: "Extend an image on any of the four sides via Flux2OutpaintingChain"
+    )
+
+    @Option(name: .long, help: "Root of the FluxForge Studio Models directory.")
+    var modelsDir: String = "/Users/vincent/Pictures/FluxforgeStudio/Models"
+
+    @Option(name: .long, help: "FLUX.2 model: klein-9b (distilled, default) | klein-9b-base | klein-9b-kv | dev | klein-4b | klein-4b-base.")
+    var fluxModel: String = "klein-9b"
+
+    @Option(name: [.short, .long], help: "Input image to extend.")
+    var image: String
+
+    @Option(name: [.short, .long], help: "Text prompt describing the full extended scene.")
+    var prompt: String
+
+    @Option(name: [.short, .long], help: "Output PNG path.")
+    var output: String
+
+    @Option(name: .long, help: "Pixels to add at the top. Rounded up to a multiple of 32.")
+    var top: Int = 0
+    @Option(name: .long, help: "Pixels to add at the bottom. Rounded up to a multiple of 32.")
+    var bottom: Int = 0
+    @Option(name: .long, help: "Pixels to add on the left. Rounded up to a multiple of 32.")
+    var left: Int = 0
+    @Option(name: .long, help: "Pixels to add on the right. Rounded up to a multiple of 32.")
+    var right: Int = 0
+
+    @Option(name: .long, help: "Denoising steps (4 for distilled klein, 25-28 for base/dev).")
+    var steps: Int = 4
+    @Option(name: .long, help: "Guidance scale (1.0 for distilled, 3.5 for base, 4.0 for dev).")
+    var guidance: Float = 1.0
+    @Option(name: .long, help: "Random seed.")
+    var seed: UInt64?
+    @Option(name: .long, help: "Width of the soft transition band, in pixels of the keep region. Default 32.")
+    var transitionPixels: Int = 32
+    @Option(name: .long, help: "Cap on the total working pixel count. Defaults to 4 M; raise if you want larger canvases.")
+    var maxPixels: Int = 4 * 1024 * 1024
+
+    func run() async throws {
+        @Sendable func logErr(_ msg: String) {
+            FileHandle.standardError.write(Data((msg + "\n").utf8))
+        }
+
+        ModelRegistry.customModelsDirectory = URL(fileURLWithPath: modelsDir)
+
+        guard let imageCG = Self.loadCGImage(at: image) else {
+            throw ValidationError("Could not decode image at \(image)")
+        }
+        logErr("Image: \(image) (\(imageCG.width)×\(imageCG.height))")
+        logErr("Padding: top=\(top) bottom=\(bottom) left=\(left) right=\(right)")
+        logErr("Prompt: \(prompt)")
+
+        let modelChoice: Flux2Model
+        switch fluxModel.lowercased() {
+        case "klein-9b", "klein9b":               modelChoice = .klein9B
+        case "klein-9b-base", "klein9b-base":     modelChoice = .klein9BBase
+        case "klein-9b-kv", "klein9b-kv":         modelChoice = .klein9BKV
+        case "klein-4b", "klein4b":               modelChoice = .klein4B
+        case "klein-4b-base", "klein4b-base":     modelChoice = .klein4BBase
+        case "dev":                               modelChoice = .dev
+        default:
+            throw ValidationError("Unsupported --flux-model '\(fluxModel)'.")
+        }
+
+        let pipeline = Flux2Pipeline(
+            model: modelChoice,
+            quantization: .memoryEfficient,
+            vaeVariant: .smallDecoder
+        )
+        let loadStart = Date()
+        try await pipeline.loadModels()
+        logErr("✓ Flux2 pipeline ready in \(String(format: "%.1fs", Date().timeIntervalSince(loadStart)))")
+
+        let chain = Flux2OutpaintingChain(
+            pipeline: pipeline,
+            image: imageCG,
+            top: top,
+            bottom: bottom,
+            left: left,
+            right: right,
+            prompt: prompt,
+            steps: steps,
+            guidance: guidance,
+            seed: seed,
+            transitionPixels: transitionPixels,
+            maxPixels: maxPixels,
+            onProgress: { step, total in
+                logErr("  step \(step)/\(total)")
+            }
+        )
+
+        let runStart = Date()
+        let result = try await chain.run()
+        logErr("✓ Outpainting done in \(String(format: "%.1fs", Date().timeIntervalSince(runStart)))")
+        try Self.savePNG(result.image, to: output)
+        logErr("✓ Outpainted image → \(output)")
+    }
+
+    private static func loadCGImage(at path: String) -> CGImage? {
+        let url = URL(fileURLWithPath: path)
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else { return nil }
+        return CGImageSourceCreateImageAtIndex(source, 0, nil)
+    }
+
+    private static func savePNG(_ image: CGImage, to path: String) throws {
+        let url = URL(fileURLWithPath: path)
+        guard let dest = CGImageDestinationCreateWithURL(
+            url as CFURL,
+            UTType.png.identifier as CFString,
+            1,
+            nil
+        ) else {
+            throw ValidationError("Could not create PNG destination at \(path)")
+        }
+        CGImageDestinationAddImage(dest, image, nil)
+        guard CGImageDestinationFinalize(dest) else {
+            throw ValidationError("Failed to write PNG at \(path)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Move `inpaint` and `outpaint` from `sharp-cli` (in the sibling `rephoto-swift-coreml` repo) into the `flux2` CLI here, where they structurally belong: both commands wrap chains defined in `Flux2Chains` and have **zero** dependency on SHARP / MetalSplatter / CoreML. They originally landed in `sharp-cli` only because that's where chain iteration was happening alongside the 3D-repair chain.

Result: a single binary (`flux2`) exposes all the pure-Flux2 chain commands; `sharp-cli` keeps only what genuinely depends on the AMLR-licensed SHARP CoreML model.

## Changes

- `Package.swift` — `Flux2CLI` target now depends on `Flux2Chains`.
- `Sources/Flux2CLI/InpaintCommand.swift` (new) — copied verbatim from `rephoto-swift-coreml@main:Sources/SharpCLI/InpaintCommand.swift`, only the header comment and command name change.
- `Sources/Flux2CLI/OutpaintCommand.swift` (new) — same.
- `Sources/Flux2CLI/Flux2CLI.swift` — registers `Inpaint.self` and `Outpaint.self` in the subcommands list.

## Migration

`sharp-cli inpaint` → `flux2 inpaint` (same flags, same semantics).
`sharp-cli outpaint` → `flux2 outpaint` (same flags, same semantics).

The companion PR on rephoto deletes the orphaned sources.

## Test plan

- [x] `xcodebuild -scheme Flux2CLI -configuration Release build` — succeeds
- [x] `xcodebuild test -only-testing:Flux2ChainsTests` — 27/27 pass (chain logic unchanged)
- [x] `flux2 inpaint --help` shows the expected usage
- [x] `flux2 outpaint --help` shows the expected usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)