### PR TITLE
fix(textencoders): extend off-main loading to Flux2Core wrappers + docs

### DIFF
--- a/Sources/Flux2CLI/CompareEncoders.swift
+++ b/Sources/Flux2CLI/CompareEncoders.swift
@@ -105,7 +105,7 @@ struct CompareEncoders: AsyncParsableCommand {
         print("  Encoding time: \(String(format: "%.1f", standardElapsed))s")
 
         // Unload standard
-        await MainActor.run { FluxTextEncoders.shared.unloadKleinModel() }
+        FluxTextEncoders.shared.unloadKleinModel()
         Memory.clearCache()
 
         // ── Step 2: Qwen3-VL embeddings ──
@@ -135,7 +135,7 @@ struct CompareEncoders: AsyncParsableCommand {
         print("  Encoding time: \(String(format: "%.1f", vlElapsed))s")
 
         // Unload VL
-        await MainActor.run { FluxTextEncoders.shared.unloadKleinModel() }
+        FluxTextEncoders.shared.unloadKleinModel()
         Memory.clearCache()
 
         // ── Step 3: Compare embeddings ──

--- a/Sources/Flux2CLI/TestQwen35.swift
+++ b/Sources/Flux2CLI/TestQwen35.swift
@@ -119,7 +119,7 @@ struct TestQwen35: AsyncParsableCommand {
             let totalElapsed = Date().timeIntervalSince(startTime)
             print("\nTotal time: \(String(format: "%.1f", totalElapsed))s")
 
-            await MainActor.run { FluxTextEncoders.shared.unloadQwen35VLM() }
+            FluxTextEncoders.shared.unloadQwen35VLM()
             return
         }
 
@@ -174,6 +174,6 @@ struct TestQwen35: AsyncParsableCommand {
         print("Total time: \(String(format: "%.1f", totalElapsed))s")
 
         // Cleanup
-        await MainActor.run { FluxTextEncoders.shared.unloadQwen35VLM() }
+        FluxTextEncoders.shared.unloadQwen35VLM()
     }
 }

--- a/Sources/Flux2CLI/TestVLGeneration.swift
+++ b/Sources/Flux2CLI/TestVLGeneration.swift
@@ -83,6 +83,6 @@ struct TestVLGeneration: AsyncParsableCommand {
         print("Speed: \(String(format: "%.1f", result.tokensPerSecond)) tok/s")
 
         // Cleanup
-        await MainActor.run { FluxTextEncoders.shared.unloadKleinModel() }
+        FluxTextEncoders.shared.unloadKleinModel()
     }
 }

