### PR TITLE
feat(pipeline): reference-encode budget as a framework policy

### DIFF
--- a/Sources/Flux2CLI/Flux2CLI.swift
+++ b/Sources/Flux2CLI/Flux2CLI.swift
@@ -404,6 +404,9 @@ struct ImageToImage: AsyncParsableCommand {
     @Option(name: .shortAndLong, help: "Output image height (default: from first reference image)")
     var height: Int?
 
+    @Option(name: .long, help: "Max VAE encode budget per reference image, in megapixels (1 MP = 1024×1024; default 1.0). Raise for higher-fidelity conditioning at the cost of memory; e.g. 4.0 ≈ 2048².")
+    var maxReferenceMegapixels: Double?
+
     @Flag(name: .long, help: "Enhance prompt with visual details using Mistral before encoding")
     var upsamplePrompt: Bool = false
 
@@ -653,6 +656,12 @@ struct ImageToImage: AsyncParsableCommand {
             checkpointDir = nil
         }
 
+        // Reference-encode budget policy: framework owns the mechanism (a per-image
+        // pixel ceiling); the CLI just maps the user-facing megapixel flag to pixels.
+        // 1 MP == 1024×1024, so the default resolves to the historical 1024² budget.
+        let maxReferencePixels = maxReferenceMegapixels
+            .map { max(32 * 32, Int(($0 * 1024 * 1024).rounded())) } ?? (1024 * 1024)
+
         let image = try await pipeline.generateImageToImage(
             prompt: prompt,
             images: refImages,
@@ -664,6 +673,7 @@ struct ImageToImage: AsyncParsableCommand {
             seed: seed,
             upsamplePrompt: upsamplePrompt,
             checkpointInterval: checkpoint,
+            maxReferencePixels: maxReferencePixels,
             onProgress: { current, total in
                 let progress = Float(current) / Float(total) * 100
                 print("\rStep \(current)/\(total) [\(String(format: "%.0f", progress))%]", terminator: "")

--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
@@ -646,6 +646,7 @@ public class Flux2Pipeline: @unchecked Sendable {
         seed: UInt64? = nil,
         upsamplePrompt: Bool = false,
         checkpointInterval: Int? = nil,
+        maxReferencePixels: Int = 1024 * 1024,
         onProgress: Flux2ProgressCallback? = nil,
         onCheckpoint: Flux2CheckpointCallback? = nil
     ) async throws -> CGImage {
@@ -668,6 +669,7 @@ public class Flux2Pipeline: @unchecked Sendable {
             seed: seed,
             upsamplePrompt: upsamplePrompt,
             checkpointInterval: checkpointInterval,
+            maxReferencePixels: maxReferencePixels,
             onProgress: onProgress,
             onCheckpoint: onCheckpoint
         )
@@ -687,6 +689,7 @@ public class Flux2Pipeline: @unchecked Sendable {
         seed: UInt64? = nil,
         upsamplePrompt: Bool = false,
         checkpointInterval: Int? = nil,
+        maxReferencePixels: Int = 1024 * 1024,
         onProgress: Flux2ProgressCallback? = nil,
         onCheckpoint: Flux2CheckpointCallback? = nil
     ) async throws -> CGImage {
@@ -707,6 +710,7 @@ public class Flux2Pipeline: @unchecked Sendable {
             seed: seed,
             upsamplePrompt: upsamplePrompt,
             checkpointInterval: checkpointInterval,
+            maxReferencePixels: maxReferencePixels,
             onProgress: onProgress,
             onCheckpoint: onCheckpoint
         )
@@ -758,6 +762,7 @@ public class Flux2Pipeline: @unchecked Sendable {
         seed: UInt64? = nil,
         upsamplePrompt: Bool = false,
         checkpointInterval: Int? = nil,
+        maxReferencePixels: Int = 1024 * 1024,
         onProgress: Flux2ProgressCallback? = nil,
         onCheckpoint: Flux2CheckpointCallback? = nil
     ) async throws -> Flux2GenerationResult {
@@ -780,6 +785,7 @@ public class Flux2Pipeline: @unchecked Sendable {
             seed: seed,
             upsamplePrompt: upsamplePrompt,
             checkpointInterval: checkpointInterval,
+            maxReferencePixels: maxReferencePixels,
             onProgress: onProgress,
             onCheckpoint: onCheckpoint
         )
@@ -799,6 +805,7 @@ public class Flux2Pipeline: @unchecked Sendable {
         seed: UInt64? = nil,
         upsamplePrompt: Bool = false,
         checkpointInterval: Int? = nil,
+        maxReferencePixels: Int = 1024 * 1024,
         onProgress: Flux2ProgressCallback? = nil,
         onCheckpoint: Flux2CheckpointCallback? = nil
     ) async throws -> Flux2GenerationResult {
@@ -819,6 +826,7 @@ public class Flux2Pipeline: @unchecked Sendable {
             seed: seed,
             upsamplePrompt: upsamplePrompt,
             checkpointInterval: checkpointInterval,
+            maxReferencePixels: maxReferencePixels,
             onProgress: onProgress,
             onCheckpoint: onCheckpoint
         )
@@ -837,6 +845,7 @@ public class Flux2Pipeline: @unchecked Sendable {
         upsamplePrompt: Bool,
         precomputedEmbeddings: MLXArray? = nil,
         checkpointInterval: Int?,
+        maxReferencePixels: Int = 1024 * 1024,
         onProgress: Flux2ProgressCallback?,
         onCheckpoint: Flux2CheckpointCallback?,
         onStep: Flux2StepHook? = nil
@@ -853,6 +862,7 @@ public class Flux2Pipeline: @unchecked Sendable {
             upsamplePrompt: upsamplePrompt,
             precomputedEmbeddings: precomputedEmbeddings,
             checkpointInterval: checkpointInterval,
+            maxReferencePixels: maxReferencePixels,
             onProgress: onProgress,
             onCheckpoint: onCheckpoint,
             onStep: onStep
@@ -861,6 +871,10 @@ public class Flux2Pipeline: @unchecked Sendable {
     }
 
     /// Unified generation method with full result including used prompt
+    ///
+    /// - Parameter maxReferencePixels: I2I only — per-reference-image VAE encode
+    ///   budget in pixels (see ``encodeReferenceImages``). Ignored for text-to-image.
+    ///   Defaults to the historical 1024² budget.
     public func generateWithResult(
         mode: Flux2GenerationMode,
         prompt: String,
@@ -873,6 +887,7 @@ public class Flux2Pipeline: @unchecked Sendable {
         upsamplePrompt: Bool,
         precomputedEmbeddings: MLXArray? = nil,
         checkpointInterval: Int?,
+        maxReferencePixels: Int = 1024 * 1024,
         onProgress: Flux2ProgressCallback?,
         onCheckpoint: Flux2CheckpointCallback?,
         onStep: Flux2StepHook? = nil
@@ -1145,7 +1160,8 @@ public class Flux2Pipeline: @unchecked Sendable {
             let (referenceLatents, referencePositionIds) = try await encodeReferenceImages(
                 images,
                 height: validHeight,
-                width: validWidth
+                width: validWidth,
+                maxReferencePixels: maxReferencePixels
             )
             eval(referenceLatents)
             Flux2Debug.log("Encoded \(images.count) reference images: latents \(referenceLatents.shape), posIds \(referencePositionIds.shape)")
@@ -1737,11 +1753,17 @@ public class Flux2Pipeline: @unchecked Sendable {
     ///   - images: Reference images (1-10 supported)
     ///   - height: Target output height
     ///   - width: Target output width
+    ///   - maxReferencePixels: Per-image ceiling, in pixels, for the VAE
+    ///     conditioning encode. Any reference larger than this is downscaled
+    ///     (preserving aspect ratio) before encoding, which bounds token count
+    ///     and VRAM. Policy owned by the caller; defaults to the historical
+    ///     1024² budget (diffusers `pipeline_flux2.py:892-893`).
     /// - Returns: Tuple of (latents [1, seq_len, 128], position IDs [seq_len, 4])
     private func encodeReferenceImages(
         _ images: [CGImage],
         height: Int,
-        width: Int
+        width: Int,
+        maxReferencePixels: Int = 1024 * 1024
     ) async throws -> (latents: MLXArray, positionIds: MLXArray) {
         guard let vae = vae else {
             throw Flux2Error.modelNotLoaded("VAE")
@@ -1754,10 +1776,12 @@ public class Flux2Pipeline: @unchecked Sendable {
         Flux2Debug.log("Encoding \(images.count) reference images separately with unique T-coordinates...")
 
         // === STEP 1: Process each image separately ===
-        // Max area per image - matches diffusers pipeline_flux2.py line 892-893
-        // Reference uses 1024² for conditioning images (not 768² which is for upsampling)
-        let maxImageArea = 1024 * 1024  // ~4096 tokens per image
+        // Max area per image — caller-supplied policy (see `maxReferencePixels`).
+        // Historical default is 1024² (matches diffusers pipeline_flux2.py line
+        // 892-893; conditioning images, not the 768² upsampling budget). Floored
+        // at one 32px tile so a pathological value can never zero out the encode.
         let multipleOf = 32  // vae_scale_factor * 2
+        let maxImageArea = max(maxReferencePixels, multipleOf * multipleOf)  // ~4096 tokens/image at 1024²
 
         var allPackedLatents: [MLXArray] = []
         var latentHeights: [Int] = []


### PR DESCRIPTION
## Contexte

Notre implémentation propre du budget d'encodage des références, en réponse au point soulevé sur la [PR #99](https://github.com/VincentGourbin/flux-2-swift-mlx/pull/99). Cette PR-là cappait le budget en **codant `2048²` en dur au cœur de `Flux2Core`** — une décision de *politique* enterrée dans le framework, non surchargeable par aucun consommateur (CLI, app, tiers).

Ici on garde la ligne « **le framework est la référence, le CLI le consomme** » : Core expose le *mécanisme* (un plafond de pixels par image de référence), la *politique* (quelle valeur) est décidée au bord.

## Ce que ça change

**Framework (`Flux2Core`)**
- `encodeReferenceImages` prend `maxReferencePixels: Int` à la place de la constante `1024 * 1024` en dur.
- Le paramètre est threadé à travers les points d'entrée I2I publics (`generate`, `generateWithResult`, les 4 wrappers `generateImageToImage[WithResult]`), **défaut `1024 * 1024`**.
- Planché à une tuile de 32px pour qu'une valeur pathologique ne puisse jamais annuler l'encode.
- **Source-compatible** : défauts partout → aucun call-site existant à toucher, l'enum `Flux2GenerationMode` et le chemin T2I sont intacts.

**CLI (`Flux2CLI`)**
- Nouveau flag `--max-reference-megapixels` (1 MP = 1024×1024, défaut 1.0), converti en pixels avant l'appel pipeline.
- Monter la valeur = conditionnement plus fidèle contre plus de mémoire (ex. `4.0 ≈ 2048²`, l'équivalent du cap de #99, mais **au choix de l'utilisateur** au lieu d'être figé dans Core).

## Comportement

Zéro changement au budget par défaut : `1024²` reste la valeur historique (diffusers `pipeline_flux2.py:892-893`). La politique n'est qu'*exposée*, pas modifiée.

## Tests

- `swift build --product Flux2CLI` : OK
- `xcodebuild test -scheme Flux2Swift-Package -only-testing:Flux2CoreTests` : **382 tests, 0 échec** (Metal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)