### PR TITLE
chore(deps): pin mlx-swift to exact 0.31.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,9 @@ let package = Package(
         .executable(name: "Flux2App", targets: ["Flux2App"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/ml-explore/mlx-swift", from: "0.30.2"),
+        // Pinned exactly: mlx-swift introduces breaking API changes even in patch
+        // releases (e.g. AdamW TupleState -> AdamState in 0.31.4). Bump deliberately.
+        .package(url: "https://github.com/ml-explore/mlx-swift", exact: "0.31.4"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0"),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
         .package(url: "https://github.com/jpsim/Yams", from: "5.1.0"),


### PR DESCRIPTION
## Summary
- Pin `mlx-swift` to `exact: "0.31.4"` instead of `from: "0.30.2"`.
- mlx-swift introduces breaking API changes even in patch releases — `AdamW` switched from `TupleState` to `AdamState` + `biasCorrection` in 0.31.4, which is exactly what broke the build behind #95. Because `Package.resolved` is gitignored, the floating `from:` constraint let fresh clones / CI resolve a newer, source-incompatible version silently.
- Pinning exactly makes mlx-swift bumps deliberate (and reviewable), preventing another break-on-resolve PR of this type.

## Test plan
- `swift package resolve` → resolves mlx-swift 0.31.4, no conflict with swift-mlx-profiler.
- `swift build --product Flux2Core` → builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)