### PR TITLE
test(vae): fix stale default VAEVariant assertion

### DIFF
--- a/Tests/Flux2CoreTests/SmallDecoderVAETests.swift
+++ b/Tests/Flux2CoreTests/SmallDecoderVAETests.swift
@@ -440,7 +440,8 @@ final class PipelineVAEVariantTests: XCTestCase {
 
     func testPipelineDefaultVAEVariant() {
         let pipeline = Flux2Pipeline(model: .klein4B, quantization: .balanced)
-        XCTAssertEqual(pipeline.vaeVariant, .standard)
+        // Default is .smallDecoder since dce6fc5 ("Default vaeVariant to .smallDecoder across SDK and CLI")
+        XCTAssertEqual(pipeline.vaeVariant, .smallDecoder)
     }
 
     func testPipelineSmallDecoderVariant() {


### PR DESCRIPTION
## Summary
- `PipelineVAEVariantTests.testPipelineDefaultVAEVariant` asserted the default `vaeVariant` was `.standard`, but the default was intentionally changed to `.smallDecoder` in dce6fc5 ("Default vaeVariant to .smallDecoder across SDK and CLI").
- This was the single pre-existing failure in `Flux2CoreTests` (surfaced while reviewing #95). Updates the assertion to `.smallDecoder` to match the shipped default.

## Test plan
- `xcodebuild test -scheme Flux2Swift-Package -destination 'platform=macOS' -only-testing:Flux2CoreTests/PipelineVAEVariantTests` → 3/3 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)