### PR TITLE
chore(deps): bump mlx-swift 0.31.6, transformers 1.3.3, Yams 6, arg-parser, profiler

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,11 +18,13 @@ let package = Package(
     dependencies: [
         // Pinned exactly: mlx-swift introduces breaking API changes even in patch
         // releases (e.g. AdamW TupleState -> AdamState in 0.31.4). Bump deliberately.
-        .package(url: "https://github.com/ml-explore/mlx-swift", exact: "0.31.4"),
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0"),
-        .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
-        .package(url: "https://github.com/jpsim/Yams", from: "5.1.0"),
-        .package(url: "https://github.com/VincentGourbin/swift-mlx-profiler", from: "1.1.1"),
+        // 0.31.6 verified against the full Metal test suite + a generation run;
+        // 0.31.5+ requires a Swift 6.3 toolchain (Xcode 26+).
+        .package(url: "https://github.com/ml-explore/mlx-swift", exact: "0.31.6"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.8.2"),
+        .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.3"),
+        .package(url: "https://github.com/jpsim/Yams", from: "6.0.0"),
+        .package(url: "https://github.com/VincentGourbin/swift-mlx-profiler", from: "1.4.0"),
     ],
     targets: [
         // MARK: - Libraries

--- a/docs/examples/lion-vs-adamw/README.md
+++ b/docs/examples/lion-vs-adamw/README.md
@@ -113,7 +113,8 @@ Both produce high-quality results. The figurine is clearly recognizable with cor
 
 ```bash
 # Build CLI first
-xcodebuild -scheme Flux2CLI -configuration Release -destination 'platform=macOS' build
+# -skipPackagePluginValidation is required since mlx-swift 0.31.5+ ships a CudaBuild plugin
+xcodebuild -scheme Flux2CLI -configuration Release -destination 'platform=macOS' -skipPackagePluginValidation build
 
 # Run both trainings
 flux2 train-lora --config docs/examples/lion-vs-adamw/cat_toy_adamw.yaml

--- a/docs/examples/lion-vs-adamw/run_comparison.sh
+++ b/docs/examples/lion-vs-adamw/run_comparison.sh
@@ -6,7 +6,7 @@ set -e
 
 CLI="$(find ~/Library/Developer/Xcode/DerivedData/flux-2-swift-mlx-*/Build/Products/Release/Flux2CLI -type f 2>/dev/null | head -1)"
 if [ -z "$CLI" ]; then
-    echo "Error: Flux2CLI not found. Build with: xcodebuild -scheme Flux2CLI -configuration Release -destination 'platform=macOS' build"
+    echo "Error: Flux2CLI not found. Build with: xcodebuild -scheme Flux2CLI -configuration Release -destination 'platform=macOS' -skipPackagePluginValidation build"
     exit 1
 fi
 echo "Using CLI: $CLI"


### PR DESCRIPTION
Rafraîchissement délibéré des dépendances, toutes vérifiées **ensemble** sur ce toolchain (Swift 6.3.3 / Xcode 26.6).

## Bumps

| Dépendance | De → Vers | Note |
|---|---|---|
| **mlx-swift** | `exact 0.31.4` → `0.31.6` | Additif ; **pas** de rupture type `AdamState`. ⚠️ voir plugin ci-dessous |
| swift-transformers | `1.1.6` → `1.3.3` | ⚠️ tire un arbre bien plus lourd (swift-nio, swift-crypto, swift-huggingface, EventSource, yyjson) |
| Yams | `5.x` → `6.x` | Seule rupture = types associés de `YamlError.duplicatedKeysInMapping` (Sendable) — non utilisés ici |
| swift-argument-parser | `1.2.0` → `1.8.2` | mineur |
| swift-mlx-profiler | `1.1.1` → `1.4.0` | mineur (paquet interne) |

## ⚠️ Impact build — nouveau flag requis

mlx-swift 0.31.5+ embarque un **build-tool plugin `CudaBuild`** et monte son `swift-tools-version` à **6.3**. Conséquences :
- **xcodebuild** exige désormais `-skipPackagePluginValidation` (sinon `Plugin "CudaBuild" ... must be enabled`).
- **Xcode (GUI)** affiche un « Trust & Enable » à la première ouverture.
- Nécessite **Xcode 26+ / Swift 6.3+**.

Commandes doc mises à jour en conséquence.

## Vérification

- ✅ Build `swift` + `xcodebuild` Release
- ✅ **382 tests Flux2Core** + **145 Flux2Chains/FluxTextEncoders**, 0 échec (Metal)
- ✅ Génération I2I (Klein 4B qint8, seed 42) **byte-identique** au rendu sous 0.31.4 → inférence inchangée

## Points d'attention pour la review

1. **swift-transformers 1.3.3** alourdit nettement le graphe de dépendances (NIO/Crypto/HuggingFace client). Si tu préfères rester léger, on peut le tenir à une version antérieure — dis-moi.
2. Le flag `-skipPackagePluginValidation` est le prix du support CUDA amont de mlx ; sans impact runtime sur macOS/Metal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)