### PR TITLE
feat(profiling): per-phase gaps closed + inpaint CLI benchmark options

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,6 +74,7 @@ let package = Package(
             dependencies: [
                 "Flux2Core",
                 "Flux2Chains",
+                .product(name: "MLX", package: "mlx-swift"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Yams", package: "Yams"),
             ]

--- a/Sources/Flux2CLI/InpaintCommand.swift
+++ b/Sources/Flux2CLI/InpaintCommand.swift
@@ -14,6 +14,7 @@ import UniformTypeIdentifiers
 import Flux2Core
 import Flux2Chains
 import FluxTextEncoders
+import MLX
 
 /// User-facing string mapping for ``Flux2MaskConvention``.
 ///
@@ -112,6 +113,21 @@ struct Inpaint: AsyncParsableCommand {
     var strength: Float = 1.0
     @Option(name: .long, help: "Crop-and-stitch padding in pixels (like diffusers padding_mask_crop). When set, inpaint only a crop around the mask (full token budget on the edit) and paste the result back onto the untouched original — output keeps the original resolution. Typical: 32-64. Recommended when the mask is small relative to the photo.")
     var maskCropPadding: Int?
+
+    @Option(name: .long, help: "Text encoder quantization: bf16, 8bit, 6bit, 4bit")
+    var textQuant: String = "4bit"
+
+    @Option(name: .long, help: "Transformer quantization: \(TransformerQuantization.cliValueList)")
+    var transformerQuant: String = "qint8"
+
+    @Flag(name: .long, help: "Show detailed per-phase performance profiling (model loads, text encoding, VAE encodes, per-step timings).")
+    var profile: Bool = false
+
+    @Option(name: .long, help: "Run the chain N times in the same process (same pipeline instance) to separate cold-start (first run: kernel compilation, cache warm-up) from steady-state. Default 1.")
+    var repeatCount: Int = 1
+
+    @Flag(name: .long, help: "Clear the MLX GPU buffer cache between --repeat-count runs (diagnostic for run-to-run slowdown).")
+    var cleanupBetweenRuns: Bool = false
     @Flag(name: .long, help: "Composite the generated canvas back onto the original in pixel space using the soft mask (kept pixels stay bit-identical, no VAE roundtrip). Implied by --mask-crop-padding.")
     var compositeOnOriginal: Bool = false
 
@@ -176,9 +192,21 @@ struct Inpaint: AsyncParsableCommand {
             logErr("✓ Qwen3.5 VLM loaded")
         }
 
+        guard let textQuantization = MistralQuantization(rawValue: textQuant) else {
+            throw ValidationError("Invalid text quantization: \(textQuant). Use bf16, 8bit, 6bit, or 4bit")
+        }
+        let quantConfig = Flux2QuantizationConfig(
+            textEncoder: textQuantization,
+            transformer: try TransformerQuantization.parseCLI(transformerQuant)
+        )
+
+        if profile {
+            Flux2Profiler.shared.enable()
+        }
+
         let pipeline = Flux2Pipeline(
             model: modelChoice,
-            quantization: .memoryEfficient,
+            quantization: quantConfig,
             vaeVariant: .smallDecoder
         )
         let loadStart = Date()
@@ -217,11 +245,52 @@ struct Inpaint: AsyncParsableCommand {
             }
         )
 
-        let runStart = Date()
-        let result = try await chain.run()
-        logErr("✓ Inpainting done in \(String(format: "%.1fs", Date().timeIntervalSince(runStart)))")
-        try Self.savePNG(result.image, to: output)
-        logErr("✓ Inpainted image → \(output)")
+        guard repeatCount >= 1 else {
+            throw ValidationError("--repeat-count must be ≥ 1")
+        }
+        @Sendable func logMLXMemory(_ label: String) {
+            let active = MLX.Memory.activeMemory / 1_048_576
+            let peak = MLX.Memory.peakMemory / 1_048_576
+            let cache = MLX.Memory.cacheMemory / 1_048_576
+            var info = mach_task_basic_info()
+            var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4
+            let kr = withUnsafeMutablePointer(to: &info) {
+                $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                    task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+                }
+            }
+            let rss = kr == KERN_SUCCESS ? "\(info.resident_size / 1_048_576) MB" : "n/a"
+            logErr("[mem \(label)] MLX active=\(active) MB peak=\(peak) MB cache=\(cache) MB | RSS=\(rss)")
+        }
+
+        var wallTimes: [TimeInterval] = []
+        for runIndex in 1...repeatCount {
+            if profile { Flux2Profiler.shared.reset() }
+            if cleanupBetweenRuns && runIndex > 1 {
+                MLX.Memory.clearCache()
+                logErr("[mem] cleared MLX cache between runs")
+            }
+            logMLXMemory("before run \(runIndex)")
+            let runStart = Date()
+            let result = try await chain.run()
+            let wall = Date().timeIntervalSince(runStart)
+            wallTimes.append(wall)
+            logMLXMemory("after run \(runIndex)")
+            logErr("✓ Inpainting run \(runIndex)/\(repeatCount) done in \(String(format: "%.1fs", wall))")
+            if profile {
+                print(Flux2Profiler.shared.generateReport())
+            }
+            if runIndex == repeatCount {
+                try Self.savePNG(result.image, to: output)
+                logErr("✓ Inpainted image → \(output)")
+            }
+        }
+        if repeatCount > 1 {
+            let summary = wallTimes.enumerated()
+                .map { "run \($0.offset + 1): \(String(format: "%.1fs", $0.element))" }
+                .joined(separator: "  |  ")
+            logErr("Σ wall times — \(summary)")
+        }
     }
 
     private static func loadCGImage(at path: String) -> CGImage? {

--- a/Sources/Flux2Chains/Flux2MaskedInpaintingChain.swift
+++ b/Sources/Flux2Chains/Flux2MaskedInpaintingChain.swift
@@ -298,7 +298,10 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
     /// - Throws: Whatever the underlying pipeline can throw (model not
     ///   loaded, memory, generation cancellation).
     public func run() async throws -> Flux2GenerationResult {
+        let profiler = Flux2Profiler.shared
+        profiler.start("0. Chain: Load Models")
         try await pipeline.loadModels()
+        profiler.end("0. Chain: Load Models")
 
         // Resolve which prompt + upsample flag actually reach the pipeline.
         // VLM enrichment is strictly opt-in and gracefully falls back when
@@ -355,6 +358,7 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
 
         // Encode the source image *once*, before the denoising loop starts.
         // The VAE stays resident so the post-denoising decode reuses it.
+        profiler.start("0b. Chain: VAE Encode Source")
         let imageLatents = try await pipeline.encodeImageToPackedSequence(
             workImage,
             targetHeight: targetH,
@@ -367,6 +371,7 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
             targetWidth: targetW,
             convention: maskConvention
         )
+        profiler.end("0b. Chain: VAE Encode Source")
 
         // Blend noise is drawn ONCE and reused at every step (diffusers
         // parity): the outside-mask region then follows a single consistent
@@ -431,6 +436,8 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
         // to full-canvas — the caller was promised an original-resolution
         // output with bit-exact kept pixels) or `compositeOnOriginal` is set.
         if cropRect != nil || maskCropPadding != nil || compositeOnOriginal {
+            profiler.start("9. Chain: Pixel Composite")
+            defer { profiler.end("9. Chain: Pixel Composite") }
             let region = cropRect ?? CGRect(x: 0, y: 0, width: image.width, height: image.height)
             if let composited = Flux2InpaintCompositing.composite(
                 original: image,

--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
@@ -1180,6 +1180,7 @@ public class Flux2Pipeline: @unchecked Sendable {
             Flux2Debug.log("Generated output noise latents: \(patchifiedLatents.shape)")
 
             // Encode ALL reference images
+            profiler.start("5b. VAE Encode References")
             let (referenceLatents, referencePositionIds) = try await encodeReferenceImages(
                 images,
                 height: validHeight,
@@ -1187,6 +1188,7 @@ public class Flux2Pipeline: @unchecked Sendable {
                 maxReferencePixels: maxReferencePixels
             )
             eval(referenceLatents)
+            profiler.end("5b. VAE Encode References")
             Flux2Debug.log("Encoded \(images.count) reference images: latents \(referenceLatents.shape), posIds \(referencePositionIds.shape)")
 
             // Pack output latents to sequence format


### PR DESCRIPTION
## Contexte

Le rapport app (Fluxforge Studio, « generation slowness ») demandait des hooks de timing par phase dans la chaîne d'inpainting (§6.1) et une baseline de référence (§6.3). En instrumentant, l'enquête a aussi identifié la cause racine de la variance ×3–×9 : voir résultats ci-dessous.

## Changements

- **Profiler — trous comblés** : `5b. VAE Encode References` (pipeline I2I), `0b. Chain: VAE Encode Source` et `9. Chain: Pixel Composite` (`Flux2MaskedInpaintingChain`). Un rapport `--profile` couvre désormais tout le wall time d'un inpaint.
- **`flux2 inpaint`** : `--profile`, `--text-quant` / `--transformer-quant` (avant : `.memoryEfficient` hardcodé — impossible de reproduire les runs « High Quality » bf16 de l'app), `--repeat-count N` (runs consécutifs même process : froid vs régime établi), `--cleanup-between-runs` + logs mémoire MLX par run (diagnostics).
- `Package.swift` : dépendance produit `MLX` pour Flux2CLI (logs mémoire).

## Résultats obtenus avec cet outillage (M3 Max 96 GB)

Baseline klein-9b bf16, chaîne inpainting app-parity (crop-and-stitch 48 px, 1 MP, 4 steps) :

| Phase | Temps (chaud) |
|---|---|
| Load text encoder (Qwen3-8B-4bit) | 1,2 s |
| Text encoding | 1,7 s |
| Load transformer (17 GB bf16) | **2,5 s** |
| VAE encode source | 1,9 s |
| Denoising 4 steps | 53,5 s (13,4 s/step) |
| VAE decode + composite | 2,7 s |
| **Total** | **~64 s** |

Les lenteurs ×3–×9 rapportées côté app ne se reproduisent que sous charge GPU concurrente (démonstration : 577 s → 57 s dans le même process en suspendant le process concurrent — en l'occurrence l'app elle-même, dont une vue anime en boucle ; détail dans le rapport d'investigation de session). Le chargement des modèles est hors de cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