--- a/Sources/Flux2Core/Loading/DevTextEncoder.swift
+++ b/Sources/Flux2Core/Loading/DevTextEncoder.swift
@@ -34,7 +34,6 @@ public class DevTextEncoder: @unchecked Sendable {
 
     /// Load the Mistral model for Dev text encoding
     /// - Parameter modelPath: Path to model directory (or nil to auto-download)
-    @MainActor
     public func load(from modelPath: URL? = nil) async throws {
         Flux2Debug.log("Loading Dev text encoder (Mistral, \(quantization.displayName))...")
 
@@ -109,7 +108,6 @@ public class DevTextEncoder: @unchecked Sendable {
     // MARK: - Memory Management
 
     /// Unload the model to free memory
-    @MainActor
     public func unload() {
         FluxTextEncoders.shared.unloadModel()
 

--- a/Sources/Flux2Core/Loading/KleinTextEncoder.swift
+++ b/Sources/Flux2Core/Loading/KleinTextEncoder.swift
@@ -40,7 +40,6 @@ public class KleinTextEncoder: @unchecked Sendable {
 
     /// Load the Qwen3 model for Klein text encoding
     /// - Parameter modelPath: Path to model directory (or nil to auto-download)
-    @MainActor
     public func load(from modelPath: URL? = nil) async throws {
         Flux2Debug.log("Loading Klein text encoder (\(variant.displayName), \(quantization.displayName))...")
 
@@ -186,7 +185,6 @@ public class KleinTextEncoder: @unchecked Sendable {
     // MARK: - Memory Management
 
     /// Unload the model to free memory
-    @MainActor
     public func unload() {
         FluxTextEncoders.shared.unloadKleinModel()
 

--- a/Sources/Flux2Core/Loading/MistralEncoder.swift
+++ b/Sources/Flux2Core/Loading/MistralEncoder.swift
@@ -33,7 +33,6 @@ public class Flux2TextEncoder: @unchecked Sendable {
 
     /// Load the Mistral model for text encoding
     /// - Parameter modelPath: Path to model directory (or nil to auto-download)
-    @MainActor
     public func load(from modelPath: URL? = nil) async throws {
         Flux2Debug.log("Loading Mistral text encoder (\(quantization.displayName))...")
 
@@ -436,7 +435,6 @@ public class Flux2TextEncoder: @unchecked Sendable {
     // MARK: - Memory Management
 
     /// Unload the model to free memory
-    @MainActor
     public func unload() {
         FluxTextEncoders.shared.unloadModel()
 

--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
@@ -980,7 +980,7 @@ public class Flux2Pipeline: @unchecked Sendable {
 
                     // Step 1: Unload Qwen3 to free memory for Mistral
                     Flux2Debug.log("Unloading Qwen3 to make room for Mistral VLM...")
-                    await MainActor.run { kleinEncoder?.unload() }
+                    kleinEncoder?.unload()
                     memoryManager.fullCleanup()
 
                     // Step 2: Load Mistral VLM
@@ -1008,7 +1008,7 @@ public class Flux2Pipeline: @unchecked Sendable {
 
                     // Step 4: Unload Mistral
                     Flux2Debug.log("Unloading Mistral VLM...")
-                    await MainActor.run { tempMistralForInterpret.unload() }
+                    tempMistralForInterpret.unload()
                     memoryManager.fullCleanup()
 
                     // Step 5: Reload Qwen3 for text encoding
@@ -1047,7 +1047,7 @@ public class Flux2Pipeline: @unchecked Sendable {
 
                     // Step 1: Unload Qwen3 (already loaded by loadTextEncoder) to free memory for Mistral
                     Flux2Debug.log("Unloading Qwen3 to make room for Mistral VLM...")
-                    await MainActor.run { kleinEncoder?.unload() }
+                    kleinEncoder?.unload()
                     memoryManager.fullCleanup()
 
                     // Step 2: Load Mistral VLM for vision-aware upsampling
@@ -1063,7 +1063,7 @@ public class Flux2Pipeline: @unchecked Sendable {
 
                     // Step 4: Unload Mistral to free memory
                     Flux2Debug.log("Unloading Mistral VLM...")
-                    await MainActor.run { tempMistralEncoder.unload() }
+                    tempMistralEncoder.unload()
                     memoryManager.fullCleanup()
 
                     // Step 5: Reload Qwen3 for text encoding

--- a/Sources/Flux2Core/Training/LoRAEvaluator.swift
+++ b/Sources/Flux2Core/Training/LoRAEvaluator.swift
@@ -176,7 +176,7 @@ public class LoRAEvaluator {
         onProgress?("  DOP: \(analysisResult.dopRecommended ? "yes (\(analysisResult.dopClass ?? "object"))" : "no")")
 
         // Unload VLM to free memory for generation
-        await MainActor.run { FluxTextEncoders.shared.unloadQwen35VLM() }
+        FluxTextEncoders.shared.unloadQwen35VLM()
         Memory.clearCache()
 
         // === Step 3: Generate baseline image with base model ===
@@ -263,7 +263,7 @@ public class LoRAEvaluator {
         onProgress?("  Style: \(comparison.styleScore)/100 — \(comparison.styleReason)")
 
         // Unload VLM
-        await MainActor.run { FluxTextEncoders.shared.unloadQwen35VLM() }
+        FluxTextEncoders.shared.unloadQwen35VLM()
 
         // === Step 5: Generate recommendation ===
         onProgress?("[5/5] Generating training recommendation...")

--- a/Sources/Flux2Core/Training/LoRATrainingSetup.swift
+++ b/Sources/Flux2Core/Training/LoRATrainingSetup.swift
@@ -131,7 +131,7 @@ public class LoRATrainingSetup_API {
         onProgress?("Validation prompt: \"\(validationPrompt.prefix(80))...\"")
 
         // Unload VLM
-        await MainActor.run { FluxTextEncoders.shared.unloadQwen35VLM() }
+        FluxTextEncoders.shared.unloadQwen35VLM()
 
         return LoRATrainingSetup(
             referenceImage: refImage,

--- a/Sources/Flux2Core/Training/Loop/SimpleLoRATrainer.swift
+++ b/Sources/Flux2Core/Training/Loop/SimpleLoRATrainer.swift
@@ -2172,7 +2172,7 @@ public final class SimpleLoRATrainer {
             }
 
             // Unload VLM and clear memory
-            await MainActor.run { FluxTextEncoders.shared.unloadQwen35VLM() }
+            FluxTextEncoders.shared.unloadQwen35VLM()
             eval([])
             try await Task.sleep(nanoseconds: 500_000_000)
             MLX.Memory.clearCache()
@@ -2208,7 +2208,7 @@ public final class SimpleLoRATrainer {
         } catch {
             print("    Warning: VLM scoring failed: \(error.localizedDescription)")
             // Ensure VLM is unloaded even on error
-            await MainActor.run { FluxTextEncoders.shared.unloadQwen35VLM() }
+            FluxTextEncoders.shared.unloadQwen35VLM()
             MLX.Memory.clearCache()
             return nil
         }

--- a/Sources/FluxTextEncoders/FluxTextEncoders.swift
+++ b/Sources/FluxTextEncoders/FluxTextEncoders.swift
@@ -22,7 +22,14 @@ import AppKit
 // MARK: - Public API
 
 /// Main interface for FLUX.2 text encoder operations
-/// Thread-safe: load/unload on main thread, inference can run on any thread
+///
+/// Concurrency: `load*`/`unload*` and inference are all `nonisolated` and may
+/// run on any thread (loaders were moved off `@MainActor` so heavy weight
+/// loading no longer blocks the UI). Callers are responsible for **not**
+/// invoking `load`/`unload` concurrently (the class is `@unchecked Sendable`
+/// with no internal lock; the safe pattern is load → use → unload in sequence),
+/// and for hopping back to the main actor themselves if a `progress:` callback
+/// touches UI state — those callbacks are now delivered off-main.
 public final class FluxTextEncoders: @unchecked Sendable {
     /// Shared singleton instance
     public static let shared = FluxTextEncoders()

--- a/Sources/FluxTextEncoders/Loading/TextEncoderModelDownloader.swift
+++ b/Sources/FluxTextEncoders/Loading/TextEncoderModelDownloader.swift
@@ -6,7 +6,11 @@
 import Foundation
 import Hub
 
-/// Progress callback for download updates
+/// Progress callback for download updates.
+///
+/// - Important: May be invoked on **any thread** (loaders run off the main
+///   actor). If the callback updates UI/observable state, hop to the main
+///   actor yourself (e.g. `Task { @MainActor in … }`).
 public typealias TextEncoderDownloadProgressCallback = @Sendable (Double, String) -> Void
 
 /// Model downloader with HuggingFace Hub integration


### PR DESCRIPTION
Suivi de #103, suite à la **revue indépendante**. Applique les améliorations « cheap + étendre off-main ».

## Contexte
#103 a sorti les `load*`/`unload*` de `FluxTextEncoders` du `@MainActor`. Mais la revue a montré que les **wrappers `Flux2Core`** (`MistralEncoder`/`DevTextEncoder`/`KleinTextEncoder`) étaient toujours `@MainActor` et appelaient les loaders (désormais sync/nonisolated) directement sur le main → le chemin « chemin local » continuait de bloquer l'UI.

## Changements

**Étendre off-main**
- Retrait de `@MainActor` sur `Flux2TextEncoder.load/unload`, `DevTextEncoder.load/unload`, `KleinTextEncoder.load/unload` — tout le chemin de chargement tourne off-main (ces corps ne touchent que de l'état nonisolated + les loaders async de `FluxTextEncoders`).

**Cleanup**
- Retrait de **14** `await MainActor.run { …unload() }` devenus superflus (Flux2Pipeline / training / CLI). Les `unload*` sont nonisolated depuis #103 ; ce hop vers le main était mort (et nuisible pendant l'entraînement).

**Docs**
- Correction du commentaire de classe obsolète (« load/unload on main thread ») + doc explicite que `TextEncoderDownloadProgressCallback` peut désormais être invoqué off-main (l'appelant qui touche l'UI doit hopper vers `@MainActor` lui-même).

## Hors scope (follow-up séparé, orienté entraînement)
`TrainingTextEncoder.load` reste `@MainActor` : il tourne dans des tâches d'entraînement détachées et son isolation mérite sa propre revue.

## Vérification
- ✅ Build `Flux2CLI` + `Flux2App`
- ✅ **527 tests** (Core + Chains + TextEncoders), 0 échec
- ✅ `test-qwen35` charge Qwen3.5 off-main → description correcte
- ✅ Klein I2I (charge via `KleinTextEncoder`) **byte-identique** au rendu d'avant → aucune régression d'inférence

🤖 Generated with [Claude Code](https://claude.com/claude-code)