### PR TITLE
feat(chains): VLM-aware prompt enrichment + Vision-based subject mask

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,6 +52,7 @@ let package = Package(
             name: "Flux2Chains",
             dependencies: [
                 "Flux2Core",
+                "FluxTextEncoders",  // Qwen3.5 VLM service for opt-in prompt enrichment
                 .product(name: "MLX", package: "mlx-swift"),
                 .product(name: "MLXRandom", package: "mlx-swift"),
             ]

--- a/Sources/Flux2CLI/Flux2CLI.swift
+++ b/Sources/Flux2CLI/Flux2CLI.swift
@@ -28,6 +28,7 @@ struct Flux2CLI: AsyncParsableCommand {
             ImageToImage.self,
             Inpaint.self,
             Outpaint.self,
+            MaskSubject.self,
             Download.self,
             Info.self,
             Profile.self,

--- a/Sources/Flux2CLI/InpaintCommand.swift
+++ b/Sources/Flux2CLI/InpaintCommand.swift
@@ -13,6 +13,7 @@ import ImageIO
 import UniformTypeIdentifiers
 import Flux2Core
 import Flux2Chains
+import FluxTextEncoders
 
 /// User-facing string mapping for ``Flux2MaskConvention``.
 ///
@@ -27,6 +28,26 @@ enum MaskConventionArg: String, ExpressibleByArgument, CaseIterable {
         switch self {
         case .grayscale: return .grayscaleWhiteInpaint
         case .alpha:     return .alphaTransparentInpaint
+        }
+    }
+}
+
+/// User-facing string mapping for ``Flux2InpaintIntent``.
+///
+/// Kept local to the CLI so the framework enum stays free of
+/// ArgumentParser dependencies. Same identifiers as the enum cases.
+enum InpaintIntentArg: String, ExpressibleByArgument, CaseIterable {
+    case replace
+    case remove
+    case modify
+    case changeScene = "change-scene"
+
+    var intent: Flux2InpaintIntent {
+        switch self {
+        case .replace:     return .replace
+        case .remove:      return .remove
+        case .modify:      return .modify
+        case .changeScene: return .changeScene
         }
     }
 }
@@ -64,8 +85,20 @@ struct Inpaint: AsyncParsableCommand {
     @Flag(name: .long, help: "Auto-feed the source image as I2I conditioning when --reference is not set. OFF by default — for 'replace object X with object Y' inpainting, the source still contains X under the mask and bleeds X into Y via attention. Enable for repair / scene-extension where the masked region is empty.")
     var useImageAsReference: Bool = false
 
-    @Flag(name: .long, help: "Rewrite the prompt via the bundled Qwen3.5 VLM before encoding. Useful when --prompt is a short edit instruction rather than a full descriptive Flux 2 prompt. Adds one extra VLM forward pass.")
+    @Flag(name: .long, help: "Text-encoder-only prompt rewriting (Mistral/Klein-Qwen3). Does NOT look at the image. For image-aware rewriting that inherits the source's lighting/camera/materials, use --enrich-prompt-with-vlm instead.")
     var upsamplePrompt: Bool = false
+
+    @Flag(name: .long, help: "Image-aware prompt rewriting via the bundled Qwen3.5 VLM. The VLM looks at --image and rewrites --prompt into a 30-80 word BFL-style Flux 2 prompt that inherits the source's photographic identity (camera angle, lighting direction, materials, palette, depth of field). Strictly optional: if the VLM is not loaded, the chain falls back to --prompt verbatim with a warning. Note: this CLI does NOT auto-load the VLM; load it ahead of time via FluxEncodersCLI or the test-qwen35 command. When both --upsample-prompt and --enrich-prompt-with-vlm are set, the VLM wins.")
+    var enrichPromptWithVLM: Bool = false
+
+    @Option(name: .long, help: "Drives --enrich-prompt-with-vlm (ignored otherwise). 'replace' = swap object X for Y (default). 'remove' = clear object X, surface continues. 'modify' = keep object X but change colour/outfit/expression. 'change-scene' = keep subject exactly as-is, change the scene around it (use this when the mask preserves the subject — e.g. 'put the cat at the pool').")
+    var intent: InpaintIntentArg = .replace
+
+    @Option(name: .long, help: "Qwen3.5 VLM variant to load in-process when --enrich-prompt-with-vlm is set: '8bit' (default, 5 GB, recommended) or '4bit' (3 GB, faster but lower quality). Auto-downloads if missing. Omit to skip loading — the chain will then fall back to --prompt verbatim and emit a warning.")
+    var qwen35Variant: String?
+
+    @Option(name: .long, help: "Override the local path to Qwen3.5 VLM weights (alternative to --qwen35-variant for sandboxed apps).")
+    var qwen35Path: String?
 
     @Option(name: .long, help: "Denoising steps for FLUX.2 (4 for distilled klein, 25-28 for base/dev).")
     var steps: Int = 4
@@ -105,6 +138,38 @@ struct Inpaint: AsyncParsableCommand {
             throw ValidationError("Unsupported --flux-model '\(fluxModel)'.")
         }
 
+        // Optional Qwen3.5 VLM load — only relevant when the user opts
+        // into --enrich-prompt-with-vlm. The chain itself doesn't
+        // auto-load; we do it here at the CLI level so a single
+        // invocation is enough to benchmark the VLM-enriched path.
+        if enrichPromptWithVLM {
+            // Surface the VLM-built prompt via FluxDebug.info so the
+            // user can audit what FLUX.2 actually receives.
+            FluxDebug.isEnabled = true
+            if qwen35Variant == nil, qwen35Path == nil {
+                logErr("WARNING: --enrich-prompt-with-vlm is set but neither --qwen35-variant nor --qwen35-path was provided — the chain will fall back to --prompt verbatim.")
+            }
+        }
+        if let qwen35Path {
+            logErr("Loading Qwen3.5 VLM from \(qwen35Path) ...")
+            try await FluxTextEncoders.shared.loadQwen35VLM(from: qwen35Path)
+            logErr("✓ Qwen3.5 VLM loaded")
+        } else if let variantStr = qwen35Variant {
+            let selectedVariant: Qwen35Variant
+            switch variantStr.lowercased() {
+            case "4bit": selectedVariant = .qwen35_4B_4bit
+            case "8bit": selectedVariant = .qwen35_4B_8bit
+            default: throw ValidationError("Unsupported --qwen35-variant '\(variantStr)' (use '8bit' or '4bit')")
+            }
+            logErr("Downloading/loading Qwen3.5 VLM (\(selectedVariant.displayName)) ...")
+            let downloader = TextEncoderModelDownloader()
+            let path = try await downloader.downloadQwen35(variant: selectedVariant) { progress, message in
+                logErr("  [\(Int(progress * 100))%] \(message)")
+            }
+            try await FluxTextEncoders.shared.loadQwen35VLM(from: path.path)
+            logErr("✓ Qwen3.5 VLM loaded")
+        }
+
         let pipeline = Flux2Pipeline(
             model: modelChoice,
             quantization: .memoryEfficient,
@@ -135,6 +200,8 @@ struct Inpaint: AsyncParsableCommand {
             guidance: guidance,
             seed: seed,
             upsamplePrompt: upsamplePrompt,
+            enrichPromptWithVLM: enrichPromptWithVLM,
+            intent: intent.intent,
             maxPixels: maxPixels,
             onProgress: { step, total in
                 logErr("  step \(step)/\(total)")

--- a/Sources/Flux2CLI/MaskSubjectCommand.swift
+++ b/Sources/Flux2CLI/MaskSubjectCommand.swift
@@ -27,8 +27,11 @@ struct MaskSubject: AsyncParsableCommand {
     @Option(name: [.short, .long], help: "Output PNG path for the generated mask.")
     var output: String
 
-    @Option(name: .long, help: "Width of the Gaussian transition on the subject boundary, in pixels of the source. 0 = bit-hard edge (risk of visible seam). Default 4.")
+    @Option(name: .long, help: "Width of the Gaussian transition on the subject boundary, in pixels of the working image. 0 = bit-hard edge (risk of visible seam). Default 4.")
     var edgeSoftnessPixels: Int = 4
+
+    @Option(name: .long, help: "Optional working-resolution cap (total pixels). When set, the source is downscaled with Lanczos before Vision runs and the mask is produced at the smaller size — useful when the downstream pipeline will downscale to ~1 MP anyway (saves up to 24× of work on a 24 MP iPhone shot). Omit to keep the mask at source dimensions (right choice for ad-hoc inspection).")
+    var targetMaxPixels: Int?
 
     func run() async throws {
         @Sendable func logErr(_ msg: String) {
@@ -39,12 +42,16 @@ struct MaskSubject: AsyncParsableCommand {
             throw ValidationError("Could not decode image at \(image)")
         }
         logErr("Image: \(image) (\(cg.width)×\(cg.height))")
+        if let cap = targetMaxPixels {
+            logErr("Target max pixels: \(cap)")
+        }
 
         let mask: CGImage
         do {
             mask = try Flux2SubjectMask.makeChangeSceneMask(
                 from: cg,
-                edgeSoftnessPixels: edgeSoftnessPixels
+                edgeSoftnessPixels: edgeSoftnessPixels,
+                targetMaxPixels: targetMaxPixels
             )
         } catch Flux2SubjectMask.Error.noSubjectDetected {
             throw ValidationError("Vision found no foreground subject in \(image). Use a hand-drawn mask for this image.")
@@ -53,7 +60,7 @@ struct MaskSubject: AsyncParsableCommand {
         }
 
         try Self.savePNG(mask, to: output)
-        logErr("✓ Mask written → \(output)")
+        logErr("✓ Mask written → \(output) (\(mask.width)×\(mask.height))")
     }
 
     private static func loadCGImage(at path: String) -> CGImage? {

--- a/Sources/Flux2CLI/MaskSubjectCommand.swift
+++ b/Sources/Flux2CLI/MaskSubjectCommand.swift
@@ -1,0 +1,80 @@
+// MaskSubjectCommand.swift — `flux2 mask-subject` (auto-segmentation)
+// Copyright 2025 Vincent Gourbin
+//
+// Generates a Flux-convention inpaint mask from auto-segmentation of
+// the source image's foreground subject. Intended for the
+// `.changeScene` workflow where the user wants to keep a subject and
+// regenerate everything around it — a use case that breaks with
+// hand-drawn blob masks (FLUX hallucinates a second-anatomy chimera in
+// the soft mask ramp).
+
+import Foundation
+import ArgumentParser
+import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
+import Flux2Chains
+
+struct MaskSubject: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "mask-subject",
+        abstract: "Auto-segment the foreground subject and produce a Flux-convention inpaint mask (BLACK = subject = keep, WHITE = inpaint)."
+    )
+
+    @Option(name: [.short, .long], help: "Input image to segment.")
+    var image: String
+
+    @Option(name: [.short, .long], help: "Output PNG path for the generated mask.")
+    var output: String
+
+    @Option(name: .long, help: "Width of the Gaussian transition on the subject boundary, in pixels of the source. 0 = bit-hard edge (risk of visible seam). Default 4.")
+    var edgeSoftnessPixels: Int = 4
+
+    func run() async throws {
+        @Sendable func logErr(_ msg: String) {
+            FileHandle.standardError.write(Data((msg + "\n").utf8))
+        }
+
+        guard let cg = Self.loadCGImage(at: image) else {
+            throw ValidationError("Could not decode image at \(image)")
+        }
+        logErr("Image: \(image) (\(cg.width)×\(cg.height))")
+
+        let mask: CGImage
+        do {
+            mask = try Flux2SubjectMask.makeChangeSceneMask(
+                from: cg,
+                edgeSoftnessPixels: edgeSoftnessPixels
+            )
+        } catch Flux2SubjectMask.Error.noSubjectDetected {
+            throw ValidationError("Vision found no foreground subject in \(image). Use a hand-drawn mask for this image.")
+        } catch {
+            throw ValidationError("Auto-segmentation failed: \(error)")
+        }
+
+        try Self.savePNG(mask, to: output)
+        logErr("✓ Mask written → \(output)")
+    }
+
+    private static func loadCGImage(at path: String) -> CGImage? {
+        let url = URL(fileURLWithPath: path)
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else { return nil }
+        return CGImageSourceCreateImageAtIndex(source, 0, nil)
+    }
+
+    private static func savePNG(_ image: CGImage, to path: String) throws {
+        let url = URL(fileURLWithPath: path)
+        guard let dest = CGImageDestinationCreateWithURL(
+            url as CFURL,
+            UTType.png.identifier as CFString,
+            1,
+            nil
+        ) else {
+            throw ValidationError("Could not create PNG destination at \(path)")
+        }
+        CGImageDestinationAddImage(dest, image, nil)
+        guard CGImageDestinationFinalize(dest) else {
+            throw ValidationError("Failed to write PNG at \(path)")
+        }
+    }
+}

--- a/Sources/Flux2CLI/OutpaintCommand.swift
+++ b/Sources/Flux2CLI/OutpaintCommand.swift
@@ -53,8 +53,11 @@ struct Outpaint: AsyncParsableCommand {
     var guidance: Float = 1.0
     @Option(name: .long, help: "Random seed.")
     var seed: UInt64?
-    @Flag(name: .long, help: "Rewrite the prompt via the bundled Qwen3.5 VLM before encoding. Useful when --prompt is a short instruction rather than a full descriptive Flux 2 prompt.")
+    @Flag(name: .long, help: "Text-encoder-only prompt rewriting (Mistral/Klein-Qwen3). Does NOT look at the image. For image-aware rewriting that continues the source's lighting/materials into the new strips, use --enrich-prompt-with-vlm instead.")
     var upsamplePrompt: Bool = false
+
+    @Flag(name: .long, help: "Image-aware prompt rewriting via the bundled Qwen3.5 VLM. The VLM looks at --image and the requested extension sides, then assembles a 30-80 word BFL-style Flux 2 prompt that continues the kept region's materials, perspective, lighting and palette into the new strips. Strictly optional: if the VLM is not loaded, the chain falls back to --prompt verbatim with a warning. Load the VLM ahead of time via FluxEncodersCLI or the test-qwen35 command. When both --upsample-prompt and --enrich-prompt-with-vlm are set, the VLM wins.")
+    var enrichPromptWithVLM: Bool = false
     @Option(name: .long, help: "Width of the soft transition band, in pixels of the keep region. Default 32.")
     var transitionPixels: Int = 32
     @Option(name: .long, help: "Cap on the total working pixel count. Defaults to 4 M; raise if you want larger canvases.")
@@ -107,6 +110,7 @@ struct Outpaint: AsyncParsableCommand {
             guidance: guidance,
             seed: seed,
             upsamplePrompt: upsamplePrompt,
+            enrichPromptWithVLM: enrichPromptWithVLM,
             transitionPixels: transitionPixels,
             maxPixels: maxPixels,
             onProgress: { step, total in

--- a/Sources/Flux2Chains/Flux2InpaintIntent.swift
+++ b/Sources/Flux2Chains/Flux2InpaintIntent.swift
@@ -1,0 +1,74 @@
+// Flux2InpaintIntent.swift — Edit intent enum for VLM-guided prompt enrichment
+// Copyright 2025 Vincent Gourbin
+//
+// FLUX.2 has no negative prompts and no dedicated edit instruction channel:
+// the *only* steering signal for the masked region is the text prompt.
+// What that prompt should look like depends on what the user is trying to
+// do — and the three cases below have *opposite* requirements.
+
+import Foundation
+
+/// What the caller is trying to do inside the masked region of an inpaint.
+///
+/// Used by ``Flux2MaskedInpaintingChain`` when `enrichPromptWithVLM` is
+/// enabled: the chain picks an intent-specific system prompt for the
+/// bundled Qwen3.5 VLM so the produced FLUX.2 prompt matches the user's
+/// actual goal. When `enrichPromptWithVLM` is `false`, this enum has no
+/// effect — the caller's prompt is passed through verbatim.
+///
+/// Each case maps to a different prompting strategy because FLUX.2 reacts
+/// very differently to "describe the new subject" vs "describe the empty
+/// surface" vs "modify the existing subject":
+///
+/// - ``replace``: name the *new* subject in the BFL Subject+Action+Style
+///   +Context structure; *never* mention the object being removed (naming
+///   it would re-introduce it — FLUX.2 has no negatives). The VLM
+///   describes the source's camera angle, lighting direction, materials,
+///   palette, and depth of field so the new subject inherits the scene's
+///   photographic identity, including a cast shadow consistent with the
+///   existing light direction.
+///
+/// - ``remove``: describe *only* the surface that should continue under
+///   what is being removed. The VLM looks at the pixels around the
+///   masked region and writes a prompt about that surface alone — naming
+///   the object would make it reappear.
+///
+/// - ``modify``: keep the existing subject recognisable but apply the
+///   user's modification (colour change, outfit swap, expression
+///   change). The VLM preserves the scene's photographic identity *and*
+///   the subject's identity, applying the change as Action.
+public enum Flux2InpaintIntent: String, Sendable, CaseIterable, Codable {
+    /// The masked region currently contains an object the user wants to
+    /// swap for a different subject. Example: *cat → duck*. The user
+    /// supplies the new subject as the prompt.
+    case replace
+
+    /// The masked region currently contains an object the user wants
+    /// gone, with the surrounding surface continuing seamlessly into the
+    /// gap. Example: removing a person from a beach photo so only the
+    /// sand remains. The user's prompt (if any) is consumed as context
+    /// only; the produced FLUX.2 prompt never mentions the removed
+    /// subject.
+    case remove
+
+    /// The masked region contains an existing subject the user wants to
+    /// modify in place (colour, outfit, expression…) while keeping it
+    /// recognisable and integrated. Example: *change the cat's collar
+    /// from red to blue*. The user's prompt describes the modification.
+    case modify
+
+    /// The mask is **inverted** vs the other cases: it preserves a
+    /// subject and the inpainted region is the **scene around it**. The
+    /// user wants the same subject but relocated into a new context.
+    /// Example: *put the cat at a swimming pool* — cat stays as-is,
+    /// the asphalt + wall background becomes a pool deck. The user's
+    /// prompt describes the new scene; the VLM is instructed to
+    /// preserve the subject's anatomy verbatim and inherit the source's
+    /// lighting direction so the new scene integrates naturally with
+    /// the kept region.
+    ///
+    /// Distinct from ``modify`` because `.modify` invents a subject-
+    /// level change (e.g., a "bright orange life vest" hallucinated
+    /// from a "pool" cue), which is the wrong direction here.
+    case changeScene
+}

--- a/Sources/Flux2Chains/Flux2MaskedInpaintingChain.swift
+++ b/Sources/Flux2Chains/Flux2MaskedInpaintingChain.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 import Flux2Core
+import FluxTextEncoders  // FluxDebug logger; VLM service is reached via Flux2VLMPromptBuilder
 @preconcurrency import MLX
 @preconcurrency import MLXRandom
 import CoreGraphics
@@ -95,13 +96,53 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
     public let steps: Int
     public let guidance: Float
     public let seed: UInt64?
-    /// When `true`, the active text encoder rewrites the prompt with an
-    /// internal vision-language model (Qwen3.5 VLM in this framework)
-    /// before encoding. Useful when the caller supplies a short edit
-    /// instruction rather than a full Flux 2-style descriptive prompt.
-    /// Cost: one extra VLM forward pass per call. Default `false` to
-    /// preserve the caller's exact wording.
+    /// When `true`, the active text encoder rewrites the prompt with its
+    /// own internal language model (Mistral / Klein-Qwen3) before
+    /// encoding. **Text-only path** — does not look at ``image``. Useful
+    /// when the caller supplies a short instruction; the text encoder
+    /// expands it with stylistic detail.
+    ///
+    /// For *image-aware* enrichment (the prompt is built from the source
+    /// image's actual lighting / camera / materials, following the BFL
+    /// prompting guide), use ``enrichPromptWithVLM`` instead — see the
+    /// collision rules below.
+    ///
+    /// Cost: one extra text-encoder forward pass per call. Default
+    /// `false` to preserve the caller's exact wording.
     public let upsamplePrompt: Bool
+
+    /// When `true`, ask the bundled Qwen3.5 VLM to look at ``image`` and
+    /// rewrite ``prompt`` into a 30-80 word BFL-style Flux 2 prompt that
+    /// inherits the source's photographic identity (camera angle,
+    /// lighting direction, surface materials, colour palette, depth of
+    /// field). The exact rewriting strategy depends on ``intent``.
+    ///
+    /// **The VLM is never required.** Behaviour by configuration:
+    /// - VLM loaded → image-aware prompt is built and used; the
+    ///   downstream `upsamplePrompt` is forced to `false` so the text
+    ///   encoder doesn't re-process the already-finalised prompt.
+    /// - VLM not loaded → a warning is logged via ``FluxDebug`` and the
+    ///   chain falls back to the existing behaviour (caller's prompt,
+    ///   honouring ``upsamplePrompt`` as documented). No throw.
+    ///
+    /// **Collision with ``upsamplePrompt``:** when both are `true`, the
+    /// VLM wins because it produces the higher-quality, image-aware
+    /// output. A warning is logged so the caller can clean up their
+    /// configuration.
+    ///
+    /// Cost: one extra VLM forward pass (~few seconds on M-series). The
+    /// caller is responsible for the VLM lifecycle — load it via
+    /// ``FluxTextEncoders/shared/loadQwen35VLM(from:)`` before
+    /// ``run()`` and unload when done. Default `false`.
+    public let enrichPromptWithVLM: Bool
+
+    /// Drives ``Flux2VLMPromptBuilder`` when ``enrichPromptWithVLM`` is
+    /// `true`. Ignored otherwise. See ``Flux2InpaintIntent`` — the three
+    /// cases (`.replace`, `.remove`, `.modify`) have *opposite* prompting
+    /// requirements and must be told apart explicitly.
+    ///
+    /// Default `.replace` (most common case: swap object X for Y).
+    public let intent: Flux2InpaintIntent
     /// Optional progress callback forwarded to `generateWithResult`.
     public let onProgress: Flux2ProgressCallback?
 
@@ -146,9 +187,16 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
     ///     klein; raise to ≈ 3.5 with `.klein9BBase` or `.klein4BBase` to
     ///     trigger the classical CFG path on the underlying pipeline.
     ///   - seed: Random seed for reproducibility. `nil` for non-deterministic.
-    ///   - upsamplePrompt: Rewrite the prompt via the bundled VLM before
-    ///     encoding. Useful when the caller supplies a short edit
-    ///     instruction. Default `false`.
+    ///   - upsamplePrompt: Text-encoder-only prompt rewriting. See the
+    ///     property doc for the difference vs ``enrichPromptWithVLM``,
+    ///     and for the collision rule when both are set. Default `false`.
+    ///   - enrichPromptWithVLM: Opt-in image-aware prompt rewriting via
+    ///     the bundled Qwen3.5 VLM. Strictly optional — when the VLM is
+    ///     not loaded the chain falls back to the verbatim prompt and
+    ///     logs a warning. Default `false`.
+    ///   - intent: Drives the VLM system prompt when
+    ///     `enrichPromptWithVLM == true`; ignored otherwise. Default
+    ///     `.replace`.
     ///   - maxPixels: Cap on the working resolution. Larger inputs are scaled
     ///     down (aspect preserved) before being clamped to a multiple of 32.
     ///   - onProgress: Forwarded to the pipeline's denoising loop.
@@ -164,6 +212,8 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
         guidance: Float = 1.0,
         seed: UInt64? = nil,
         upsamplePrompt: Bool = false,
+        enrichPromptWithVLM: Bool = false,
+        intent: Flux2InpaintIntent = .replace,
         maxPixels: Int = 1024 * 1024,
         onProgress: Flux2ProgressCallback? = nil
     ) {
@@ -178,6 +228,8 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
         self.guidance = guidance
         self.seed = seed
         self.upsamplePrompt = upsamplePrompt
+        self.enrichPromptWithVLM = enrichPromptWithVLM
+        self.intent = intent
         self.maxPixels = maxPixels
         self.onProgress = onProgress
     }
@@ -195,6 +247,11 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
     ///   loaded, memory, generation cancellation).
     public func run() async throws -> Flux2GenerationResult {
         try await pipeline.loadModels()
+
+        // Resolve which prompt + upsample flag actually reach the pipeline.
+        // VLM enrichment is strictly opt-in and gracefully falls back when
+        // the VLM is not loaded — never throws or auto-loads.
+        let (resolvedPrompt, resolvedUpsample) = await resolveFinalPromptAndUpsample()
 
         let (targetH, targetW) = Flux2Pipeline.resolveChainDimensions(
             width: image.width,
@@ -245,19 +302,65 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
 
         return try await pipeline.generateWithResult(
             mode: mode,
-            prompt: prompt,
+            prompt: resolvedPrompt,
             interpretImagePaths: nil,
             height: targetH,
             width: targetW,
             steps: steps,
             guidance: guidance,
             seed: seed,
-            upsamplePrompt: upsamplePrompt,
+            upsamplePrompt: resolvedUpsample,
             precomputedEmbeddings: nil,
             checkpointInterval: nil,
             onProgress: onProgress,
             onCheckpoint: nil,
             onStep: onStep
         )
+    }
+
+    // MARK: - VLM enrichment resolution
+
+    /// Compute the prompt and the downstream `upsamplePrompt` that
+    /// actually reach `Flux2Pipeline.generateWithResult`. Handles the
+    /// strictly-optional VLM path, the collision rule with
+    /// ``upsamplePrompt``, and the graceful fallback when the VLM isn't
+    /// loaded.
+    ///
+    /// Outcomes (in order of preference):
+    /// 1. `enrichPromptWithVLM == true` + VLM loaded + builder returns a
+    ///    non-empty string → use that prompt, force `upsamplePrompt = false`
+    ///    downstream (the prompt is already finalised). If
+    ///    ``upsamplePrompt`` was also `true`, log a warning — VLM wins.
+    /// 2. `enrichPromptWithVLM == true` + VLM not loaded → log a
+    ///    warning, fall through to (3).
+    /// 3. Default → caller's prompt + caller's ``upsamplePrompt`` (existing
+    ///    behaviour, byte-identical to before this feature).
+    private func resolveFinalPromptAndUpsample() async -> (String, Bool) {
+        guard enrichPromptWithVLM else {
+            return (prompt, upsamplePrompt)
+        }
+        guard FluxTextEncoders.shared.isQwen35VLMLoaded else {
+            FluxDebug.error("[Flux2MaskedInpaintingChain] enrichPromptWithVLM=true but Qwen3.5 VLM is not loaded. Falling back to caller's prompt. Load the VLM via FluxTextEncoders.shared.loadQwen35VLM(from:) before run() to enable image-aware prompt enrichment.")
+            return (prompt, upsamplePrompt)
+        }
+        if upsamplePrompt {
+            FluxDebug.error("[Flux2MaskedInpaintingChain] Both enrichPromptWithVLM and upsamplePrompt are true — VLM wins (image-aware enrichment supersedes text-only upsampling). Disable one of the two to silence this warning.")
+        }
+        do {
+            let built = try await Flux2VLMPromptBuilder.buildInpaintPrompt(
+                source: image,
+                userInstruction: prompt,
+                intent: intent
+            )
+            guard let final = built?.trimmingCharacters(in: .whitespacesAndNewlines), !final.isEmpty else {
+                FluxDebug.error("[Flux2MaskedInpaintingChain] VLM returned an empty prompt — falling back to caller's prompt.")
+                return (prompt, upsamplePrompt)
+            }
+            FluxDebug.info("[Flux2MaskedInpaintingChain] VLM-enriched prompt (\(intent.rawValue)): \(final)")
+            return (final, false)
+        } catch {
+            FluxDebug.error("[Flux2MaskedInpaintingChain] VLM enrichment failed: \(error). Falling back to caller's prompt.")
+            return (prompt, upsamplePrompt)
+        }
     }
 }

--- a/Sources/Flux2Chains/Flux2OutpaintingChain.swift
+++ b/Sources/Flux2Chains/Flux2OutpaintingChain.swift
@@ -16,6 +16,7 @@
 
 import Foundation
 import Flux2Core
+import FluxTextEncoders  // FluxDebug logger; VLM service is reached via Flux2VLMPromptBuilder
 @preconcurrency import MLX
 import CoreGraphics
 
@@ -60,10 +61,31 @@ public struct Flux2OutpaintingChain: Flux2Chain {
     public let steps: Int
     public let guidance: Float
     public let seed: UInt64?
-    /// Rewrite the prompt via the bundled VLM before encoding. Useful
-    /// when the caller passes a short instruction rather than a full
-    /// Flux 2-style descriptive prompt. Default `false`.
+    /// Text-encoder-only prompt rewriting (Mistral / Klein-Qwen3). Does
+    /// not look at ``image``. For *image-aware* enrichment that
+    /// describes the kept region's lighting / camera / materials and
+    /// instructs FLUX.2 to continue them, use ``enrichPromptWithVLM``
+    /// instead — when both are set, the VLM wins and a warning is
+    /// logged. Default `false`.
     public let upsamplePrompt: Bool
+
+    /// When `true`, ask the bundled Qwen3.5 VLM to look at ``image`` and
+    /// the list of sides being extended, then assemble a 30-80 word
+    /// BFL-style prompt that continues the kept region's materials,
+    /// perspective, lighting direction, and colour palette into the new
+    /// strips.
+    ///
+    /// **The VLM is never required.** When it isn't loaded, a warning is
+    /// logged via ``FluxDebug`` and the chain falls back to the
+    /// caller's prompt + ``upsamplePrompt`` (existing behaviour).
+    ///
+    /// **Collision with ``upsamplePrompt``:** when both are `true`, the
+    /// VLM wins. A warning is logged.
+    ///
+    /// The caller owns the VLM lifecycle (load via
+    /// ``FluxTextEncoders/shared/loadQwen35VLM(from:)`` before
+    /// ``run()``, unload when done). Default `false`.
+    public let enrichPromptWithVLM: Bool
     public let onProgress: Flux2ProgressCallback?
 
     /// Width of the soft transition band, in pixels of the canvas. The band
@@ -96,9 +118,13 @@ public struct Flux2OutpaintingChain: Flux2Chain {
     ///   - steps: Denoising step count. `4` matches klein distilled defaults.
     ///   - guidance: Classifier-free guidance scale.
     ///   - seed: Random seed for reproducibility. `nil` for non-deterministic.
-    ///   - upsamplePrompt: Rewrite the prompt via the bundled VLM before
-    ///     encoding. Useful when the caller passes a short instruction
-    ///     rather than a full descriptive Flux 2 prompt. Default `false`.
+    ///   - upsamplePrompt: Text-encoder-only prompt rewriting. See the
+    ///     property doc for the difference vs ``enrichPromptWithVLM``
+    ///     and the collision rule. Default `false`.
+    ///   - enrichPromptWithVLM: Opt-in image-aware prompt rewriting via
+    ///     the bundled Qwen3.5 VLM. Strictly optional — when the VLM is
+    ///     not loaded the chain falls back to the verbatim prompt and
+    ///     logs a warning. Default `false`.
     ///   - transitionPixels: Width of the soft transition band, in pixels of
     ///     the keep region. The band lives *inside* the keep so the strips
     ///     themselves carry mask = 1.0 (pure paint, no seed contamination).
@@ -118,6 +144,7 @@ public struct Flux2OutpaintingChain: Flux2Chain {
         guidance: Float = 1.0,
         seed: UInt64? = nil,
         upsamplePrompt: Bool = false,
+        enrichPromptWithVLM: Bool = false,
         transitionPixels: Int = 32,
         maxPixels: Int = 4 * 1024 * 1024,
         onProgress: Flux2ProgressCallback? = nil
@@ -133,6 +160,7 @@ public struct Flux2OutpaintingChain: Flux2Chain {
         self.guidance = guidance
         self.seed = seed
         self.upsamplePrompt = upsamplePrompt
+        self.enrichPromptWithVLM = enrichPromptWithVLM
         self.transitionPixels = transitionPixels
         self.maxPixels = maxPixels
         self.onProgress = onProgress
@@ -207,9 +235,19 @@ public struct Flux2OutpaintingChain: Flux2Chain {
             throw Flux2ChainError.invalidInput("Failed to build smart mask")
         }
 
+        // VLM enrichment runs at this level (not delegated to the inner
+        // inpaint chain) because we know which sides are being extended,
+        // and we want the VLM to inspect the ORIGINAL image (not the
+        // padded canvas with noise strips). The inner chain is then
+        // called with `enrichPromptWithVLM: false` so there's no
+        // double-pass.
+        let (resolvedPrompt, resolvedUpsample) = await resolveFinalPromptAndUpsample(
+            paddings: (t: t, b: b, l: l, r: r)
+        )
+
         let inpaint = Flux2MaskedInpaintingChain(
             pipeline: pipeline,
-            prompt: prompt,
+            prompt: resolvedPrompt,
             image: canvas,
             mask: mask,
             referenceImages: [image],  // I2I conditioning continues the scene
@@ -217,11 +255,66 @@ public struct Flux2OutpaintingChain: Flux2Chain {
             steps: steps,
             guidance: guidance,
             seed: seed,
-            upsamplePrompt: upsamplePrompt,
+            upsamplePrompt: resolvedUpsample,
+            enrichPromptWithVLM: false,  // already handled here, don't double-process
             maxPixels: max(maxPixels, canvasW * canvasH),
             onProgress: onProgress
         )
         return try await inpaint.run()
+    }
+
+    // MARK: - VLM enrichment resolution
+
+    /// Same contract as the inpainting chain's resolver, but the VLM is
+    /// given the ORIGINAL ``image`` (not the padded canvas) and the set
+    /// of active sides so it can focus on the right edges.
+    ///
+    /// Outcomes (in order of preference):
+    /// 1. `enrichPromptWithVLM == true` + VLM loaded + builder returns a
+    ///    non-empty string → use that prompt, force `upsamplePrompt = false`
+    ///    downstream. If ``upsamplePrompt`` was also `true`, warn — VLM wins.
+    /// 2. `enrichPromptWithVLM == true` + VLM not loaded → warn, fall
+    ///    through to (3).
+    /// 3. Default → caller's prompt + caller's ``upsamplePrompt``
+    ///    (existing behaviour, byte-identical to before this feature).
+    private func resolveFinalPromptAndUpsample(
+        paddings: (t: Int, b: Int, l: Int, r: Int)
+    ) async -> (String, Bool) {
+        guard enrichPromptWithVLM else {
+            return (prompt, upsamplePrompt)
+        }
+        guard FluxTextEncoders.shared.isQwen35VLMLoaded else {
+            FluxDebug.error("[Flux2OutpaintingChain] enrichPromptWithVLM=true but Qwen3.5 VLM is not loaded. Falling back to caller's prompt. Load the VLM via FluxTextEncoders.shared.loadQwen35VLM(from:) before run() to enable image-aware prompt enrichment.")
+            return (prompt, upsamplePrompt)
+        }
+        if upsamplePrompt {
+            FluxDebug.error("[Flux2OutpaintingChain] Both enrichPromptWithVLM and upsamplePrompt are true — VLM wins (image-aware enrichment supersedes text-only upsampling). Disable one of the two to silence this warning.")
+        }
+
+        var sides = Set<OutpaintSide>()
+        if paddings.t > 0 { sides.insert(.top) }
+        if paddings.b > 0 { sides.insert(.bottom) }
+        if paddings.l > 0 { sides.insert(.left) }
+        if paddings.r > 0 { sides.insert(.right) }
+        // `paddings` is guaranteed to have at least one positive value by
+        // the validation at the top of run(), so `sides` is non-empty.
+
+        do {
+            let built = try await Flux2VLMPromptBuilder.buildOutpaintPrompt(
+                source: image,
+                userInstruction: prompt,
+                sides: sides
+            )
+            guard let final = built?.trimmingCharacters(in: .whitespacesAndNewlines), !final.isEmpty else {
+                FluxDebug.error("[Flux2OutpaintingChain] VLM returned an empty prompt — falling back to caller's prompt.")
+                return (prompt, upsamplePrompt)
+            }
+            FluxDebug.info("[Flux2OutpaintingChain] VLM-enriched prompt (sides=\(sides.sorted(by: { $0.rawValue < $1.rawValue }).map(\.rawValue).joined(separator: ","))): \(final)")
+            return (final, false)
+        } catch {
+            FluxDebug.error("[Flux2OutpaintingChain] VLM enrichment failed: \(error). Falling back to caller's prompt.")
+            return (prompt, upsamplePrompt)
+        }
     }
 
     // MARK: - Canvas / mask builders

--- a/Sources/Flux2Chains/Flux2SubjectMask.swift
+++ b/Sources/Flux2Chains/Flux2SubjectMask.swift
@@ -1,0 +1,222 @@
+// Flux2SubjectMask.swift — Auto-segmentation mask helper for .changeScene workflows
+// Copyright 2025 Vincent Gourbin
+//
+// Why this exists:
+// The `.changeScene` inpaint workflow ("keep subject, change scene around")
+// is *extremely* sensitive to mask quality. A loose hand-drawn blob lets
+// the subject's anatomy (paw tips, tail, ears) extend into the soft mask
+// ramp, where RePaint partially regenerates them — FLUX then invents a
+// second-anatomy chimera to rationalise the half-cat shape it sees. No
+// amount of prompt engineering fixes that.
+//
+// What does fix it: a pixel-accurate subject silhouette, slightly
+// dilated, with a short edge ramp. Vision's
+// `VNGenerateForegroundInstanceMaskRequest` (macOS 14+) produces exactly
+// that for free — no extra weights, no extra dependency, instant on
+// Apple Silicon.
+
+import Foundation
+import CoreGraphics
+import CoreImage
+import Vision
+
+/// Build inpainting masks from auto-segmented subjects.
+public enum Flux2SubjectMask {
+
+    public enum Error: Swift.Error, CustomStringConvertible, Sendable {
+        case noSubjectDetected
+        case maskRenderFailed
+        case visionFailure(String)
+
+        public var description: String {
+            switch self {
+            case .noSubjectDetected:
+                return "Vision could not detect a foreground subject in the image."
+            case .maskRenderFailed:
+                return "Failed to render the segmentation mask to a CGImage."
+            case .visionFailure(let msg):
+                return "Vision request failed: \(msg)"
+            }
+        }
+    }
+
+    /// Generate a Flux2-ready grayscale mask suitable for the
+    /// `.changeScene` inpaint workflow: BLACK over the subject (keep)
+    /// and WHITE everywhere else (inpaint). Compatible with
+    /// `Flux2MaskConvention.grayscaleWhiteInpaint`.
+    ///
+    /// Pipeline:
+    /// 1. Run `VNGenerateForegroundInstanceMaskRequest` on `image` —
+    ///    returns a per-instance segmentation. We OR-combine the
+    ///    instances so every subject the model finds is kept.
+    /// 2. The Vision mask is WHITE on the subject; we **invert** it to
+    ///    Flux's BLACK-keep convention.
+    /// 3. Apply a small Gaussian blur (`edgeSoftnessPixels`, default
+    ///    4 px) on the inverted mask so the boundary isn't bit-hard —
+    ///    keeps RePaint from leaving a visible seam, while staying
+    ///    tight enough that the subject's anatomy doesn't get
+    ///    repainted.
+    ///
+    /// - Parameters:
+    ///   - image: The source image to segment.
+    ///   - edgeSoftnessPixels: Width of the Gaussian transition on the
+    ///     subject boundary, in pixels of the source. Default 4. Set to
+    ///     0 for a bit-hard edge (visible seam likely).
+    /// - Returns: A grayscale CGImage at the same dimensions as the
+    ///   input, ready to pass to `Flux2MaskedInpaintingChain` with the
+    ///   default `.grayscaleWhiteInpaint` mask convention.
+    /// - Throws: ``Error/noSubjectDetected`` if Vision finds nothing,
+    ///   ``Error/visionFailure`` if the request throws, or
+    ///   ``Error/maskRenderFailed`` if we couldn't compose the result.
+    @available(macOS 14.0, *)
+    public static func makeChangeSceneMask(
+        from image: CGImage,
+        edgeSoftnessPixels: Int = 4
+    ) throws -> CGImage {
+        let request = VNGenerateForegroundInstanceMaskRequest()
+        let handler = VNImageRequestHandler(cgImage: image, options: [:])
+
+        do {
+            try handler.perform([request])
+        } catch {
+            throw Error.visionFailure(String(describing: error))
+        }
+
+        guard let observation = request.results?.first, !observation.allInstances.isEmpty else {
+            throw Error.noSubjectDetected
+        }
+
+        // Combine all detected instances into a single mask (some
+        // animals split into multiple instances).
+        let pixelBuffer: CVPixelBuffer
+        do {
+            pixelBuffer = try observation.generateScaledMaskForImage(
+                forInstances: observation.allInstances,
+                from: handler
+            )
+        } catch {
+            throw Error.visionFailure("Failed to scale subject mask: \(error)")
+        }
+
+        // The pixel buffer is single-channel float, white = subject.
+        // Convert to grayscale UInt8 in Flux convention (black = keep =
+        // subject ⇒ INVERT) at the same dimensions as the input.
+        guard let mask = renderInvertedMask(
+            from: pixelBuffer,
+            targetWidth: image.width,
+            targetHeight: image.height,
+            edgeSoftnessPixels: edgeSoftnessPixels
+        ) else {
+            throw Error.maskRenderFailed
+        }
+        return mask
+    }
+
+    // MARK: - Internals
+
+    /// Render a CVPixelBuffer (kCVPixelFormatType_OneComponent8 from
+    /// Vision) into a Flux-convention grayscale CGImage: subject → 0
+    /// (black, keep), background → 255 (white, inpaint), with an
+    /// optional Gaussian-style softening on the boundary.
+    private static func renderInvertedMask(
+        from pixelBuffer: CVPixelBuffer,
+        targetWidth: Int,
+        targetHeight: Int,
+        edgeSoftnessPixels: Int
+    ) -> CGImage? {
+        let pbW = CVPixelBufferGetWidth(pixelBuffer)
+        let pbH = CVPixelBufferGetHeight(pixelBuffer)
+        let pbFormat = CVPixelBufferGetPixelFormatType(pixelBuffer)
+        CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
+        defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly) }
+        guard let srcBase = CVPixelBufferGetBaseAddress(pixelBuffer) else { return nil }
+        let srcRowBytes = CVPixelBufferGetBytesPerRow(pixelBuffer)
+
+        // 1) Read the Vision mask into a UInt8 grayscale buffer in
+        //    Flux convention (subject = black, background = white). The
+        //    format depends on the Vision API:
+        //    - `generateMaskForInstances(...)` returns
+        //      `kCVPixelFormatType_OneComponent8` (subject = 255).
+        //    - `generateScaledMaskForImage(...)` returns
+        //      `kCVPixelFormatType_OneComponent32Float` (subject = 1.0).
+        //    Treating the float buffer as UInt8 reads 4-byte floats as
+        //    4 separate bytes ⇒ random-looking mask; that's the bug we
+        //    saw the first time.
+        var inverted = [UInt8](repeating: 0, count: pbW * pbH)
+        switch pbFormat {
+        case kCVPixelFormatType_OneComponent32Float:
+            for y in 0..<pbH {
+                let row = srcBase.advanced(by: y * srcRowBytes)
+                    .assumingMemoryBound(to: Float32.self)
+                for x in 0..<pbW {
+                    let v = max(0, min(1, row[x]))  // clamp [0, 1]
+                    inverted[y * pbW + x] = UInt8((1.0 - v) * 255.0)
+                }
+            }
+        case kCVPixelFormatType_OneComponent8:
+            for y in 0..<pbH {
+                let row = srcBase.advanced(by: y * srcRowBytes)
+                    .assumingMemoryBound(to: UInt8.self)
+                for x in 0..<pbW {
+                    inverted[y * pbW + x] = 255 &- row[x]
+                }
+            }
+        default:
+            return nil  // unknown format ⇒ caller bubbles maskRenderFailed
+        }
+        let cs = CGColorSpaceCreateDeviceGray()
+        guard let srcCtx = CGContext(
+            data: &inverted,
+            width: pbW, height: pbH,
+            bitsPerComponent: 8,
+            bytesPerRow: pbW,
+            space: cs,
+            bitmapInfo: CGImageAlphaInfo.none.rawValue
+        ), let srcImage = srcCtx.makeImage() else { return nil }
+
+        // 3) Draw into the target-sized grayscale context. Core
+        //    Graphics' bilinear sampling already softens the boundary
+        //    a bit when the source is larger or smaller; we add an
+        //    explicit small Gaussian-like blur next if requested.
+        var dst = [UInt8](repeating: 255, count: targetWidth * targetHeight)
+        guard let dstCtx = CGContext(
+            data: &dst,
+            width: targetWidth, height: targetHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: targetWidth,
+            space: cs,
+            bitmapInfo: CGImageAlphaInfo.none.rawValue
+        ) else { return nil }
+        dstCtx.interpolationQuality = .high
+        dstCtx.draw(srcImage, in: CGRect(x: 0, y: 0, width: targetWidth, height: targetHeight))
+
+        guard let hardImage = CGContext(
+            data: &dst,
+            width: targetWidth, height: targetHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: targetWidth,
+            space: cs,
+            bitmapInfo: CGImageAlphaInfo.none.rawValue
+        )?.makeImage() else { return nil }
+
+        guard edgeSoftnessPixels > 0 else { return hardImage }
+        return applyGaussianBlur(hardImage, radius: edgeSoftnessPixels) ?? hardImage
+    }
+
+    /// Soften the mask edge with a small Gaussian via Core Image
+    /// (CIGaussianBlur). Falls back to the hard mask if anything goes
+    /// wrong — better a slight visible seam than a black-broken mask.
+    private static func applyGaussianBlur(_ image: CGImage, radius: Int) -> CGImage? {
+        let ci = CIImage(cgImage: image)
+        let filter = CIFilter(name: "CIGaussianBlur")
+        filter?.setValue(ci, forKey: kCIInputImageKey)
+        filter?.setValue(Double(radius), forKey: kCIInputRadiusKey)
+        guard let output = filter?.outputImage else { return nil }
+        // Clamp to the original extent — CIGaussianBlur expands the
+        // image by the blur radius on every side; we want the same
+        // dimensions back.
+        let originalExtent = ci.extent
+        let context = CIContext(options: nil)
+        return context.createCGImage(output, from: originalExtent)
+    }
+}

--- a/Sources/Flux2Chains/Flux2SubjectMask.swift
+++ b/Sources/Flux2Chains/Flux2SubjectMask.swift
@@ -16,6 +16,7 @@
 // Apple Silicon.
 
 import Foundation
+import Accelerate
 import CoreGraphics
 import CoreImage
 import Vision
@@ -27,6 +28,7 @@ public enum Flux2SubjectMask {
         case noSubjectDetected
         case maskRenderFailed
         case visionFailure(String)
+        case unsupportedPixelFormat(UInt32)
 
         public var description: String {
             switch self {
@@ -36,9 +38,30 @@ public enum Flux2SubjectMask {
                 return "Failed to render the segmentation mask to a CGImage."
             case .visionFailure(let msg):
                 return "Vision request failed: \(msg)"
+            case .unsupportedPixelFormat(let fmt):
+                return "Unsupported CVPixelBuffer format from Vision: 0x\(String(format: "%08X", fmt)). Vision may have changed its mask output format; please file a bug."
             }
         }
     }
+
+    // MARK: - Shared resources
+    //
+    // CIContexts compile Metal pipelines on first use (~50–200 ms one-time
+    // cost). Caching one process-wide amortises that across calls, which
+    // matters for hosts that invoke `makeChangeSceneMask` repeatedly
+    // (e.g. FluxForge Studio live preview). `cacheIntermediates: false`
+    // prevents the context from holding onto multi-MB intermediate
+    // CIImages between calls — relevant when input masks are 20+ MP.
+    // CIContext is thread-safe per Apple docs, so static let is fine.
+    private static let sharedCIContext: CIContext = {
+        CIContext(options: [.cacheIntermediates: false])
+    }()
+
+    // Note on Vision request caching: `VNGenerateForegroundInstanceMaskRequest`
+    // stores its results as mutable state on the request instance. Caching
+    // one statically would let concurrent calls clobber each other's
+    // `results`. The request itself is cheap to instantiate (no Metal
+    // compilation), so we create it per call and stay concurrency-safe.
 
     /// Generate a Flux2-ready grayscale mask suitable for the
     /// `.changeScene` inpaint workflow: BLACK over the subject (keep)
@@ -46,35 +69,52 @@ public enum Flux2SubjectMask {
     /// `Flux2MaskConvention.grayscaleWhiteInpaint`.
     ///
     /// Pipeline:
-    /// 1. Run `VNGenerateForegroundInstanceMaskRequest` on `image` —
-    ///    returns a per-instance segmentation. We OR-combine the
-    ///    instances so every subject the model finds is kept.
-    /// 2. The Vision mask is WHITE on the subject; we **invert** it to
-    ///    Flux's BLACK-keep convention.
-    /// 3. Apply a small Gaussian blur (`edgeSoftnessPixels`, default
-    ///    4 px) on the inverted mask so the boundary isn't bit-hard —
-    ///    keeps RePaint from leaving a visible seam, while staying
-    ///    tight enough that the subject's anatomy doesn't get
-    ///    repainted.
+    /// 1. (Optional) downscale the source to `targetMaxPixels` so all
+    ///    subsequent work happens at the smaller resolution. Use this
+    ///    when the caller knows the chain will downscale anyway — saves
+    ///    a 24× factor on a 24-MP iPhone shot vs the chain's default
+    ///    1 MP working size.
+    /// 2. Run `VNGenerateForegroundInstanceMaskRequest` on the working
+    ///    image. We OR-combine all detected instances so multi-part
+    ///    subjects (e.g. an animal split into head + body) all get kept.
+    /// 3. Vision's float mask (1.0 = subject) is inverted into Flux
+    ///    convention (0 = subject = keep), vectorised via Accelerate.
+    /// 4. Optional `CIGaussianBlur` for a soft edge — keeps RePaint from
+    ///    leaving a visible seam without losing anatomy.
     ///
     /// - Parameters:
     ///   - image: The source image to segment.
     ///   - edgeSoftnessPixels: Width of the Gaussian transition on the
-    ///     subject boundary, in pixels of the source. Default 4. Set to
-    ///     0 for a bit-hard edge (visible seam likely).
-    /// - Returns: A grayscale CGImage at the same dimensions as the
-    ///   input, ready to pass to `Flux2MaskedInpaintingChain` with the
-    ///   default `.grayscaleWhiteInpaint` mask convention.
+    ///     subject boundary, in pixels of the *working* image (after
+    ///     downscaling). Default 4. Set to 0 for a bit-hard edge.
+    ///   - targetMaxPixels: When set, the source is downscaled with
+    ///     Lanczos so the total pixel count is at most this many before
+    ///     Vision runs. The returned mask is at the downscaled size, so
+    ///     callers that pair the mask back with the unscaled source
+    ///     must resize themselves. `nil` (default) keeps the source as
+    ///     is — the right choice for ad-hoc inspection (CLI
+    ///     `mask-subject`). Pass `1024 * 1024` from hosts that will
+    ///     route the mask straight to `Flux2MaskedInpaintingChain`.
+    /// - Returns: A grayscale CGImage at the *working* dimensions
+    ///   (source dims when `targetMaxPixels` is nil, else clamped).
     /// - Throws: ``Error/noSubjectDetected`` if Vision finds nothing,
-    ///   ``Error/visionFailure`` if the request throws, or
-    ///   ``Error/maskRenderFailed`` if we couldn't compose the result.
+    ///   ``Error/visionFailure`` if the request throws,
+    ///   ``Error/unsupportedPixelFormat`` if Vision returns a format we
+    ///   don't know how to decode, or ``Error/maskRenderFailed`` if we
+    ///   couldn't compose the final CGImage.
     @available(macOS 14.0, *)
     public static func makeChangeSceneMask(
         from image: CGImage,
-        edgeSoftnessPixels: Int = 4
+        edgeSoftnessPixels: Int = 4,
+        targetMaxPixels: Int? = nil
     ) throws -> CGImage {
+        // Step 1: optional downscale. Doing it BEFORE Vision means the
+        // model runs on fewer pixels AND the returned mask is small
+        // enough to skip the identity-scale draw in renderInvertedMask.
+        let workingImage = downscaledIfNeeded(image, targetMaxPixels: targetMaxPixels) ?? image
+
         let request = VNGenerateForegroundInstanceMaskRequest()
-        let handler = VNImageRequestHandler(cgImage: image, options: [:])
+        let handler = VNImageRequestHandler(cgImage: workingImage, options: [:])
 
         do {
             try handler.perform([request])
@@ -86,8 +126,6 @@ public enum Flux2SubjectMask {
             throw Error.noSubjectDetected
         }
 
-        // Combine all detected instances into a single mask (some
-        // animals split into multiple instances).
         let pixelBuffer: CVPixelBuffer
         do {
             pixelBuffer = try observation.generateScaledMaskForImage(
@@ -98,62 +136,91 @@ public enum Flux2SubjectMask {
             throw Error.visionFailure("Failed to scale subject mask: \(error)")
         }
 
-        // The pixel buffer is single-channel float, white = subject.
-        // Convert to grayscale UInt8 in Flux convention (black = keep =
-        // subject ⇒ INVERT) at the same dimensions as the input.
-        guard let mask = renderInvertedMask(
+        return try renderInvertedMask(
             from: pixelBuffer,
-            targetWidth: image.width,
-            targetHeight: image.height,
+            targetWidth: workingImage.width,
+            targetHeight: workingImage.height,
             edgeSoftnessPixels: edgeSoftnessPixels
-        ) else {
-            throw Error.maskRenderFailed
-        }
-        return mask
+        )
     }
 
     // MARK: - Internals
 
-    /// Render a CVPixelBuffer (kCVPixelFormatType_OneComponent8 from
-    /// Vision) into a Flux-convention grayscale CGImage: subject → 0
-    /// (black, keep), background → 255 (white, inpaint), with an
-    /// optional Gaussian-style softening on the boundary.
+    /// Render a CVPixelBuffer (Vision's float mask) into a
+    /// Flux-convention grayscale CGImage. The hot path (Vision returns
+    /// a buffer already at `targetWidth×targetHeight`, which it does
+    /// for `generateScaledMaskForImage(from:)`) avoids any
+    /// CoreGraphics draw — we go straight from inverted bytes to
+    /// CGImage. The fallback path (sizes differ, e.g. unexpected
+    /// EXIF orientation) does one rescaling draw.
+    @available(macOS 14.0, *)
     private static func renderInvertedMask(
         from pixelBuffer: CVPixelBuffer,
         targetWidth: Int,
         targetHeight: Int,
         edgeSoftnessPixels: Int
-    ) -> CGImage? {
+    ) throws -> CGImage {
         let pbW = CVPixelBufferGetWidth(pixelBuffer)
         let pbH = CVPixelBufferGetHeight(pixelBuffer)
         let pbFormat = CVPixelBufferGetPixelFormatType(pixelBuffer)
         CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
         defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly) }
-        guard let srcBase = CVPixelBufferGetBaseAddress(pixelBuffer) else { return nil }
+        guard let srcBase = CVPixelBufferGetBaseAddress(pixelBuffer) else {
+            throw Error.maskRenderFailed
+        }
         let srcRowBytes = CVPixelBufferGetBytesPerRow(pixelBuffer)
+        let count = pbW * pbH
 
-        // 1) Read the Vision mask into a UInt8 grayscale buffer in
-        //    Flux convention (subject = black, background = white). The
-        //    format depends on the Vision API:
-        //    - `generateMaskForInstances(...)` returns
-        //      `kCVPixelFormatType_OneComponent8` (subject = 255).
-        //    - `generateScaledMaskForImage(...)` returns
-        //      `kCVPixelFormatType_OneComponent32Float` (subject = 1.0).
-        //    Treating the float buffer as UInt8 reads 4-byte floats as
-        //    4 separate bytes ⇒ random-looking mask; that's the bug we
-        //    saw the first time.
-        var inverted = [UInt8](repeating: 0, count: pbW * pbH)
+        // 1) Decode the Vision mask into a Flux-convention UInt8 buffer
+        //    (subject=0 black=keep, background=255 white=inpaint).
+        //    Vectorised via Accelerate for the float path, which is what
+        //    `generateScaledMaskForImage` actually returns today.
+        var inverted = [UInt8](repeating: 0, count: count)
         switch pbFormat {
         case kCVPixelFormatType_OneComponent32Float:
-            for y in 0..<pbH {
-                let row = srcBase.advanced(by: y * srcRowBytes)
-                    .assumingMemoryBound(to: Float32.self)
-                for x in 0..<pbW {
-                    let v = max(0, min(1, row[x]))  // clamp [0, 1]
-                    inverted[y * pbW + x] = UInt8((1.0 - v) * 255.0)
+            // Read float mask values into a contiguous buffer, then run
+            // three vDSP passes: clamp to [0,1], compute (255 - 255*v),
+            // and saturating-cast to UInt8.
+            var floats = [Float](repeating: 0, count: count)
+            if srcRowBytes == pbW * MemoryLayout<Float>.size {
+                // Tightly packed: one memcpy.
+                floats.withUnsafeMutableBufferPointer { dst in
+                    memcpy(dst.baseAddress!, srcBase, count * MemoryLayout<Float>.size)
+                }
+            } else {
+                // Row padding: copy row-by-row.
+                floats.withUnsafeMutableBufferPointer { dst in
+                    for y in 0..<pbH {
+                        let row = srcBase.advanced(by: y * srcRowBytes)
+                        memcpy(
+                            dst.baseAddress!.advanced(by: y * pbW),
+                            row,
+                            pbW * MemoryLayout<Float>.size
+                        )
+                    }
                 }
             }
+            var lo: Float = 0
+            var hi: Float = 1
+            floats.withUnsafeMutableBufferPointer { fb in
+                vDSP_vclip(fb.baseAddress!, 1, &lo, &hi, fb.baseAddress!, 1, vDSP_Length(count))
+            }
+            // (1 - v) * 255  =  255 + (-255) * v  → vDSP_vsmsa
+            var negScale: Float = -255
+            var bias: Float = 255
+            floats.withUnsafeMutableBufferPointer { fb in
+                vDSP_vsmsa(fb.baseAddress!, 1, &negScale, &bias, fb.baseAddress!, 1, vDSP_Length(count))
+            }
+            inverted.withUnsafeMutableBufferPointer { dst in
+                floats.withUnsafeBufferPointer { src in
+                    vDSP_vfixu8(src.baseAddress!, 1, dst.baseAddress!, 1, vDSP_Length(count))
+                }
+            }
+
         case kCVPixelFormatType_OneComponent8:
+            // Defensive path: kept in case Vision ever switches back.
+            // Scalar loop is fine for byte inversion; vImage would be
+            // marginal here.
             for y in 0..<pbH {
                 let row = srcBase.advanced(by: y * srcRowBytes)
                     .assumingMemoryBound(to: UInt8.self)
@@ -161,62 +228,104 @@ public enum Flux2SubjectMask {
                     inverted[y * pbW + x] = 255 &- row[x]
                 }
             }
+
         default:
-            return nil  // unknown format ⇒ caller bubbles maskRenderFailed
+            throw Error.unsupportedPixelFormat(pbFormat)
         }
+
+        // 2) Build the final CGImage. Hot path: the Vision mask is
+        //    already at the target dimensions (Vision returns at the
+        //    handler's image size), so we skip the intermediate
+        //    CGContext draw and create the CGImage directly from
+        //    `inverted`. The fallback handles the rare case where
+        //    Vision returns at a different size (e.g. EXIF orientation
+        //    surprises) by scaling via a CGContext draw.
         let cs = CGColorSpaceCreateDeviceGray()
-        guard let srcCtx = CGContext(
-            data: &inverted,
-            width: pbW, height: pbH,
-            bitsPerComponent: 8,
-            bytesPerRow: pbW,
-            space: cs,
-            bitmapInfo: CGImageAlphaInfo.none.rawValue
-        ), let srcImage = srcCtx.makeImage() else { return nil }
+        let hardImage: CGImage
+        if pbW == targetWidth && pbH == targetHeight {
+            guard let ctx = CGContext(
+                data: &inverted,
+                width: pbW, height: pbH,
+                bitsPerComponent: 8,
+                bytesPerRow: pbW,
+                space: cs,
+                bitmapInfo: CGImageAlphaInfo.none.rawValue
+            ), let image = ctx.makeImage() else {
+                throw Error.maskRenderFailed
+            }
+            hardImage = image
+        } else {
+            guard let srcCtx = CGContext(
+                data: &inverted,
+                width: pbW, height: pbH,
+                bitsPerComponent: 8,
+                bytesPerRow: pbW,
+                space: cs,
+                bitmapInfo: CGImageAlphaInfo.none.rawValue
+            ), let srcImage = srcCtx.makeImage() else {
+                throw Error.maskRenderFailed
+            }
+            var dst = [UInt8](repeating: 255, count: targetWidth * targetHeight)
+            guard let dstCtx = CGContext(
+                data: &dst,
+                width: targetWidth, height: targetHeight,
+                bitsPerComponent: 8,
+                bytesPerRow: targetWidth,
+                space: cs,
+                bitmapInfo: CGImageAlphaInfo.none.rawValue
+            ) else {
+                throw Error.maskRenderFailed
+            }
+            dstCtx.interpolationQuality = .high
+            dstCtx.draw(srcImage, in: CGRect(x: 0, y: 0, width: targetWidth, height: targetHeight))
+            guard let image = dstCtx.makeImage() else {
+                throw Error.maskRenderFailed
+            }
+            hardImage = image
+        }
 
-        // 3) Draw into the target-sized grayscale context. Core
-        //    Graphics' bilinear sampling already softens the boundary
-        //    a bit when the source is larger or smaller; we add an
-        //    explicit small Gaussian-like blur next if requested.
-        var dst = [UInt8](repeating: 255, count: targetWidth * targetHeight)
-        guard let dstCtx = CGContext(
-            data: &dst,
-            width: targetWidth, height: targetHeight,
-            bitsPerComponent: 8,
-            bytesPerRow: targetWidth,
-            space: cs,
-            bitmapInfo: CGImageAlphaInfo.none.rawValue
-        ) else { return nil }
-        dstCtx.interpolationQuality = .high
-        dstCtx.draw(srcImage, in: CGRect(x: 0, y: 0, width: targetWidth, height: targetHeight))
-
-        guard let hardImage = CGContext(
-            data: &dst,
-            width: targetWidth, height: targetHeight,
-            bitsPerComponent: 8,
-            bytesPerRow: targetWidth,
-            space: cs,
-            bitmapInfo: CGImageAlphaInfo.none.rawValue
-        )?.makeImage() else { return nil }
-
-        guard edgeSoftnessPixels > 0 else { return hardImage }
-        return applyGaussianBlur(hardImage, radius: edgeSoftnessPixels) ?? hardImage
+        if edgeSoftnessPixels > 0,
+           let blurred = applyGaussianBlur(hardImage, radius: edgeSoftnessPixels) {
+            return blurred
+        }
+        return hardImage
     }
 
-    /// Soften the mask edge with a small Gaussian via Core Image
-    /// (CIGaussianBlur). Falls back to the hard mask if anything goes
-    /// wrong — better a slight visible seam than a black-broken mask.
+    /// Soften the mask edge with a small Gaussian via the shared
+    /// Core Image context. Falls back to the hard mask if anything
+    /// goes wrong — better a slight visible seam than a broken mask.
     private static func applyGaussianBlur(_ image: CGImage, radius: Int) -> CGImage? {
         let ci = CIImage(cgImage: image)
-        let filter = CIFilter(name: "CIGaussianBlur")
-        filter?.setValue(ci, forKey: kCIInputImageKey)
-        filter?.setValue(Double(radius), forKey: kCIInputRadiusKey)
-        guard let output = filter?.outputImage else { return nil }
-        // Clamp to the original extent — CIGaussianBlur expands the
-        // image by the blur radius on every side; we want the same
-        // dimensions back.
-        let originalExtent = ci.extent
-        let context = CIContext(options: nil)
-        return context.createCGImage(output, from: originalExtent)
+        guard let filter = CIFilter(name: "CIGaussianBlur") else { return nil }
+        filter.setValue(ci, forKey: kCIInputImageKey)
+        filter.setValue(Double(radius), forKey: kCIInputRadiusKey)
+        guard let output = filter.outputImage else { return nil }
+        // CIGaussianBlur expands the extent by the blur radius on every
+        // side; clamp back to the original extent so the mask keeps the
+        // input's dimensions.
+        return sharedCIContext.createCGImage(output, from: ci.extent)
+    }
+
+    /// Downscale `image` so its total pixel count is ≤ `targetMaxPixels`,
+    /// preserving aspect ratio. Returns nil when no downscaling is
+    /// needed (input already fits, or `targetMaxPixels` is nil). Uses
+    /// `CILanczosScaleTransform` for high-quality, deterministic
+    /// resampling.
+    ///
+    /// `internal` so unit tests can verify the no-op vs scaling
+    /// boundaries without needing a real subject image (Vision-free
+    /// path).
+    internal static func downscaledIfNeeded(_ image: CGImage, targetMaxPixels: Int?) -> CGImage? {
+        guard let target = targetMaxPixels else { return nil }
+        let srcPixels = image.width * image.height
+        guard srcPixels > target else { return nil }
+        let scale = (Double(target) / Double(srcPixels)).squareRoot()
+        let ci = CIImage(cgImage: image)
+        guard let filter = CIFilter(name: "CILanczosScaleTransform") else { return nil }
+        filter.setValue(ci, forKey: kCIInputImageKey)
+        filter.setValue(scale, forKey: kCIInputScaleKey)
+        filter.setValue(1.0, forKey: kCIInputAspectRatioKey)
+        guard let output = filter.outputImage else { return nil }
+        return sharedCIContext.createCGImage(output, from: output.extent)
     }
 }

--- a/Sources/Flux2Chains/Flux2VLMPromptBuilder.swift
+++ b/Sources/Flux2Chains/Flux2VLMPromptBuilder.swift
@@ -195,15 +195,11 @@ public enum Flux2VLMPromptBuilder {
         }
         let userMessage = userMessage(forInpaint: intent, instruction: userInstruction)
 
-        let result = try FluxTextEncoders.shared.analyzeImageWithQwen35(
-            image: source,
-            prompt: userMessage,
-            systemPrompt: systemPrompt,
-            enableThinking: false,
-            maxTokens: 220,
-            temperature: 0
-        )
-        return cleanFinalPrompt(result.text)
+        // The VLM forward is synchronous and takes ~3 s on M-series. Run
+        // it on a detached task so other work on the cooperative pool
+        // (UI updates, concurrent chains) isn't starved while we wait.
+        let raw = try await runVLM(image: source, prompt: userMessage, systemPrompt: systemPrompt)
+        return cleanFinalPrompt(raw)
     }
 
     /// Build a FLUX.2 outpainting prompt. The VLM looks at the source and
@@ -229,15 +225,28 @@ public enum Flux2VLMPromptBuilder {
 
         let userMessage = userMessage(forOutpaintSides: sides, instruction: userInstruction)
 
-        let result = try FluxTextEncoders.shared.analyzeImageWithQwen35(
-            image: source,
-            prompt: userMessage,
-            systemPrompt: outpaintSystemPrompt,
-            enableThinking: false,
-            maxTokens: 220,
-            temperature: 0
-        )
-        return cleanFinalPrompt(result.text)
+        let raw = try await runVLM(image: source, prompt: userMessage, systemPrompt: outpaintSystemPrompt)
+        return cleanFinalPrompt(raw)
+    }
+
+    /// Run the Qwen3.5 VLM forward on a detached, user-initiated task
+    /// so the ~3 s sync call doesn't block the cooperative thread pool.
+    /// CGImage / String are Sendable in the SDK we target.
+    private static func runVLM(
+        image: CGImage,
+        prompt: String,
+        systemPrompt: String
+    ) async throws -> String {
+        try await Task.detached(priority: .userInitiated) {
+            try FluxTextEncoders.shared.analyzeImageWithQwen35(
+                image: image,
+                prompt: prompt,
+                systemPrompt: systemPrompt,
+                enableThinking: false,
+                maxTokens: 220,
+                temperature: 0
+            ).text
+        }.value
     }
 
     // MARK: - User message assembly (exposed for tests)

--- a/Sources/Flux2Chains/Flux2VLMPromptBuilder.swift
+++ b/Sources/Flux2Chains/Flux2VLMPromptBuilder.swift
@@ -1,0 +1,328 @@
+// Flux2VLMPromptBuilder.swift — Build FLUX.2 prompts from a source image via the bundled VLM
+// Copyright 2025 Vincent Gourbin
+//
+// Why this exists:
+// FLUX.2 has no negative prompts and no edit-instruction channel — the
+// prompt is the only steering signal for the masked region. Short prompts
+// (`"a duck"`, `"replace the cat"`) leave the model without lighting,
+// perspective, scale or material cues; the result floats, hallucinates
+// wrong surfaces, or copies the source. The BFL prompting guide
+// (<https://docs.bfl.ml/guides/prompting_guide_flux2>) recommends 30-80
+// words structured Subject + Action + Style + Context, with photographic
+// vocabulary (focal length, lighting direction, depth of field).
+//
+// This builder asks the bundled Qwen3.5 VLM to *look at the source* and
+// assemble such a prompt automatically, with an operation-specific system
+// prompt so the produced text matches the actual intent (replace / remove
+// / modify / outpaint). The chains call this as a strictly opt-in
+// preprocessor — when the VLM isn't loaded the call returns `nil` so the
+// caller can fall back to the user's verbatim prompt.
+
+import Foundation
+import CoreGraphics
+import FluxTextEncoders
+
+/// Build FLUX.2-style prompts from a source image using the bundled
+/// Qwen3.5 VLM. Returns `nil` whenever the VLM is not currently loaded
+/// (callers must treat this as a graceful fallback signal — never as an
+/// error).
+public enum Flux2VLMPromptBuilder {
+
+    // MARK: - System prompts (public so tests can introspect them)
+
+    /// System prompt used for `Flux2InpaintIntent.replace`. Instructs the
+    /// VLM to write a 30-80 word BFL-style prompt naming the *new*
+    /// subject, inheriting the source's photographic identity, and asking
+    /// for a shadow consistent with the existing light direction. The
+    /// removed subject is **never** named (FLUX.2 has no negatives — naming
+    /// it would re-introduce it).
+    public static let replaceSystemPrompt: String = """
+    You are a prompt engineer for FLUX.2 by Black Forest Labs. The user wants to REPLACE an existing object in an image with a different subject they will describe to you. Your job is to produce a single FLUX.2 image-generation prompt.
+
+    Look at the provided image and extract its photographic identity:
+    - camera angle and apparent height (top-down, eye-level, low ground-level…)
+    - approximate focal length feel (wide-angle, normal, telephoto)
+    - lighting direction, softness, and colour temperature; time of day
+    - surface materials around the area being replaced (asphalt, sand, grass…)
+    - dominant colour palette and depth of field
+    - overall style (naturalistic phone photo, DSLR, illustration, 3D render…)
+
+    Then assemble a single FLUX.2 prompt of 30–80 words following the structure Subject + Action + Style + Context:
+    - Subject = the user's NEW subject.
+    - Action = its pose at the position where the previous subject was, with an explicit cast shadow direction consistent with the existing lighting.
+    - Style + Context = the source's photographic identity, verbatim.
+
+    Rules:
+    - NEVER name or describe the object being replaced. Naming it would make FLUX.2 reproduce it (no negative prompts in FLUX.2).
+    - NEVER use generic suffixes like "seamlessly extend", "high quality", "8k", "masterpiece".
+    - NEVER use negative phrases ("without", "no", "not").
+    - Use specific photographic vocabulary (focal length, f-stop, light direction).
+    - Output ONLY the final prompt, on a single line. No preamble, no quotes, no explanation.
+    """
+
+    /// System prompt used for `Flux2InpaintIntent.remove`. Instructs the
+    /// VLM to describe **only the surface** that should continue under the
+    /// removed object — never naming the object itself.
+    public static let removeSystemPrompt: String = """
+    You are a prompt engineer for FLUX.2 by Black Forest Labs. The user wants to REMOVE an object from an image; nothing should replace it — the surrounding surface must simply continue. Your job is to produce a single FLUX.2 image-generation prompt that describes the surface as it would look if the object had never been there.
+
+    Look at the provided image, focusing on what is AROUND the area to be cleared (not on the object itself):
+    - the exact surface material under and around the object (asphalt grain, concrete edge, sand ripples, grass density…)
+    - continuity features that should flow through the gap (cracks, gravel scatter, shadow patterns, foliage…)
+    - lighting direction, softness, and colour temperature; time of day
+    - camera angle and apparent height, focal length feel, depth of field
+    - dominant colour palette and overall style
+
+    Assemble a single FLUX.2 prompt of 30–80 words following the structure Subject + Action + Style + Context:
+    - Subject = the surface itself (e.g., "weathered grey asphalt pavement").
+    - Action = describe its continuity ("running uninhibited from the limestone wall to the brick drain cover…").
+    - Style + Context = the source's photographic identity, verbatim.
+
+    Rules:
+    - NEVER name, describe, or hint at the object being removed. Naming it would make FLUX.2 reproduce it (no negative prompts in FLUX.2).
+    - NEVER use generic suffixes like "seamlessly extend", "high quality", "8k".
+    - NEVER use negative phrases ("without the X", "no people", "empty of").
+    - Use specific photographic vocabulary.
+    - Output ONLY the final prompt, on a single line. No preamble, no quotes, no explanation.
+    """
+
+    /// System prompt used for `Flux2InpaintIntent.modify`. Instructs the
+    /// VLM to keep the existing subject recognisable and apply the user's
+    /// modification while preserving the scene's photographic identity.
+    public static let modifySystemPrompt: String = """
+    You are a prompt engineer for FLUX.2 by Black Forest Labs. The user wants to MODIFY an existing subject in an image (change its colour, outfit, expression, accessory, etc.) while keeping it recognisable and integrated in the same scene. Your job is to produce a single FLUX.2 image-generation prompt.
+
+    Look at the provided image and capture:
+    - the existing subject's identity (species, breed, age, gender, pose…)
+    - the source's photographic identity (camera angle, focal length feel, lighting direction and colour temperature, depth of field, palette, style)
+    - the surface and immediate context where the subject sits
+
+    Assemble a single FLUX.2 prompt of 30–80 words following Subject + Action + Style + Context:
+    - Subject = the existing subject, described faithfully.
+    - Action = the subject's pose with the user's modification applied (e.g., "wearing a blue collar instead of red", "with a wide smile").
+    - Style + Context = the source's photographic identity, verbatim, including the surface and existing cast shadow.
+
+    Rules:
+    - NEVER use negative phrases ("without", "no").
+    - NEVER use generic suffixes like "seamlessly extend", "high quality", "8k".
+    - Use specific photographic vocabulary.
+    - Output ONLY the final prompt, on a single line. No preamble, no quotes, no explanation.
+    """
+
+    /// System prompt used for `Flux2InpaintIntent.changeScene`. The
+    /// mask is inverted vs the other inpaint intents: it preserves a
+    /// subject and the inpainted region is the *scene around it*.
+    /// Instructs the VLM to keep the existing subject's anatomy and
+    /// appearance verbatim, and only describe a NEW scene that
+    /// inherits the source's lighting direction so the kept subject
+    /// integrates naturally with the new context.
+    public static let changeSceneSystemPrompt: String = """
+    You are a prompt engineer for FLUX.2 by Black Forest Labs. The user wants to CHANGE THE SCENE around an existing subject in an image. The subject is preserved BY THE MASK — your prompt must describe ONLY the new scene the subject is now in. **You must NEVER name or describe the subject itself**, because FLUX.2 would then paint a duplicate of it in the inpainted region (next to the one the mask preserves) — the classic "two cats" failure mode.
+
+    Look at the provided image to capture ONLY:
+    - the source's lighting direction, softness, and colour temperature; time of day
+    - the source's camera angle, apparent height, focal length feel, depth of field
+    - the source's overall style (naturalistic phone photo, DSLR, illustration, 3D render…)
+
+    Ignore the subject completely. Do not name it, describe it, count it, or hint at it.
+
+    Assemble a single FLUX.2 prompt of 30–80 words describing the NEW SCENE the user requested, structured Subject + Action + Style + Context:
+    - Subject = the principal element of the NEW scene (e.g., "a swimming pool", "a sandy beach", "a forest clearing"). NOT the existing subject.
+    - Action = the state / activity of that scene element ("with calm turquoise water lapping at white deck tiles…").
+    - Style + Context = the source's photographic identity, verbatim (camera angle, focal length feel, lighting direction, depth of field, colour palette).
+
+    Rules:
+    - NEVER name, describe, count, or hint at the existing subject. Not "a cat", not "an animal", not "a creature", not "a figure". The mask handles it.
+    - NEVER invent accessories, outfits, gear, or props.
+    - NEVER use negative phrases ("without", "no").
+    - NEVER use generic suffixes like "seamlessly extend", "high quality", "8k".
+    - Use specific photographic vocabulary inherited from the source.
+    - Output ONLY the final prompt, on a single line. No preamble, no quotes, no explanation.
+    """
+
+    /// System prompt used by ``Flux2OutpaintingChain``. Instructs the VLM
+    /// to look at the *edges* of the kept region and describe what should
+    /// continue into the new strips, preserving the source's
+    /// photographic identity.
+    public static let outpaintSystemPrompt: String = """
+    You are a prompt engineer for FLUX.2 by Black Forest Labs. The user wants to OUTPAINT an image — extend it on one or more sides — and will tell you which sides are being extended and what they want there. Your job is to produce a single FLUX.2 image-generation prompt that describes the FULL extended scene so the new strips continue the kept region naturally.
+
+    Look at the provided image, paying attention to what is visible at the EDGES the user is extending:
+    - the materials and scene elements at each active edge (sky, foliage, walls, sand, water, perspective lines…)
+    - the source's photographic identity (camera angle and apparent height, focal length feel, lighting direction and colour temperature, depth of field, colour palette, overall style)
+    - any horizon line, vanishing point, or recurring pattern that must continue
+
+    Assemble a single FLUX.2 prompt of 30–80 words following Subject + Action + Style + Context, describing the COMPLETE extended scene. Be specific about what continues into each newly added side, and how it relates to the kept region. Preserve the source's lighting direction, colour temperature, focal length feel, depth of field, and style verbatim.
+
+    Rules:
+    - NEVER use generic suffixes like "seamlessly extend and complete the image" — they leak into FLUX.2's output and add nothing.
+    - NEVER use negative phrases ("without", "no").
+    - Use specific photographic vocabulary.
+    - Output ONLY the final prompt, on a single line. No preamble, no quotes, no explanation.
+    """
+
+    // MARK: - Public builders
+
+    /// Build a FLUX.2 inpainting prompt by asking the VLM to look at
+    /// `source` and combine the user's instruction with the source's
+    /// photographic identity, using the system prompt for `intent`.
+    ///
+    /// - Parameters:
+    ///   - source: The image being inpainted.
+    ///   - userInstruction: What the user typed (e.g.,
+    ///     `"replace the cat with a duck"`, `"remove the person"`). Can
+    ///     be empty for `.remove` since the VLM ignores it anyway.
+    ///   - intent: Drives system prompt selection. See
+    ///     ``Flux2InpaintIntent``.
+    /// - Returns: A 30-80 word FLUX.2 prompt, or `nil` when the VLM is
+    ///   not loaded (the caller falls back to `userInstruction` verbatim).
+    /// - Throws: Whatever the VLM throws at runtime (token sampling
+    ///   failure, malformed input). Never throws to signal
+    ///   "VLM unavailable" — that case returns `nil`.
+    public static func buildInpaintPrompt(
+        source: CGImage,
+        userInstruction: String,
+        intent: Flux2InpaintIntent
+    ) async throws -> String? {
+        guard FluxTextEncoders.shared.isQwen35VLMLoaded else { return nil }
+
+        let systemPrompt: String
+        switch intent {
+        case .replace:     systemPrompt = replaceSystemPrompt
+        case .remove:      systemPrompt = removeSystemPrompt
+        case .modify:      systemPrompt = modifySystemPrompt
+        case .changeScene: systemPrompt = changeSceneSystemPrompt
+        }
+        let userMessage = userMessage(forInpaint: intent, instruction: userInstruction)
+
+        let result = try FluxTextEncoders.shared.analyzeImageWithQwen35(
+            image: source,
+            prompt: userMessage,
+            systemPrompt: systemPrompt,
+            enableThinking: false,
+            maxTokens: 220,
+            temperature: 0
+        )
+        return cleanFinalPrompt(result.text)
+    }
+
+    /// Build a FLUX.2 outpainting prompt. The VLM looks at the source and
+    /// the list of sides being extended, then produces a 30-80 word BFL
+    /// prompt describing the full extended scene with continuity.
+    ///
+    /// - Parameters:
+    ///   - source: The image being extended.
+    ///   - userInstruction: The user's description of what should appear
+    ///     in the extensions (e.g., `"a sunset desert horizon on the right"`).
+    ///     Can be empty — the VLM defaults to coherent continuation.
+    ///   - sides: Which canvas sides are being extended (non-empty).
+    /// - Returns: A 30-80 word FLUX.2 prompt, or `nil` when the VLM is
+    ///   not loaded.
+    /// - Throws: VLM runtime errors only.
+    public static func buildOutpaintPrompt(
+        source: CGImage,
+        userInstruction: String,
+        sides: Set<OutpaintSide>
+    ) async throws -> String? {
+        guard FluxTextEncoders.shared.isQwen35VLMLoaded else { return nil }
+        guard !sides.isEmpty else { return nil }
+
+        let userMessage = userMessage(forOutpaintSides: sides, instruction: userInstruction)
+
+        let result = try FluxTextEncoders.shared.analyzeImageWithQwen35(
+            image: source,
+            prompt: userMessage,
+            systemPrompt: outpaintSystemPrompt,
+            enableThinking: false,
+            maxTokens: 220,
+            temperature: 0
+        )
+        return cleanFinalPrompt(result.text)
+    }
+
+    // MARK: - User message assembly (exposed for tests)
+
+    /// Compose the user-turn message for an inpaint request. The system
+    /// prompt teaches the VLM the rules; this message carries the
+    /// per-request payload (intent reminder + user instruction).
+    public static func userMessage(forInpaint intent: Flux2InpaintIntent, instruction: String) -> String {
+        let trimmed = instruction.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch intent {
+        case .replace:
+            if trimmed.isEmpty {
+                return "Replace the main subject in the masked region. Produce the FLUX.2 prompt now."
+            }
+            return "User's new subject: \(trimmed). Produce the FLUX.2 prompt now."
+        case .remove:
+            // For .remove the user's instruction (if any) tells us WHICH
+            // object to remove — but we must not echo that name in the
+            // produced prompt. We pass it as context only.
+            if trimmed.isEmpty {
+                return "Describe the surface that should continue under the masked region, with no subject in it. Produce the FLUX.2 prompt now."
+            }
+            return "The user wants to remove this from the masked region: \(trimmed). Do NOT name it in your output. Describe the surface that should continue in its place. Produce the FLUX.2 prompt now."
+        case .modify:
+            if trimmed.isEmpty {
+                return "Keep the existing subject and adjust it slightly to better match the scene. Produce the FLUX.2 prompt now."
+            }
+            return "User's modification to apply to the existing subject: \(trimmed). Keep the subject recognisable. Produce the FLUX.2 prompt now."
+        case .changeScene:
+            if trimmed.isEmpty {
+                return "Describe a coherent new scene that inherits the source's lighting and camera. Do NOT name or describe the existing subject in the image — the mask preserves it; mentioning it would make FLUX paint a duplicate next to it. Produce the FLUX.2 prompt now."
+            }
+            return "User's NEW SCENE (the existing subject is preserved by the mask — do NOT name or describe it in your output, or FLUX will paint a duplicate): \(trimmed). Produce the FLUX.2 prompt now."
+        }
+    }
+
+    /// Compose the user-turn message for an outpaint request. Lists the
+    /// active sides explicitly so the VLM focuses on the right edges.
+    public static func userMessage(forOutpaintSides sides: Set<OutpaintSide>, instruction: String) -> String {
+        // Deterministic ordering for reproducibility.
+        let ordered = OutpaintSide.allCases.filter { sides.contains($0) }
+        let sidesList = ordered.map(\.rawValue).joined(separator: ", ")
+        let trimmed = instruction.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            return "Sides to extend: \(sidesList). Continue the scene coherently on those sides. Produce the FLUX.2 prompt now."
+        }
+        return "Sides to extend: \(sidesList). User wants in the extensions: \(trimmed). Produce the FLUX.2 prompt now."
+    }
+
+    // MARK: - Output cleanup
+
+    /// Strip whitespace and one surrounding pair of quotes if present.
+    /// Small models occasionally wrap the prompt in quotes despite the
+    /// system prompt saying not to; we remove them so the FLUX.2 text
+    /// encoder doesn't ingest them. Mismatched leftover quotes inside
+    /// the prompt (e.g., a quoted brand name) are left alone.
+    internal static func cleanFinalPrompt(_ raw: String) -> String {
+        var s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Symmetric pairs: (opening, closing). Typographic pairs use
+        // distinct characters so a single-character check would miss
+        // them. Order matters: try the longest/most-specific first
+        // (though all of these are single grapheme clusters in practice).
+        let pairs: [(open: String, close: String)] = [
+            ("\"", "\""),
+            ("'", "'"),
+            ("“", "”"),
+            ("‘", "’"),
+            ("«", "»"),
+        ]
+        for (open, close) in pairs {
+            if s.hasPrefix(open) && s.hasSuffix(close) && s.count > open.count + close.count {
+                s = String(s.dropFirst(open.count).dropLast(close.count))
+                break
+            }
+        }
+        return s.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+/// Identifies one of the four canvas sides that an outpainting chain may
+/// extend. Used by ``Flux2VLMPromptBuilder/buildOutpaintPrompt(source:userInstruction:sides:)``
+/// to tell the VLM which edges of the source matter for continuity.
+public enum OutpaintSide: String, Sendable, CaseIterable, Codable {
+    case top
+    case bottom
+    case left
+    case right
+}

--- a/Tests/Flux2ChainsTests/Flux2MaskedInpaintingChainTests.swift
+++ b/Tests/Flux2ChainsTests/Flux2MaskedInpaintingChainTests.swift
@@ -34,6 +34,10 @@ final class Flux2MaskedInpaintingChainTests: XCTestCase {
                        "Auto I2I conditioning is OFF by default — feeding the source as ref bleeds the to-be-replaced subject into the result via attention. Enable only for repair / scene-extension.")
         XCTAssertFalse(chain.upsamplePrompt,
                        "Default off — caller's wording wins unless they explicitly opt into VLM rewriting")
+        XCTAssertFalse(chain.enrichPromptWithVLM,
+                       "Default off — VLM enrichment is strictly opt-in so the chain is usable without the VLM loaded")
+        XCTAssertEqual(chain.intent, .replace,
+                       "Default intent is .replace (most common case: swap object X for Y). Only meaningful when enrichPromptWithVLM is true.")
     }
 
     func testInitForwardsExplicitArguments() {
@@ -52,6 +56,8 @@ final class Flux2MaskedInpaintingChainTests: XCTestCase {
             guidance: 3.5,
             seed: 1234,
             upsamplePrompt: true,
+            enrichPromptWithVLM: true,
+            intent: .remove,
             maxPixels: 2_400_000
         )
         XCTAssertEqual(chain.prompt, "hello")
@@ -62,6 +68,8 @@ final class Flux2MaskedInpaintingChainTests: XCTestCase {
         XCTAssertEqual(chain.referenceImages?.count, 2)
         XCTAssertTrue(chain.useImageAsReference)
         XCTAssertTrue(chain.upsamplePrompt)
+        XCTAssertTrue(chain.enrichPromptWithVLM)
+        XCTAssertEqual(chain.intent, .remove)
     }
 
     func testMaskConventionDefaultsToGrayscale() {

--- a/Tests/Flux2ChainsTests/Flux2OutpaintingChainTests.swift
+++ b/Tests/Flux2ChainsTests/Flux2OutpaintingChainTests.swift
@@ -243,6 +243,7 @@ final class Flux2OutpaintingChainTests: XCTestCase {
             prompt: "hello",
             steps: 7, guidance: 2.5, seed: 99,
             upsamplePrompt: true,
+            enrichPromptWithVLM: true,
             transitionPixels: 16, maxPixels: 500_000
         )
         XCTAssertEqual(chain.top, 16)
@@ -254,6 +255,7 @@ final class Flux2OutpaintingChainTests: XCTestCase {
         XCTAssertEqual(chain.guidance, 2.5)
         XCTAssertEqual(chain.seed, 99)
         XCTAssertTrue(chain.upsamplePrompt)
+        XCTAssertTrue(chain.enrichPromptWithVLM)
         XCTAssertEqual(chain.transitionPixels, 16)
         XCTAssertEqual(chain.maxPixels, 500_000)
     }
@@ -264,6 +266,14 @@ final class Flux2OutpaintingChainTests: XCTestCase {
         let chain = Flux2OutpaintingChain(pipeline: pipeline, image: img, prompt: "x")
         XCTAssertFalse(chain.upsamplePrompt,
                        "Off by default — caller's exact wording is preserved unless they opt in")
+    }
+
+    func testEnrichPromptWithVLMDefaultsOff() {
+        let pipeline = Flux2Pipeline(model: .klein9B)
+        let img = makeSolidImage(width: 32, height: 32, value: 50)
+        let chain = Flux2OutpaintingChain(pipeline: pipeline, image: img, prompt: "x")
+        XCTAssertFalse(chain.enrichPromptWithVLM,
+                       "Off by default — VLM enrichment is strictly opt-in so the chain runs without the VLM loaded")
     }
 
     // MARK: - Helpers

--- a/Tests/Flux2ChainsTests/Flux2SubjectMaskTests.swift
+++ b/Tests/Flux2ChainsTests/Flux2SubjectMaskTests.swift
@@ -1,0 +1,120 @@
+// Flux2SubjectMaskTests.swift — Tests for the auto-segmentation helper
+// Copyright 2025 Vincent Gourbin
+//
+// We cover the parts that don't require Vision to detect a subject
+// (which would need a bundled real-world test image and an OS that
+// agrees with us on what counts as a foreground). The Vision pipeline
+// itself is Apple-tested. What we want pinned here:
+//   - The downscale helper's no-op vs scaling boundaries (correctness
+//     matters for the `targetMaxPixels` opt-in — wrong scale ⇒ caller's
+//     mask is at the wrong resolution and won't align with the source).
+//   - The public API rejects subject-less inputs cleanly with
+//     `noSubjectDetected` (the documented contract).
+
+import XCTest
+@testable import Flux2Chains
+import CoreGraphics
+
+final class Flux2SubjectMaskTests: XCTestCase {
+
+    // MARK: - downscaledIfNeeded
+
+    func testDownscaleReturnsNilWhenTargetIsNil() {
+        let img = makeSolidImage(width: 100, height: 100, value: 128)
+        XCTAssertNil(
+            Flux2SubjectMask.downscaledIfNeeded(img, targetMaxPixels: nil),
+            "nil target ⇒ no-op; caller keeps the original image"
+        )
+    }
+
+    func testDownscaleReturnsNilWhenSourceAlreadyFits() {
+        let img = makeSolidImage(width: 100, height: 100, value: 128)
+        XCTAssertNil(
+            Flux2SubjectMask.downscaledIfNeeded(img, targetMaxPixels: 100 * 100),
+            "Source already at target pixel count ⇒ no-op (cheaper than a needless re-render)"
+        )
+        XCTAssertNil(
+            Flux2SubjectMask.downscaledIfNeeded(img, targetMaxPixels: 200_000),
+            "Source smaller than target ⇒ no-op"
+        )
+    }
+
+    func testDownscalePreservesAspectRatio() throws {
+        // 4:3 source, large enough to require scaling.
+        let src = makeSolidImage(width: 4000, height: 3000, value: 128)
+        let target = 100_000  // ~316² square equivalent ⇒ should give ~365×274
+        let scaled = try XCTUnwrap(Flux2SubjectMask.downscaledIfNeeded(src, targetMaxPixels: target))
+        // Total pixels should fit (Lanczos may round so allow a small overshoot).
+        XCTAssertLessThanOrEqual(
+            scaled.width * scaled.height,
+            target + max(scaled.width, scaled.height),
+            "Output pixel count must be ≤ target (within one row/col of rounding)"
+        )
+        // Aspect ratio should match within 1% (Lanczos rounding tolerance).
+        let inputAspect = 4000.0 / 3000.0
+        let outputAspect = Double(scaled.width) / Double(scaled.height)
+        XCTAssertEqual(inputAspect, outputAspect, accuracy: 0.02,
+                       "Aspect ratio must survive the Lanczos resample")
+    }
+
+    func testDownscaleHandlesPortraitOrientation() throws {
+        // 3:4 portrait (iPhone Photos default), 24 MP.
+        let src = makeSolidImage(width: 4284, height: 5712, value: 200)
+        let scaled = try XCTUnwrap(
+            Flux2SubjectMask.downscaledIfNeeded(src, targetMaxPixels: 1024 * 1024)
+        )
+        // Both dimensions should shrink.
+        XCTAssertLessThan(scaled.width, src.width)
+        XCTAssertLessThan(scaled.height, src.height)
+        // And the result should respect the cap (with one-row tolerance).
+        XCTAssertLessThanOrEqual(
+            scaled.width * scaled.height,
+            1024 * 1024 + max(scaled.width, scaled.height)
+        )
+    }
+
+    // MARK: - makeChangeSceneMask error path
+
+    @available(macOS 14.0, *)
+    func testMakeChangeSceneMaskThrowsNoSubjectOnSolidImage() {
+        // A solid grey image has no foreground subject — Vision should
+        // return an empty observation set. The helper must surface that
+        // as the documented `.noSubjectDetected` error rather than
+        // crashing or returning a meaningless mask.
+        let img = makeSolidImage(width: 256, height: 256, value: 128)
+        do {
+            _ = try Flux2SubjectMask.makeChangeSceneMask(from: img)
+            XCTFail("Expected Flux2SubjectMask.Error.noSubjectDetected on a solid grey image")
+        } catch Flux2SubjectMask.Error.noSubjectDetected {
+            // ok
+        } catch {
+            // Vision occasionally returns a transient request failure on
+            // CI (e.g. simulator without GPU). Accept that too — the
+            // important invariant is that we don't return a mask.
+            if case Flux2SubjectMask.Error.visionFailure = error {
+                // ok
+            } else {
+                XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeSolidImage(width: Int, height: Int, value: UInt8) -> CGImage {
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        for i in stride(from: 0, to: pixels.count, by: 4) {
+            pixels[i] = value
+            pixels[i + 1] = value
+            pixels[i + 2] = value
+            pixels[i + 3] = 255
+        }
+        let cs = CGColorSpaceCreateDeviceRGB()
+        let ctx = CGContext(
+            data: &pixels, width: width, height: height,
+            bitsPerComponent: 8, bytesPerRow: width * 4, space: cs,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        return ctx.makeImage()!
+    }
+}

--- a/Tests/Flux2ChainsTests/Flux2VLMPromptBuilderTests.swift
+++ b/Tests/Flux2ChainsTests/Flux2VLMPromptBuilderTests.swift
@@ -1,0 +1,206 @@
+// Flux2VLMPromptBuilderTests.swift — Public-surface tests for the VLM prompt builder
+// Copyright 2025 Vincent Gourbin
+//
+// The actual VLM-driven prompt assembly is not covered here — it requires
+// the Qwen3.5 VLM weights to be present and would make the test target
+// model-dependent. Instead we exercise:
+// - the graceful nil fallback when the VLM is not loaded (the load-bearing
+//   "VLM is never required" contract from the chain APIs);
+// - the system-prompt rules that anyone reviewing this PR should be able
+//   to see at a glance (no negatives, no generic suffixes, BFL structure);
+// - the user-message assembly (which is pure-Swift and operation-specific);
+// - the output cleaner (quotes / whitespace stripping).
+
+import XCTest
+@testable import Flux2Chains
+import CoreGraphics
+
+final class Flux2VLMPromptBuilderTests: XCTestCase {
+
+    // MARK: - Fallback contract
+
+    func testInpaintBuilderReturnsNilWhenVLMNotLoaded() async throws {
+        // The VLM service is a singleton; in the test environment it's
+        // never loaded. The builder must therefore return nil — that's
+        // the signal callers use to fall back to the verbatim prompt.
+        let img = solidImage(width: 32, height: 32)
+        let out = try await Flux2VLMPromptBuilder.buildInpaintPrompt(
+            source: img,
+            userInstruction: "replace the cat with a duck",
+            intent: .replace
+        )
+        XCTAssertNil(out, "Builder must return nil when the Qwen3.5 VLM is not loaded — never throw, never auto-load.")
+    }
+
+    func testOutpaintBuilderReturnsNilWhenVLMNotLoaded() async throws {
+        let img = solidImage(width: 32, height: 32)
+        let out = try await Flux2VLMPromptBuilder.buildOutpaintPrompt(
+            source: img,
+            userInstruction: "extend with a sunset desert",
+            sides: [.left, .right]
+        )
+        XCTAssertNil(out)
+    }
+
+    func testOutpaintBuilderReturnsNilWhenSidesEmpty() async throws {
+        let img = solidImage(width: 32, height: 32)
+        let out = try await Flux2VLMPromptBuilder.buildOutpaintPrompt(
+            source: img,
+            userInstruction: "extend",
+            sides: []
+        )
+        XCTAssertNil(out, "No active sides ⇒ no-op (caller should not even call the builder).")
+    }
+
+    // MARK: - System prompt invariants
+
+    func testSystemPromptsHonourBFLRules() {
+        // Every system prompt must forbid negatives and generic suffixes
+        // and must lock the output to a single prompt with no preamble.
+        // These are the rules the BFL guide enforces — regressions here
+        // would silently make the produced prompts worse without
+        // breaking any test, so we pin them in.
+        let prompts: [(String, String)] = [
+            ("replace",     Flux2VLMPromptBuilder.replaceSystemPrompt),
+            ("remove",      Flux2VLMPromptBuilder.removeSystemPrompt),
+            ("modify",      Flux2VLMPromptBuilder.modifySystemPrompt),
+            ("changeScene", Flux2VLMPromptBuilder.changeSceneSystemPrompt),
+            ("outpaint",    Flux2VLMPromptBuilder.outpaintSystemPrompt),
+        ]
+        for (name, p) in prompts {
+            XCTAssertTrue(p.contains("FLUX.2"), "[\(name)] must mention FLUX.2 — the model name primes the assistant for the right output style")
+            XCTAssertTrue(p.contains("Subject + Action + Style + Context"), "[\(name)] must enforce the BFL structure")
+            XCTAssertTrue(p.contains("30–80") || p.contains("30-80"), "[\(name)] must enforce the 30-80 word target from the BFL guide")
+            XCTAssertTrue(p.lowercased().contains("never use generic suffixes") || p.lowercased().contains("no generic suffixes"), "[\(name)] must forbid generic suffixes like 'seamlessly extend'")
+            XCTAssertTrue(p.lowercased().contains("never use negative phrases") || p.lowercased().contains("no negative"), "[\(name)] must forbid negative phrasing (FLUX.2 has no negatives)")
+            XCTAssertTrue(p.lowercased().contains("output only"), "[\(name)] must lock the output to a single prompt — small models otherwise emit preambles")
+        }
+    }
+
+    func testRemoveSystemPromptForbidsNamingTheObject() {
+        // This is the load-bearing rule for the `.remove` case — naming
+        // the object would make FLUX.2 reproduce it. If this string ever
+        // drifts away, the regression won't surface until a user
+        // notices the object reappearing.
+        let p = Flux2VLMPromptBuilder.removeSystemPrompt.lowercased()
+        XCTAssertTrue(
+            p.contains("never name") || p.contains("do not name") || p.contains("never mention"),
+            "remove system prompt must explicitly forbid naming the object being removed"
+        )
+    }
+
+    // MARK: - User-message assembly (pure Swift, deterministic)
+
+    func testReplaceUserMessageEchoesUserInstruction() {
+        let msg = Flux2VLMPromptBuilder.userMessage(forInpaint: .replace, instruction: "a mallard duck")
+        XCTAssertTrue(msg.contains("a mallard duck"))
+    }
+
+    func testRemoveUserMessageDoesNotAskVLMToEcho() {
+        // For `.remove` the user's text (the object to remove) is passed
+        // as context but the message instructs the VLM not to echo it.
+        let msg = Flux2VLMPromptBuilder.userMessage(forInpaint: .remove, instruction: "the tabby cat")
+        XCTAssertTrue(msg.contains("the tabby cat"), "Must pass the user's text as context so the VLM knows WHAT to ignore")
+        XCTAssertTrue(msg.contains("Do NOT name it"), "Must instruct the VLM not to mention the removed subject in its output")
+    }
+
+    func testChangeSceneSystemPromptForbidsInventingAccessories() {
+        // Load-bearing: `.modify` on a "put cat at the pool" prompt
+        // hallucinated an "orange life vest" the user never asked for.
+        // `.changeScene` must explicitly forbid that pattern.
+        let p = Flux2VLMPromptBuilder.changeSceneSystemPrompt.lowercased()
+        XCTAssertTrue(
+            p.contains("never invent accessories"),
+            "changeScene must forbid inventing accessories/outfits the user did not request"
+        )
+    }
+
+    func testChangeSceneSystemPromptForbidsNamingTheSubject() {
+        // Load-bearing — pinned in 2026-05-29 after the "two cats"
+        // failure mode: when the prompt describes the preserved
+        // subject, FLUX paints a duplicate next to the one the mask
+        // preserved. The system prompt must explicitly forbid this.
+        let p = Flux2VLMPromptBuilder.changeSceneSystemPrompt.lowercased()
+        XCTAssertTrue(
+            p.contains("never name or describe the subject")
+            || p.contains("never name, describe, count, or hint at the existing subject")
+            || p.contains("ignore the subject completely"),
+            "changeScene must explicitly forbid naming the preserved subject — otherwise FLUX paints a duplicate"
+        )
+    }
+
+    func testChangeSceneUserMessageReinforcesNoSubjectMention() {
+        let msg = Flux2VLMPromptBuilder.userMessage(forInpaint: .changeScene, instruction: "at a swimming pool")
+        XCTAssertTrue(msg.contains("at a swimming pool"))
+        XCTAssertTrue(
+            msg.lowercased().contains("do not name or describe"),
+            "User message must reinforce the no-subject-mention rule alongside the system prompt"
+        )
+    }
+
+    func testModifyUserMessageDescribesTheModification() {
+        let msg = Flux2VLMPromptBuilder.userMessage(forInpaint: .modify, instruction: "blue collar instead of red")
+        XCTAssertTrue(msg.contains("blue collar instead of red"))
+        XCTAssertTrue(msg.lowercased().contains("keep the subject"), "Must remind the VLM to preserve the subject's identity")
+    }
+
+    func testReplaceUserMessageHandlesEmptyInstruction() {
+        let msg = Flux2VLMPromptBuilder.userMessage(forInpaint: .replace, instruction: "   ")
+        XCTAssertFalse(msg.isEmpty, "Empty/whitespace instruction must still produce a usable message")
+        XCTAssertTrue(msg.lowercased().contains("replace"))
+    }
+
+    func testOutpaintUserMessageListsSidesDeterministically() {
+        // Set<OutpaintSide> doesn't have a guaranteed iteration order;
+        // the builder must serialise them in the enum's declaration order
+        // so two callers with the same logical input get the same output
+        // (reproducibility matters for caching, debugging, snapshot tests).
+        let m1 = Flux2VLMPromptBuilder.userMessage(forOutpaintSides: [.right, .top], instruction: "x")
+        let m2 = Flux2VLMPromptBuilder.userMessage(forOutpaintSides: [.top, .right], instruction: "x")
+        XCTAssertEqual(m1, m2)
+        // Top declared before right in the enum.
+        let topIdx = m1.range(of: "top")!.lowerBound
+        let rightIdx = m1.range(of: "right")!.lowerBound
+        XCTAssertLessThan(topIdx, rightIdx, "Sides must be serialised in OutpaintSide.allCases order")
+    }
+
+    func testOutpaintUserMessageHandlesEmptyInstruction() {
+        let msg = Flux2VLMPromptBuilder.userMessage(forOutpaintSides: [.left], instruction: "")
+        XCTAssertFalse(msg.isEmpty)
+        XCTAssertTrue(msg.contains("left"))
+    }
+
+    // MARK: - Output cleaner
+
+    func testCleanFinalPromptStripsWhitespace() {
+        XCTAssertEqual(Flux2VLMPromptBuilder.cleanFinalPrompt("  hello  \n"), "hello")
+    }
+
+    func testCleanFinalPromptStripsMatchingQuotes() {
+        XCTAssertEqual(Flux2VLMPromptBuilder.cleanFinalPrompt("\"hello\""), "hello")
+        XCTAssertEqual(Flux2VLMPromptBuilder.cleanFinalPrompt("“hello”"), "hello")
+        XCTAssertEqual(Flux2VLMPromptBuilder.cleanFinalPrompt("'hello'"), "hello")
+    }
+
+    func testCleanFinalPromptLeavesMismatchedQuotesAlone() {
+        // Don't accidentally remove an opening quote that's part of a
+        // legitimate output (e.g., a quoted brand inside the prompt).
+        XCTAssertEqual(Flux2VLMPromptBuilder.cleanFinalPrompt("a sign reading \"OPEN\""), "a sign reading \"OPEN\"")
+    }
+
+    // MARK: - Helpers
+
+    private func solidImage(width: Int, height: Int, value: UInt8 = 128) -> CGImage {
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        for i in stride(from: 0, to: pixels.count, by: 4) {
+            pixels[i] = value; pixels[i + 1] = value; pixels[i + 2] = value; pixels[i + 3] = 255
+        }
+        let cs = CGColorSpaceCreateDeviceRGB()
+        let ctx = CGContext(
+            data: &pixels, width: width, height: height,
+            bitsPerComponent: 8, bytesPerRow: width * 4, space: cs,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        return ctx.makeImage()!
+    }
+}


### PR DESCRIPTION
## Summary

Strictly opt-in image-aware prompt rewriting for `Flux2MaskedInpaintingChain` and `Flux2OutpaintingChain`, plus a Vision-based auto-segmentation helper that makes the "swap background, keep subject" workflow viable.

The pre-existing chain behaviour is preserved byte-identically — every new feature is gated behind an explicit opt-in flag, the VLM is never required, and `Flux2Pipeline.generate*` is untouched.

## What's new

### VLM prompt enrichment
- `enrichPromptWithVLM: Bool = false` on both chains. When set + the Qwen3.5 VLM is loaded, the bundled VLM looks at the source image and rewrites the user's prompt into a 30-80 word BFL-style prompt that inherits the source's photographic identity (camera angle, lighting direction, surface materials, palette, depth of field).
- Pre-existing `upsamplePrompt` (text-encoder path) preserved as-is. When both flags are true, the VLM wins with a warning.
- When the VLM is not loaded → warning + verbatim-prompt fallback. Never throws, never auto-loads.

### `Flux2InpaintIntent` enum
Four cases with operation-specific system prompts because the prompting rules genuinely diverge:

| intent | what the VLM is told to do |
|---|---|
| `.replace` | name the new subject, inherit scene's camera/light, never name the removed object |
| `.remove` | describe only the surface continuity, never name the removed object |
| `.modify` | keep subject recognisable, apply user's change, no inventing accessories |
| `.changeScene` | mask preserves subject — describe ONLY the new scene, never name the subject (else FLUX paints a duplicate) |

### `Flux2SubjectMask` (Vision-based auto-segmentation)
- `Flux2SubjectMask.makeChangeSceneMask(from:edgeSoftnessPixels:)` wraps `VNGenerateForegroundInstanceMaskRequest` to produce a pixel-accurate Flux-convention mask (BLACK = subject, WHITE = inpaint).
- Required for `.changeScene`: hand-drawn blob masks let the subject's anatomy extend into the soft ramp, where RePaint partially repaints limbs and FLUX invents a chimera (verified failure mode).

### CLI surface
- `flux2 inpaint --enrich-prompt-with-vlm --intent {replace,remove,modify,change-scene} --qwen35-variant {8bit,4bit}`
- `flux2 outpaint --enrich-prompt-with-vlm --qwen35-variant {8bit,4bit}`
- `flux2 mask-subject -i source.png -o mask.png [--edge-softness-pixels N]`

`--qwen35-variant` downloads + loads the VLM in-process so a single CLI invocation suffices for benchmarking. The chains themselves never auto-load — the caller owns the lifecycle.

## E2E validation

Benchmarked on a cat-photo regression set against FluxForge Studio baseline outputs:

- **cat → duck** (`.replace`): dramatic improvement vs baseline — duck inherits the scene's midday lighting + cast-shadow direction, sits on the actual asphalt with no hallucinated water puddle. VLM-produced prompt visible in logs.
- **cat at the pool** (`.changeScene` + auto-mask + scene-only prompt): single coherent cat at the pool deck, vs the baseline's cat-floating-in-water composition. Required all three levers — the auto-mask alone, intent alone, or prompt change alone weren't enough.

## Test plan

- [ ] `xcodebuild test -scheme Flux2Swift-Package -destination 'platform=macOS' -only-testing:Flux2ChainsTests` — 48 tests pass (16 new on the VLM prompt builder, 5 covering the no-subject-mention rule on `.changeScene`).
- [ ] Existing inpaint workflows (`--upsample-prompt`, hand-drawn mask, T2I/I2I) behave identically — verified manually.
- [ ] `flux2 mask-subject` produces a clean black-on-white mask on the cat sample.
- [ ] `flux2 inpaint --enrich-prompt-with-vlm --intent replace` end-to-end run on the cat sample produces a duck with correct shadow and material continuity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)