### PR TITLE
feat(pipeline): kleinEncoderPath override for alternate Qwen3 encoders

### DIFF
--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
@@ -112,6 +112,16 @@ public class Flux2Pipeline: @unchecked Sendable {
     /// Klein text encoder (Qwen3 - for Klein 4B/9B)
     private var kleinEncoder: KleinTextEncoder?
 
+    /// Optional override for the Klein text encoder (Qwen3) directory.
+    /// When non-nil, `loadTextEncoder()` loads weights + tokenizer from
+    /// this path instead of resolving and downloading the curated Qwen3
+    /// variant. Lets hosting apps swap in alternate Qwen3 builds
+    /// (abliterated, fine-tuned, different quantisation, …) without
+    /// forking the package. See `docs/TextEncoders.md` for the expected
+    /// directory layout and dimension constraints. Has no effect when
+    /// `model == .dev` (which uses the Mistral encoder).
+    private let kleinEncoderPath: URL?
+
     /// Diffusion transformer
     private var transformer: Flux2Transformer2DModel?
 
@@ -145,23 +155,28 @@ public class Flux2Pipeline: @unchecked Sendable {
     /// Clear cache every N denoising steps (0 = disabled)
     public var clearCacheEveryNSteps: Int = 5
 
-    /// Initialize pipeline
-    /// - Parameters:
-    ///   - model: Model variant to use (default: .dev)
-    ///   - quantization: Quantization settings for each component
-    ///   - hfToken: HuggingFace token for gated models
     /// Initialize the Flux.2 pipeline
     /// - Parameters:
     ///   - model: Model variant (dev, klein-4b, klein-9b)
     ///   - quantization: Quantization configuration
     ///   - memoryOptimization: Memory optimization settings (nil = auto-detect based on system RAM)
+    ///   - vaeVariant: VAE decoder variant (standard or small-decoder)
     ///   - hfToken: HuggingFace token for model downloads
+    ///   - kleinEncoderPath: Optional local directory containing a Qwen3
+    ///     text encoder (`config.json`, `tokenizer.json`, `*.safetensors`).
+    ///     When set, the Klein text encoder loads from this path instead
+    ///     of resolving and downloading the curated Qwen3 variant. The
+    ///     architecture must match the target Klein variant (Qwen3-4B for
+    ///     Klein 4B, Qwen3-8B for Klein 9B). See `docs/TextEncoders.md`
+    ///     for the directory layout and a list of compatible builds. Has
+    ///     no effect when `model == .dev` (which uses the Mistral encoder).
     public init(
         model: Flux2Model = .dev,
         quantization: Flux2QuantizationConfig = .balanced,
         memoryOptimization: MemoryOptimizationConfig? = nil,
         vaeVariant: ModelRegistry.VAEVariant = .smallDecoder,
-        hfToken: String? = nil
+        hfToken: String? = nil,
+        kleinEncoderPath: URL? = nil
     ) {
         self.model = model
         self.quantization = quantization
@@ -171,6 +186,7 @@ public class Flux2Pipeline: @unchecked Sendable {
         )
         self.scheduler = FlowMatchEulerScheduler()
         self.downloader = hfToken != nil ? Flux2ModelDownloader(hfToken: hfToken) : Flux2ModelDownloader()
+        self.kleinEncoderPath = kleinEncoderPath
     }
 
     // MARK: - Model Loading
@@ -257,11 +273,11 @@ public class Flux2Pipeline: @unchecked Sendable {
 
         case .klein4B, .klein4BBase:
             kleinEncoder = KleinTextEncoder(variant: .klein4B, quantization: mistralQuant)
-            try await kleinEncoder!.load()
+            try await kleinEncoder!.load(from: kleinEncoderPath)
 
         case .klein9B, .klein9BBase, .klein9BKV:
             kleinEncoder = KleinTextEncoder(variant: .klein9B, quantization: mistralQuant)
-            try await kleinEncoder!.load()
+            try await kleinEncoder!.load(from: kleinEncoderPath)
         }
 
         memoryManager.logMemoryState()
@@ -951,7 +967,7 @@ public class Flux2Pipeline: @unchecked Sendable {
 
                     // Step 5: Reload Qwen3 for text encoding
                     Flux2Debug.log("Reloading Qwen3 for Klein text encoding...")
-                    try await kleinEncoder!.load()
+                    try await kleinEncoder!.load(from: kleinEncoderPath)
 
                     profiler.end("1b. VLM Interpretation")
                 }
@@ -1006,7 +1022,7 @@ public class Flux2Pipeline: @unchecked Sendable {
 
                     // Step 5: Reload Qwen3 for text encoding
                     Flux2Debug.log("Reloading Qwen3 for Klein text encoding...")
-                    try await kleinEncoder!.load()
+                    try await kleinEncoder!.load(from: kleinEncoderPath)
 
                     // Step 6: Encode with Qwen3 (already upsampled, so upsample=false)
                     textEmbeddings = try kleinEncoder!.encode(enhancedPrompt, upsample: false)

--- a/docs/TextEncoders.md
+++ b/docs/TextEncoders.md
@@ -120,6 +120,79 @@ FluxEncodersCLI models --download qwen3-4b-8bit
 | Qwen3 8B | 8-bit | ~8GB | 12GB |
 | Qwen3 8B | 4-bit | ~4GB | 8GB |
 
+### Swapping in an alternate Qwen3 encoder (Klein only)
+
+`Flux2Pipeline.init(...)` accepts an optional `kleinEncoderPath: URL?`
+that bypasses the curated Hub variant and loads the Klein text encoder
+from a local directory instead. This is the supported way to plug in:
+
+- **Abliterated / uncensored** Qwen3 builds (e.g.
+  [`ponpoke/flux2-klein-9b-uncensored-text-encoder`](https://huggingface.co/ponpoke/flux2-klein-9b-uncensored-text-encoder))
+  so refusal directions in the curated encoder stop distorting prompts
+  the base transformer is otherwise willing to render.
+- **Fine-tuned** Qwen3 variants (style-conditioned, language-tuned, …).
+- **Different quantisations** of the same architecture (8-bit / 4-bit /
+  bf16) without waiting for an upstream addition to `Qwen3Variant`.
+
+```swift
+let encoderDir = URL(fileURLWithPath: "/path/to/qwen3-encoder")
+
+let pipeline = Flux2Pipeline(
+    model: .klein9B,
+    quantization: .balanced,
+    kleinEncoderPath: encoderDir
+)
+try await pipeline.loadModels()  // ← uses encoderDir, no Hub fetch
+```
+
+#### Directory layout
+
+The path must point at a directory containing the standard
+HuggingFace-style layout that `FluxTextEncoders.loadKleinModel(variant:from:)`
+expects:
+
+```
+/path/to/qwen3-encoder/
+├── config.json           # Qwen3 architecture config
+├── tokenizer.json        # Qwen3 tokenizer
+└── model.safetensors     # weights (single-file or sharded *.safetensors)
+```
+
+Sharded safetensors with an `index.json` are also supported.
+
+#### Architecture constraints
+
+The override must match the **target Klein variant**'s expected
+architecture exactly. The framework reads whichever precision the
+safetensors carry, but it doesn't auto-detect dimension mismatches —
+loading the wrong arch will fail at decode time with a confusing error.
+
+| Klein variant | Required Qwen3 architecture | Output dimension |
+|---|---|---|
+| `.klein4B` / `.klein4BBase` | Qwen3-4B (3 × 2560 hidden) | 7,680 |
+| `.klein9B` / `.klein9BBase` / `.klein9BKV` | Qwen3-8B (3 × 4096 hidden) | 12,288 |
+
+The hidden-state layers extracted are `[9, 18, 27]` for both — this is
+fixed in `KleinTextEncoder` and won't follow a fine-tune that expects a
+different layer triplet.
+
+#### What happens when the path is nil
+
+The default (`kleinEncoderPath: nil`) keeps the existing auto-download
+behavior: the framework picks a curated `Qwen3Variant` based on
+`(kleinVariant, quantization)`, reuses any already-downloaded variant,
+or falls back to Hub download. No behavior change for existing callers.
+
+#### What it does NOT do
+
+- It has **no effect on Dev** (`model == .dev`) — Dev uses the Mistral
+  encoder via `Flux2TextEncoder`, which has its own loader.
+- It doesn't validate the encoder before loading; an incompatible build
+  fails at the first forward pass, not at `Flux2Pipeline.init`.
+- It doesn't change the embedding layer indices, max sequence length, or
+  any other Klein-specific extraction logic — only the source of the
+  Qwen3 weights changes.
+
 ## Performance Benchmarks
 
 Performance comparison between Swift MLX and Python MLX on Apple Silicon.


### PR DESCRIPTION
## Summary

Picks up @jrmiller1286's draft PR #86 and lands the feature with three small additions:

1. **All four call sites updated, not just two.** The PR as filed touched `loadTextEncoder()` (correct) but missed two more `kleinEncoder!.load()` invocations inside the Mistral-VLM interpret reload paths (lines ~970 and ~1025 of `Flux2Pipeline.swift`). On a custom path, those would have silently fallen back to the curated variant after a VLM interpret step. Same one-line fix applied consistently.

2. **API decisions baked in.** In response to the open questions in #86:
   - Kept `kleinEncoderPath` as the name (matches the existing `kleinEncoder` property, concise).
   - Kept flat init parameter — no `Flux2EncoderConfig` struct yet. Single-field configs are premature abstraction; revisit when we have a second encoder knob to bundle.
   - Placed at the end of the init, defaulted to `nil` — fully back-compat.

3. **Docs.** New `docs/TextEncoders.md` section ("Swapping in an alternate Qwen3 encoder") walks through:
   - Expected directory layout (`config.json` + `tokenizer.json` + `*.safetensors`, sharded `index.json` also supported).
   - Dimension constraints per Klein variant.
   - Concrete Hub references — including [`ponpoke/flux2-klein-9b-uncensored-text-encoder`](https://huggingface.co/ponpoke/flux2-klein-9b-uncensored-text-encoder), the abliterated build that motivated the original contribution.
   - Explicit no-op-on-Dev guarantee.
   - Limitations (no dimension validation at init, fixed extraction layers `[9, 18, 27]`).

## Usage

```swift
let encoderDir = URL(fileURLWithPath: "/path/to/qwen3-encoder")

let pipeline = Flux2Pipeline(
    model: .klein9B,
    quantization: .balanced,
    kleinEncoderPath: encoderDir  // ← bypasses curated Hub variant
)
try await pipeline.loadModels()
```

## Test plan

- [x] `xcodebuild -scheme Flux2Swift-Package build` succeeds
- [x] `xcodebuild test -only-testing:Flux2ChainsTests` — 31/31 pass
- [x] `xcodebuild test -only-testing:Flux2CoreTests` — green except for the one pre-existing `PipelineVAEVariantTests.testPipelineDefaultVAEVariant` failure (documented in `project_flux2_chains.md` known-issues, unrelated to this PR)

No new tests added — there are no in-tree fixtures for a Qwen3 encoder directory, and the change is a pure parameter passthrough. Adding a fixture (config.json + tokenizer.json + small safetensors stub) is non-trivial and out of scope.

## Credit

Co-authored with Ryan @jrmiller1286 — PR #86 will be closed pointing here. The contribution shape was good; this PR fills in the missing reload-path call sites and adds the docs the use case needs to be discoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)