### PR TITLE
fix(pipeline): defer CoreGraphics draws to Default-QoS worker (priority inversion)

### DIFF
--- a/Sources/Flux2Chains/Flux2MaskedInpaintingChain.swift
+++ b/Sources/Flux2Chains/Flux2MaskedInpaintingChain.swift
@@ -210,7 +210,7 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
             targetWidth: targetW
         )
 
-        let maskLatents = Flux2Pipeline.packMaskForLatentBlending(
+        let maskLatents = await Flux2Pipeline.packMaskForLatentBlending(
             mask,
             targetHeight: targetH,
             targetWidth: targetW,

--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline+ChainHelpers.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline+ChainHelpers.swift
@@ -83,7 +83,7 @@ extension Flux2Pipeline {
             throw Flux2Error.modelNotLoaded("VAE")
         }
 
-        let preprocessed = preprocessImageForVAEPublic(
+        let preprocessed = await preprocessImageForVAEPublic(
             image,
             targetHeight: targetHeight,
             targetWidth: targetWidth
@@ -150,69 +150,88 @@ extension Flux2Pipeline {
         targetHeight: Int,
         targetWidth: Int,
         convention: Flux2MaskConvention = .grayscaleWhiteInpaint
-    ) -> MLXArray {
+    ) async -> MLXArray {
         let latentH = targetHeight / 16
         let latentW = targetWidth / 16
         switch convention {
         case .grayscaleWhiteInpaint:
-            return packGrayscaleMask(mask, latentH: latentH, latentW: latentW)
+            return await packGrayscaleMask(mask, latentH: latentH, latentW: latentW)
         case .alphaTransparentInpaint:
-            return packAlphaMask(mask, latentH: latentH, latentW: latentW)
+            return await packAlphaMask(mask, latentH: latentH, latentW: latentW)
         }
     }
 
     private static func packGrayscaleMask(
         _ mask: CGImage, latentH: Int, latentW: Int
-    ) -> MLXArray {
-        var pixels = [UInt8](repeating: 0, count: latentH * latentW)
-        let colorSpace = CGColorSpaceCreateDeviceGray()
-        guard let context = CGContext(
-            data: &pixels,
-            width: latentW,
-            height: latentH,
-            bitsPerComponent: 8,
-            bytesPerRow: latentW,
-            space: colorSpace,
-            bitmapInfo: CGImageAlphaInfo.none.rawValue
-        ) else {
-            return MLXArray.zeros([1, latentH * latentW, 1])
+    ) async -> MLXArray {
+        let count = latentH * latentW
+        // The CGContext keeps a raw pointer into `pixels`; capturing it by
+        // value into a Sendable closure isn't possible. The work item runs
+        // synchronously inside the continuation and the await blocks until
+        // it completes, so `UnsafeMutableBufferPointer` ownership stays
+        // local — safe under the explicit happens-before.
+        let floats: [Float] = await Self.runAtDefaultQoS {
+            let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: count)
+            buf.initialize(repeating: 0, count: count)
+            defer {
+                buf.deinitialize(count: count)
+                buf.deallocate()
+            }
+            let colorSpace = CGColorSpaceCreateDeviceGray()
+            guard let context = CGContext(
+                data: buf,
+                width: latentW,
+                height: latentH,
+                bitsPerComponent: 8,
+                bytesPerRow: latentW,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.none.rawValue
+            ) else {
+                return [Float](repeating: 0, count: count)
+            }
+            context.interpolationQuality = .high
+            context.draw(mask, in: CGRect(x: 0, y: 0, width: latentW, height: latentH))
+            return (0..<count).map { Float(buf[$0]) / 255.0 }
         }
-        context.interpolationQuality = .high
-        context.draw(mask, in: CGRect(x: 0, y: 0, width: latentW, height: latentH))
-        let floats = pixels.map { Float($0) / 255.0 }
-        return MLXArray(floats).reshaped([1, latentH * latentW, 1])
+        return MLXArray(floats).reshaped([1, count, 1])
     }
 
     private static func packAlphaMask(
         _ mask: CGImage, latentH: Int, latentW: Int
-    ) -> MLXArray {
+    ) async -> MLXArray {
         // We need the alpha channel only. Rendering into a premultipliedLast
         // RGBA8 context with the colourspace fully neutral and then sampling
         // byte index 3 gives the unmolested alpha value (premultiplication
         // doesn't apply when src alpha is reconstructed from byte 3, since
         // the destination starts cleared and we only read the alpha plane).
-        let rgbaCount = latentH * latentW * 4
-        var pixels = [UInt8](repeating: 0, count: rgbaCount)
-        let colorSpace = CGColorSpaceCreateDeviceRGB()
-        guard let context = CGContext(
-            data: &pixels,
-            width: latentW,
-            height: latentH,
-            bitsPerComponent: 8,
-            bytesPerRow: latentW * 4,
-            space: colorSpace,
-            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-        ) else {
-            return MLXArray.zeros([1, latentH * latentW, 1])
+        let count = latentH * latentW
+        let rgbaCount = count * 4
+        let floats: [Float] = await Self.runAtDefaultQoS {
+            let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: rgbaCount)
+            buf.initialize(repeating: 0, count: rgbaCount)
+            defer {
+                buf.deinitialize(count: rgbaCount)
+                buf.deallocate()
+            }
+            let colorSpace = CGColorSpaceCreateDeviceRGB()
+            guard let context = CGContext(
+                data: buf,
+                width: latentW,
+                height: latentH,
+                bitsPerComponent: 8,
+                bytesPerRow: latentW * 4,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            ) else {
+                return [Float](repeating: 0, count: count)
+            }
+            context.interpolationQuality = .high
+            context.draw(mask, in: CGRect(x: 0, y: 0, width: latentW, height: latentH))
+            // Invert: alpha=0 (transparent) → 1.0 (inpaint); alpha=255 → 0.0 (keep).
+            return (0..<count).map { i in
+                1.0 - Float(buf[i * 4 + 3]) / 255.0
+            }
         }
-        context.interpolationQuality = .high
-        context.draw(mask, in: CGRect(x: 0, y: 0, width: latentW, height: latentH))
-        // Invert: alpha=0 (transparent) → 1.0 (inpaint); alpha=255 → 0.0 (keep).
-        var floats = [Float](repeating: 0, count: latentH * latentW)
-        for i in 0..<(latentH * latentW) {
-            let a = pixels[i * 4 + 3]
-            floats[i] = 1.0 - Float(a) / 255.0
-        }
-        return MLXArray(floats).reshaped([1, latentH * latentW, 1])
+        return MLXArray(floats).reshaped([1, count, 1])
     }
 }

--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
@@ -204,8 +204,39 @@ public class Flux2Pipeline: @unchecked Sendable {
         _ image: CGImage,
         targetHeight: Int,
         targetWidth: Int
-    ) -> MLXArray {
-        preprocessImageForVAE(image, targetHeight: targetHeight, targetWidth: targetWidth)
+    ) async -> MLXArray {
+        await preprocessImageForVAE(image, targetHeight: targetHeight, targetWidth: targetWidth)
+    }
+
+    /// Run a synchronous CPU block on a Default-QoS Dispatch worker,
+    /// regardless of the calling task's QoS.
+    ///
+    /// CoreGraphics rasterisation calls (`CGContext.draw(_:in:)` with
+    /// `interpolationQuality = .high`) dispatch their internal workers at
+    /// `.default` QoS. Calling them from a cooperative thread that
+    /// inherits a higher QoS (e.g. User-Initiated via MainActor button
+    /// click → `await chain.run()`) triggers the runtime priority-inversion
+    /// warning *"Thread running at User-initiated quality-of-service class
+    /// waiting on a lower QoS thread"* even though the work is correct
+    /// and the system silently elevates the worker via priority
+    /// inheritance.
+    ///
+    /// The fix has two pieces:
+    /// 1. `withCheckedContinuation` makes the cooperative thread *suspend*
+    ///    instead of *block* — no blocking thread means no inversion check.
+    /// 2. `DispatchWorkItem(qos: .default, flags: [.enforceQoS])` prevents
+    ///    Dispatch from elevating the worker's QoS to match the caller,
+    ///    so CG sees a Default-QoS caller and its internal workers stay at
+    ///    Default — symmetric, no inversion at the CG level either.
+    static func runAtDefaultQoS<T: Sendable>(
+        _ body: @Sendable @escaping () -> T
+    ) async -> T {
+        await withCheckedContinuation { (continuation: CheckedContinuation<T, Never>) in
+            let workItem = DispatchWorkItem(qos: .default, flags: [.enforceQoS]) {
+                continuation.resume(returning: body())
+            }
+            DispatchQueue.global(qos: .default).async(execute: workItem)
+        }
     }
 
     /// Load all required models
@@ -1111,7 +1142,7 @@ public class Flux2Pipeline: @unchecked Sendable {
             Flux2Debug.log("Generated output noise latents: \(patchifiedLatents.shape)")
 
             // Encode ALL reference images
-            let (referenceLatents, referencePositionIds) = try encodeReferenceImages(
+            let (referenceLatents, referencePositionIds) = try await encodeReferenceImages(
                 images,
                 height: validHeight,
                 width: validWidth
@@ -1711,7 +1742,7 @@ public class Flux2Pipeline: @unchecked Sendable {
         _ images: [CGImage],
         height: Int,
         width: Int
-    ) throws -> (latents: MLXArray, positionIds: MLXArray) {
+    ) async throws -> (latents: MLXArray, positionIds: MLXArray) {
         guard let vae = vae else {
             throw Flux2Error.modelNotLoaded("VAE")
         }
@@ -1757,7 +1788,7 @@ public class Flux2Pipeline: @unchecked Sendable {
             Flux2Debug.log("  -> Resized to \(targetWidth)x\(targetHeight)")
 
             // Preprocess and encode
-            let processed = preprocessImageForVAE(image, targetHeight: targetHeight, targetWidth: targetWidth)
+            let processed = await preprocessImageForVAE(image, targetHeight: targetHeight, targetWidth: targetWidth)
 
             // Encode with VAE -> [1, 32, H/8, W/8]
             // IMPORTANT: Use samplePosterior=false to get deterministic mean (like diffusers argmax)
@@ -1827,7 +1858,7 @@ public class Flux2Pipeline: @unchecked Sendable {
     /// preserve exact pixel values without format conversion or anti-aliasing artifacts.
     /// When a resize is needed, uses CGContext with high-quality interpolation, then
     /// reads from the resized image's dataProvider.
-    private func preprocessImageForVAE(_ image: CGImage, targetHeight: Int, targetWidth: Int) -> MLXArray {
+    private func preprocessImageForVAE(_ image: CGImage, targetHeight: Int, targetWidth: Int) async -> MLXArray {
         let sourceWidth = image.width
         let sourceHeight = image.height
 
@@ -1836,28 +1867,43 @@ public class Flux2Pipeline: @unchecked Sendable {
         if sourceWidth != targetWidth || sourceHeight != targetHeight {
             Flux2Debug.log("Resizing image from \(sourceWidth)x\(sourceHeight) to \(targetWidth)x\(targetHeight)")
 
+            // Pixel buffer is captured by the Default-QoS work item below; the
+            // CGContext keeps a pointer into it, so the buffer (and any backing
+            // storage) must outlive the draw. The continuation handshake
+            // guarantees the await returns only after the work completes, so
+            // capturing pixelData by reference via UnsafeMutablePointer is safe.
             let bytesPerPixel = 4
             let bytesPerRow = bytesPerPixel * targetWidth
-            var pixelData = [UInt8](repeating: 0, count: targetHeight * bytesPerRow)
+            let pixelCount = targetHeight * bytesPerRow
 
-            guard let context = CGContext(
-                data: &pixelData,
-                width: targetWidth,
-                height: targetHeight,
-                bitsPerComponent: 8,
-                bytesPerRow: bytesPerRow,
-                space: CGColorSpaceCreateDeviceRGB(),
-                bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue
-            ) else {
-                Flux2Debug.log("Failed to create resize context")
-                return MLXRandom.normal([1, 3, targetHeight, targetWidth])
+            let resized: CGImage? = await Self.runAtDefaultQoS {
+                let pixelData = UnsafeMutablePointer<UInt8>.allocate(capacity: pixelCount)
+                pixelData.initialize(repeating: 0, count: pixelCount)
+                defer {
+                    pixelData.deinitialize(count: pixelCount)
+                    pixelData.deallocate()
+                }
+
+                guard let context = CGContext(
+                    data: pixelData,
+                    width: targetWidth,
+                    height: targetHeight,
+                    bitsPerComponent: 8,
+                    bytesPerRow: bytesPerRow,
+                    space: CGColorSpaceCreateDeviceRGB(),
+                    bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue
+                ) else {
+                    return nil
+                }
+
+                // High quality interpolation
+                context.interpolationQuality = .high
+                context.draw(image, in: CGRect(x: 0, y: 0, width: targetWidth, height: targetHeight))
+
+                return context.makeImage()
             }
 
-            // High quality interpolation
-            context.interpolationQuality = .high
-            context.draw(image, in: CGRect(x: 0, y: 0, width: targetWidth, height: targetHeight))
-
-            guard let resized = context.makeImage() else {
+            guard let resized else {
                 Flux2Debug.log("Failed to create resized image")
                 return MLXRandom.normal([1, 3, targetHeight, targetWidth])
             }

--- a/Tests/Flux2ChainsTests/Flux2ChainsTests.swift
+++ b/Tests/Flux2ChainsTests/Flux2ChainsTests.swift
@@ -45,16 +45,16 @@ final class Flux2ChainHelpersTests: XCTestCase {
 
     // MARK: - Mask packing
 
-    func testPackMaskHasExpectedSequenceShape() {
+    func testPackMaskHasExpectedSequenceShape() async {
         // 512×512 image → 32×32 latent grid → 1024 tokens.
         let mask = makeUniformMask(width: 512, height: 512, value: 1.0)
-        let packed = Flux2Pipeline.packMaskForLatentBlending(mask, targetHeight: 512, targetWidth: 512)
+        let packed = await Flux2Pipeline.packMaskForLatentBlending(mask, targetHeight: 512, targetWidth: 512)
         XCTAssertEqual(packed.shape, [1, 1024, 1])
     }
 
-    func testPackMaskAllWhiteYieldsOnes() {
+    func testPackMaskAllWhiteYieldsOnes() async {
         let mask = makeUniformMask(width: 128, height: 128, value: 1.0)
-        let packed = Flux2Pipeline.packMaskForLatentBlending(mask, targetHeight: 128, targetWidth: 128)
+        let packed = await Flux2Pipeline.packMaskForLatentBlending(mask, targetHeight: 128, targetWidth: 128)
         // 128/16 = 8 → 64 tokens
         XCTAssertEqual(packed.shape, [1, 64, 1])
         // Sum should equal token count.
@@ -62,19 +62,19 @@ final class Flux2ChainHelpersTests: XCTestCase {
         XCTAssertEqual(total, 64.0, accuracy: 0.5)
     }
 
-    func testPackMaskAllBlackYieldsZeros() {
+    func testPackMaskAllBlackYieldsZeros() async {
         let mask = makeUniformMask(width: 128, height: 128, value: 0.0)
-        let packed = Flux2Pipeline.packMaskForLatentBlending(mask, targetHeight: 128, targetWidth: 128)
+        let packed = await Flux2Pipeline.packMaskForLatentBlending(mask, targetHeight: 128, targetWidth: 128)
         let total = packed.sum().item(Float.self)
         XCTAssertEqual(total, 0.0, accuracy: 0.5)
     }
 
     // MARK: - Mask packing (alpha convention)
 
-    func testAlphaMaskFullyTransparentYieldsOnes() {
+    func testAlphaMaskFullyTransparentYieldsOnes() async {
         // Fully transparent input ⇒ everything should be inpainted (mask = 1).
         let mask = makeUniformAlphaMask(width: 128, height: 128, alpha: 0)
-        let packed = Flux2Pipeline.packMaskForLatentBlending(
+        let packed = await Flux2Pipeline.packMaskForLatentBlending(
             mask, targetHeight: 128, targetWidth: 128,
             convention: .alphaTransparentInpaint
         )
@@ -83,10 +83,10 @@ final class Flux2ChainHelpersTests: XCTestCase {
                        "alpha=0 ⇒ inpaint=1.0 across all 64 tokens")
     }
 
-    func testAlphaMaskFullyOpaqueYieldsZeros() {
+    func testAlphaMaskFullyOpaqueYieldsZeros() async {
         // Fully opaque input ⇒ nothing inpainted (mask = 0 everywhere).
         let mask = makeUniformAlphaMask(width: 128, height: 128, alpha: 255)
-        let packed = Flux2Pipeline.packMaskForLatentBlending(
+        let packed = await Flux2Pipeline.packMaskForLatentBlending(
             mask, targetHeight: 128, targetWidth: 128,
             convention: .alphaTransparentInpaint
         )
@@ -95,10 +95,10 @@ final class Flux2ChainHelpersTests: XCTestCase {
                        "alpha=255 ⇒ keep=0.0 across all tokens")
     }
 
-    func testAlphaMaskSoftValueIsPreserved() {
+    func testAlphaMaskSoftValueIsPreserved() async {
         // alpha=128 ⇒ ~0.5 soft mask.
         let mask = makeUniformAlphaMask(width: 128, height: 128, alpha: 128)
-        let packed = Flux2Pipeline.packMaskForLatentBlending(
+        let packed = await Flux2Pipeline.packMaskForLatentBlending(
             mask, targetHeight: 128, targetWidth: 128,
             convention: .alphaTransparentInpaint
         )
@@ -107,15 +107,15 @@ final class Flux2ChainHelpersTests: XCTestCase {
         XCTAssertEqual(total, 64.0 * (1.0 - 128.0 / 255.0), accuracy: 1.0)
     }
 
-    func testAlphaMaskIgnoresRGBContent() {
+    func testAlphaMaskIgnoresRGBContent() async {
         // Two masks with identical alpha but wildly different RGB must
         // produce identical packed mask arrays.
         let m0 = makeAlphaMask(width: 128, height: 128, alpha: 0, rgb: (0, 0, 0))
         let m1 = makeAlphaMask(width: 128, height: 128, alpha: 0, rgb: (255, 0, 255))
-        let p0 = Flux2Pipeline.packMaskForLatentBlending(
+        let p0 = await Flux2Pipeline.packMaskForLatentBlending(
             m0, targetHeight: 128, targetWidth: 128, convention: .alphaTransparentInpaint
         )
-        let p1 = Flux2Pipeline.packMaskForLatentBlending(
+        let p1 = await Flux2Pipeline.packMaskForLatentBlending(
             m1, targetHeight: 128, targetWidth: 128, convention: .alphaTransparentInpaint
         )
         XCTAssertEqual(p0.sum().item(Float.self), p1.sum().item(Float.self),


### PR DESCRIPTION
## Summary

Closes a runtime priority-inversion warning host apps see when they call into the inpainting chain from a User-Initiated cooperative thread (e.g. a MainActor button → `await chain.run()`):

```
Thread running at User-initiated quality-of-service class waiting on
a lower QoS thread running at Default quality-of-service class.
Investigate ways to avoid priority inversions
```

Reported by FluxForge Studio's host-side analysis.

## Root cause

Three `CGContext.draw(_:in:)` calls with `interpolationQuality = .high` were running directly on the cooperative thread:

- `Flux2Pipeline.preprocessImageForVAE` (source-image resize before VAE encoding)
- `packGrayscaleMask` and `packAlphaMask` (mask packing to latent resolution for the RePaint blend)

CoreGraphics dispatches its internal workers at Default QoS regardless of caller. When the cooperative thread is at User-Initiated (inherited from a MainActor call site), it ends up blocking on those Default workers → priority inversion → OS runtime warning.

## Fix

A new `Flux2Pipeline.runAtDefaultQoS<T>(_:)` helper combines two pieces that together undo the inversion:

```swift
static func runAtDefaultQoS<T: Sendable>(
    _ body: @Sendable @escaping () -> T
) async -> T {
    await withCheckedContinuation { continuation in
        let workItem = DispatchWorkItem(qos: .default, flags: [.enforceQoS]) {
            continuation.resume(returning: body())
        }
        DispatchQueue.global(qos: .default).async(execute: workItem)
    }
}
```

1. **`withCheckedContinuation`** makes the cooperative thread *suspend* instead of *block* — no blocking thread, no inversion check fires.
2. **`.enforceQoS`** prevents Dispatch from boosting the worker QoS back up to match the caller, so CG sees a Default-QoS caller and its internal workers stay at Default — symmetric, no inversion at the CG level either.

Three call sites switched to it (the two mask packers + the VAE preprocess resize). The chain helpers and pipeline methods that wrap them become async; the chain caller (`Flux2MaskedInpaintingChain.run`) was already async, and the 8 unit-test call sites get `async` / `await` annotations.

## Notable side change

The CG bitmap backing buffers switch from stack-allocated `[UInt8]` (captured by reference via `&pixels` into `CGContext.init(data:…)`) to manually-managed `UnsafeMutablePointer<UInt8>`. The buffer has to outlive the CGContext for the duration of `context.draw`, and crossing the dispatched-closure boundary requires explicit ownership — `&pixels` on a local array doesn't survive.

The `defer { deinitialize + deallocate }` inside each closure keeps lifetimes tight; no leak.

## API change

Public + internal API made async:
- `Flux2Pipeline.packMaskForLatentBlending(_:targetHeight:targetWidth:convention:)` — was sync, now `async`
- `Flux2Pipeline.preprocessImageForVAEPublic(_:targetHeight:targetWidth:)` — was sync, now `async`

Both are documented as chain-helpers; the chain caller is already async, and the host app (which doesn't call these directly) is unaffected.

## Test plan

- [x] `xcodebuild -scheme Flux2Swift-Package build` succeeds
- [x] `xcodebuild test -only-testing:Flux2ChainsTests` — 31/31 pass
- [x] Functional E2E: `flux2 inpaint` on the cat → duck case produces a pixel-identical result to the pre-fix output, same seed 42, same prompt, klein-9b distilled, 4 steps
- [ ] **Runtime verification of the warning disappearing requires a host running from a User-Initiated context** (e.g. FluxForge Studio MainActor button). The CLI runs at Default QoS so it never triggered the inversion in the first place and can't confirm the fix. Will be validated by @VincentGourbin against FluxForge Studio's actual reproducer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)