### PR TITLE
fix(training): update ResumableAdamW for MLX optimizer API

### DIFF
--- a/Sources/Flux2Core/Training/Optimizer/ResumableAdamW.swift
+++ b/Sources/Flux2Core/Training/Optimizer/ResumableAdamW.swift
@@ -18,17 +18,24 @@ public final class ResumableAdamW: AdamW, ResumableOptimizer {
         learningRate: Float,
         betas: (Float, Float) = (0.9, 0.999),
         eps: Float = 1e-8,
-        weightDecay: Float = 0.01
+        weightDecay: Float = 0.01,
+        biasCorrection: Bool = false
     ) {
-        super.init(learningRate: learningRate, betas: betas, eps: eps, weightDecay: weightDecay)
+        super.init(
+            learningRate: learningRate,
+            betas: betas,
+            eps: eps,
+            weightDecay: weightDecay,
+            biasCorrection: biasCorrection
+        )
     }
 
     /// Override update to track step count
     public override func applySingle(
         gradient: MLXArray,
         parameter: MLXArray,
-        state: TupleState
-    ) -> (MLXArray, TupleState) {
+        state: AdamState
+    ) -> (MLXArray, AdamState) {
         step += 1
         return super.applySingle(gradient: gradient, parameter: parameter, state: state)
     }


### PR DESCRIPTION
## Summary
- Update `ResumableAdamW` to match the current `MLXOptimizers.AdamW` initializer signature.
- Forward the `biasCorrection` argument and use `AdamState` in `applySingle`.
- Keep the existing resume step tracking behavior unchanged.

## Test plan
- `ReadLints` on `Sources/Flux2Core/Training/Optimizer/ResumableAdamW.swift`: passed.
- `swift build --product Flux2App`: passed.


Made with [Cursor](https://cursor.com)