### PR TITLE
feat(cli): expose chain flags in flux2 inpaint/outpaint + drop hardcoded modelsDir

### DIFF
--- a/Sources/Flux2CLI/InpaintCommand.swift
+++ b/Sources/Flux2CLI/InpaintCommand.swift
@@ -14,14 +14,31 @@ import UniformTypeIdentifiers
 import Flux2Core
 import Flux2Chains
 
+/// User-facing string mapping for ``Flux2MaskConvention``.
+///
+/// Kept local to the CLI so the framework enum stays free of
+/// ArgumentParser dependencies; the `--mask-convention` flag accepts the
+/// short identifiers `grayscale` / `alpha`.
+enum MaskConventionArg: String, ExpressibleByArgument, CaseIterable {
+    case grayscale
+    case alpha
+
+    var convention: Flux2MaskConvention {
+        switch self {
+        case .grayscale: return .grayscaleWhiteInpaint
+        case .alpha:     return .alphaTransparentInpaint
+        }
+    }
+}
+
 struct Inpaint: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "inpaint",
-        abstract: "RePaint-style masked inpainting: regenerate the white-masked region of an image with a text prompt"
+        abstract: "RePaint-style masked inpainting: regenerate the masked region of an image with a text prompt"
     )
 
-    @Option(name: .long, help: "Root of the FluxForge Studio Models directory.")
-    var modelsDir: String = "/Users/vincent/Pictures/FluxforgeStudio/Models"
+    @Option(name: .long, help: "Custom models directory (for sandboxed apps or custom storage). Defaults to the framework's standard models path.")
+    var modelsDir: String?
 
     @Option(name: .long, help: "FLUX.2 model: klein-9b (distilled, default) | klein-9b-base | klein-9b-kv | dev | klein-4b | klein-4b-base.")
     var fluxModel: String = "klein-9b"
@@ -29,17 +46,26 @@ struct Inpaint: AsyncParsableCommand {
     @Option(name: [.short, .long], help: "Input image to inpaint.")
     var image: String
 
-    @Option(name: [.short, .long], help: "Grayscale mask, same dimensions as image. WHITE = inpaint (will be replaced), BLACK = keep (preserved by RePaint blend).")
+    @Option(name: [.short, .long], help: "Mask image, same dimensions as the input. Interpretation depends on --mask-convention: 'grayscale' (default) reads luminance, WHITE = inpaint, BLACK = keep; 'alpha' reads the alpha channel, TRANSPARENT = inpaint, OPAQUE = keep. Soft values honoured in both modes.")
     var mask: String
 
-    @Option(name: [.short, .long], help: "Text prompt describing the desired full image (the model regenerates everything, the mask just forces the original back outside the painted region).")
+    @Option(name: .long, help: "How --mask is read: 'grayscale' (default — white = inpaint) or 'alpha' (transparent = inpaint, RGB ignored). Use 'alpha' when you erased the region to redo in a photo editor and saved a PNG with alpha.")
+    var maskConvention: MaskConventionArg = .grayscale
+
+    @Option(name: [.short, .long], help: "Text prompt describing the desired full image. Follow Flux 2 prompting guidelines (https://docs.bfl.ml/guides/prompting_guide_flux2): Subject + Action + Style + Context, 30–80 words, describe the WHOLE scene including the kept surroundings (the model has no other lighting / perspective cues for the inpainted region).")
     var prompt: String
 
     @Option(name: [.short, .long], help: "Output PNG path.")
     var output: String
 
-    @Option(name: .long, help: "Optional path(s) to reference image(s) — when set, the chain runs in I2I mode so the transformer attends to these while still respecting the RePaint mask. Repeat for multiple references. Useful for outpainting where you want the new strips to continue the existing scene.")
+    @Option(name: .long, help: "Optional path(s) to reference image(s) — when set, the chain runs in I2I mode so the transformer attends to these while still respecting the RePaint mask. Repeat for multiple references. Useful for scene-extension / repair where the new content must continue the kept region.")
     var reference: [String] = []
+
+    @Flag(name: .long, help: "Auto-feed the source image as I2I conditioning when --reference is not set. OFF by default — for 'replace object X with object Y' inpainting, the source still contains X under the mask and bleeds X into Y via attention. Enable for repair / scene-extension where the masked region is empty.")
+    var useImageAsReference: Bool = false
+
+    @Flag(name: .long, help: "Rewrite the prompt via the bundled Qwen3.5 VLM before encoding. Useful when --prompt is a short edit instruction rather than a full descriptive Flux 2 prompt. Adds one extra VLM forward pass.")
+    var upsamplePrompt: Bool = false
 
     @Option(name: .long, help: "Denoising steps for FLUX.2 (4 for distilled klein, 25-28 for base/dev).")
     var steps: Int = 4
@@ -55,7 +81,7 @@ struct Inpaint: AsyncParsableCommand {
             FileHandle.standardError.write(Data((msg + "\n").utf8))
         }
 
-        ModelRegistry.customModelsDirectory = URL(fileURLWithPath: modelsDir)
+        configureModelsDirectory(modelsDir)
 
         guard let imageCG = Self.loadCGImage(at: image) else {
             throw ValidationError("Could not decode image at \(image)")
@@ -102,10 +128,13 @@ struct Inpaint: AsyncParsableCommand {
             prompt: prompt,
             image: imageCG,
             mask: maskCG,
+            maskConvention: maskConvention.convention,
             referenceImages: referenceCGs,
+            useImageAsReference: useImageAsReference,
             steps: steps,
             guidance: guidance,
             seed: seed,
+            upsamplePrompt: upsamplePrompt,
             maxPixels: maxPixels,
             onProgress: { step, total in
                 logErr("  step \(step)/\(total)")

--- a/Sources/Flux2CLI/OutpaintCommand.swift
+++ b/Sources/Flux2CLI/OutpaintCommand.swift
@@ -23,8 +23,8 @@ struct Outpaint: AsyncParsableCommand {
         abstract: "Extend an image on any of the four sides via Flux2OutpaintingChain"
     )
 
-    @Option(name: .long, help: "Root of the FluxForge Studio Models directory.")
-    var modelsDir: String = "/Users/vincent/Pictures/FluxforgeStudio/Models"
+    @Option(name: .long, help: "Custom models directory (for sandboxed apps or custom storage). Defaults to the framework's standard models path.")
+    var modelsDir: String?
 
     @Option(name: .long, help: "FLUX.2 model: klein-9b (distilled, default) | klein-9b-base | klein-9b-kv | dev | klein-4b | klein-4b-base.")
     var fluxModel: String = "klein-9b"
@@ -32,7 +32,7 @@ struct Outpaint: AsyncParsableCommand {
     @Option(name: [.short, .long], help: "Input image to extend.")
     var image: String
 
-    @Option(name: [.short, .long], help: "Text prompt describing the full extended scene.")
+    @Option(name: [.short, .long], help: "Text prompt describing the full extended scene. Follow Flux 2 prompting guidelines (https://docs.bfl.ml/guides/prompting_guide_flux2): Subject + Action + Style + Context, 30–80 words, mention the content of the keep region too.")
     var prompt: String
 
     @Option(name: [.short, .long], help: "Output PNG path.")
@@ -53,6 +53,8 @@ struct Outpaint: AsyncParsableCommand {
     var guidance: Float = 1.0
     @Option(name: .long, help: "Random seed.")
     var seed: UInt64?
+    @Flag(name: .long, help: "Rewrite the prompt via the bundled Qwen3.5 VLM before encoding. Useful when --prompt is a short instruction rather than a full descriptive Flux 2 prompt.")
+    var upsamplePrompt: Bool = false
     @Option(name: .long, help: "Width of the soft transition band, in pixels of the keep region. Default 32.")
     var transitionPixels: Int = 32
     @Option(name: .long, help: "Cap on the total working pixel count. Defaults to 4 M; raise if you want larger canvases.")
@@ -63,7 +65,7 @@ struct Outpaint: AsyncParsableCommand {
             FileHandle.standardError.write(Data((msg + "\n").utf8))
         }
 
-        ModelRegistry.customModelsDirectory = URL(fileURLWithPath: modelsDir)
+        configureModelsDirectory(modelsDir)
 
         guard let imageCG = Self.loadCGImage(at: image) else {
             throw ValidationError("Could not decode image at \(image)")
@@ -104,6 +106,7 @@ struct Outpaint: AsyncParsableCommand {
             steps: steps,
             guidance: guidance,
             seed: seed,
+            upsamplePrompt: upsamplePrompt,
             transitionPixels: transitionPixels,
             maxPixels: maxPixels,
             onProgress: { step, total in


### PR DESCRIPTION
## Summary

Wraps up the inpainting overhaul. After #87 / #88 / #89 landed, the moved CLI commands were still calling the pre-#87 chain init — so `--upsample-prompt`, `--use-image-as-reference`, and `--mask-convention` weren't reachable from the shell. This PR finishes that by:

1. **`--upsample-prompt`** on both `flux2 inpaint` and `flux2 outpaint`. Routes to `*.upsamplePrompt`.
2. **`--use-image-as-reference`** on `flux2 inpaint`. Off by default (matches the chain default — see #87 for the rationale; the source-as-ref bleeds X into Y for replacement inpainting).
3. **`--mask-convention {grayscale|alpha}`** on `flux2 inpaint`. Routes to `*.maskConvention`. Local `MaskConventionArg: String, ExpressibleByArgument` enum keeps ArgumentParser deps out of `Flux2Core`.
4. **`--mask` help** now describes both conventions inline so users don't need to grep DocC to discover alpha.
5. **`modelsDir` no longer hardcoded.** Switched to the same `var modelsDir: String?` + `configureModelsDirectory(modelsDir)` pattern the other Flux2CLI commands use — the default falls through to the framework's standard path instead of `/Users/vincent/Pictures/FluxforgeStudio/Models`. Inpaint and Outpaint both updated.
6. **`--prompt` help** now points at BFL's Flux 2 prompting guide on both commands.

## E2E validation

Ran `flux2 inpaint --mask-convention alpha` on the original cat → duck case (same seed 42, same prompt, same mask geometry expressed via alpha rather than a parallel grayscale PNG). Output is visually identical to the grayscale-mask path — confirming the new convention is neutral on quality and the CLI plumbing is correct end-to-end.

| grayscale mask | alpha mask |
|---|---|
| `duck_t2i_only.png` | `duck_alpha.png` |
| 53.2 s | 55.7 s |

Both produce the same well-integrated mallard with a coherent shadow on the concrete. (Tiny timing delta is just per-run variance.)

## Test plan

- [x] `xcodebuild -scheme Flux2CLI -configuration Release build` succeeds
- [x] `xcodebuild test -only-testing:Flux2ChainsTests` — 31/31 pass (no chain code changed)
- [x] `flux2 inpaint --help` shows the new flags + updated `--mask` help
- [x] `flux2 outpaint --help` shows `--upsample-prompt` + updated `--prompt` help
- [x] E2E alpha mask via `flux2 inpaint --mask-convention alpha` produces a visually equivalent result to the grayscale path

🤖 Generated with [Claude Code](https://claude.com/claude-code)