### PR TITLE
feat(pipeline): opt-in MLX.compile of the denoising forward (--compile-step)

### DIFF
--- a/Sources/Flux2CLI/InpaintCommand.swift
+++ b/Sources/Flux2CLI/InpaintCommand.swift
@@ -128,6 +128,9 @@ struct Inpaint: AsyncParsableCommand {
 
     @Flag(name: .long, help: "Clear the MLX GPU buffer cache between --repeat-count runs (diagnostic for run-to-run slowdown).")
     var cleanupBetweenRuns: Bool = false
+
+    @Flag(name: .long, help: "Compile the denoising transformer forward with MLX.compile (experimental). First step pays a one-time trace; subsequent steps benefit from fused elementwise kernels.")
+    var compileStep: Bool = false
     @Flag(name: .long, help: "Composite the generated canvas back onto the original in pixel space using the soft mask (kept pixels stay bit-identical, no VAE roundtrip). Implied by --mask-crop-padding.")
     var compositeOnOriginal: Bool = false
 
@@ -209,6 +212,7 @@ struct Inpaint: AsyncParsableCommand {
             quantization: quantConfig,
             vaeVariant: .smallDecoder
         )
+        pipeline.compileDenoisingStep = compileStep
         let loadStart = Date()
         try await pipeline.loadModels()
         logErr("✓ Flux2 pipeline ready in \(String(format: "%.1fs", Date().timeIntervalSince(loadStart)))")

--- a/Sources/Flux2CLI/InpaintCommand.swift
+++ b/Sources/Flux2CLI/InpaintCommand.swift
@@ -129,7 +129,7 @@ struct Inpaint: AsyncParsableCommand {
     @Flag(name: .long, help: "Clear the MLX GPU buffer cache between --repeat-count runs (diagnostic for run-to-run slowdown).")
     var cleanupBetweenRuns: Bool = false
 
-    @Flag(name: .long, help: "Compile the denoising transformer forward with MLX.compile (experimental). First step pays a one-time trace; subsequent steps benefit from fused elementwise kernels.")
+    @Flag(name: .long, help: "Compile the denoising transformer forward with MLX.compile (experimental, benchmarking only). Measured neutral on klein-9b bf16 — the elementwise hot spots are already hand-fused; steps are GEMM-bound. Forces memoryOptimization to .disabled (higher peak memory) and pays a one-time trace on the first step. Output is numerically identical.")
     var compileStep: Bool = false
     @Flag(name: .long, help: "Composite the generated canvas back onto the original in pixel space using the soft mask (kept pixels stay bit-identical, no VAE roundtrip). Implied by --mask-crop-padding.")
     var compositeOnOriginal: Bool = false

--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
@@ -155,13 +155,32 @@ public class Flux2Pipeline: @unchecked Sendable {
     /// Clear cache every N denoising steps (0 = disabled)
     public var clearCacheEveryNSteps: Int = 5
 
-    /// Compile the denoising transformer forward with `MLX.compile` (opt-in,
-    /// experimental). Fuses the elementwise chains (AdaLN modulation, gates,
-    /// activations) into JIT'd kernels — measured target ~5-15% per step.
-    /// The compiled closure is cached on the pipeline and re-traced
-    /// automatically by MLX when input shapes change (new resolution or
-    /// text length); it is rebuilt if the transformer instance or the
-    /// guidance arity changes. Not applied to the KV-cached path.
+    /// Compile the denoising transformer forward with `MLX.compile`.
+    ///
+    /// **Opt-in, experimental — OFF by default, and there is currently no
+    /// reason to enable it in production.** Measured on klein-9b bf16
+    /// (1 MP, 4 steps, M3 Max 96 GB, 2026-07): steady-state step time is
+    /// unchanged (13.2 s compiled vs 12.5–13.6 s baseline) because this
+    /// codebase already hand-optimizes the elementwise hot spots that
+    /// `compile` would fuse (modulation precomputed outside the block loop,
+    /// fused RoPE Metal kernel, `MLXFast` rmsNorm/SDPA); the remaining step
+    /// time is GEMM/SDPA-bound, which `compile` does not accelerate. The
+    /// output is numerically identical to the uncompiled path (mean RGB
+    /// delta 0.01/255 at equal seed).
+    ///
+    /// The switch is kept for experimentation (future mlx-swift versions,
+    /// other model variants, modified forward paths). Behaviour when
+    /// enabled:
+    /// - the compiled closure is cached on the pipeline; MLX re-traces it
+    ///   automatically when input shapes change (resolution, text length)
+    ///   and it is rebuilt if the transformer instance or guidance arity
+    ///   changes. First step after a (re)build pays a one-time trace
+    ///   (~1–2 s on klein-9b).
+    /// - `memoryOptimization` is forced to `.disabled` on the transformer:
+    ///   intra-forward `eval()` graph segmentation is illegal under compile
+    ///   tracing. Peak memory therefore rises to the unsegmented level —
+    ///   do NOT combine with low-memory profiles on constrained machines.
+    /// - the KV-cached path (`klein-9b-kv`) is not affected.
     public var compileDenoisingStep: Bool = false
 
     /// Cached compiled forward (see `compileDenoisingStep`).

--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
@@ -155,6 +155,77 @@ public class Flux2Pipeline: @unchecked Sendable {
     /// Clear cache every N denoising steps (0 = disabled)
     public var clearCacheEveryNSteps: Int = 5
 
+    /// Compile the denoising transformer forward with `MLX.compile` (opt-in,
+    /// experimental). Fuses the elementwise chains (AdaLN modulation, gates,
+    /// activations) into JIT'd kernels — measured target ~5-15% per step.
+    /// The compiled closure is cached on the pipeline and re-traced
+    /// automatically by MLX when input shapes change (new resolution or
+    /// text length); it is rebuilt if the transformer instance or the
+    /// guidance arity changes. Not applied to the KV-cached path.
+    public var compileDenoisingStep: Bool = false
+
+    /// Cached compiled forward (see `compileDenoisingStep`).
+    private var compiledForward: (([MLXArray]) -> [MLXArray])?
+    /// Identity key of the compiled closure: transformer instance + guidance arity.
+    private var compiledForwardKey: (transformer: ObjectIdentifier, hasGuidance: Bool)?
+
+    /// Transformer forward used by the standard denoising loops. Routes
+    /// through the compiled closure when `compileDenoisingStep` is set,
+    /// otherwise calls the transformer directly.
+    private func denoiseForward(
+        _ transformer: Flux2Transformer2DModel,
+        hiddenStates: MLXArray,
+        encoderHiddenStates: MLXArray,
+        timestep: MLXArray,
+        guidance: MLXArray?,
+        imgIds: MLXArray,
+        txtIds: MLXArray
+    ) -> MLXArray {
+        guard compileDenoisingStep else {
+            return transformer.callAsFunction(
+                hiddenStates: hiddenStates,
+                encoderHiddenStates: encoderHiddenStates,
+                timestep: timestep,
+                guidance: guidance,
+                imgIds: imgIds,
+                txtIds: txtIds
+            )
+        }
+
+        let hasGuidance = guidance != nil
+        let key = (transformer: ObjectIdentifier(transformer), hasGuidance: hasGuidance)
+        if compiledForward == nil || compiledForwardKey! != key {
+            Flux2Debug.log("Compiling denoising forward (guidance: \(hasGuidance))...")
+            // Intra-forward eval() (memory-optimization graph segmentation) is
+            // illegal inside compile tracing — and pointless once the graph is
+            // compiled. Disable it for this transformer; peak memory rises to
+            // the unsegmented level, which is the trade-off of compiling.
+            if transformer.memoryOptimization != .disabled {
+                Flux2Debug.log("compileDenoisingStep: overriding memoryOptimization \(transformer.memoryOptimization) → .disabled (intra-forward eval is incompatible with compile)")
+                transformer.memoryOptimization = .disabled
+            }
+            // Weights are tracked as compile state via `inputs: [transformer]`,
+            // so LoRA merges (value-only updates) don't stale the trace.
+            compiledForward = compile(inputs: [transformer]) { (arrays: [MLXArray]) -> [MLXArray] in
+                [transformer.callAsFunction(
+                    hiddenStates: arrays[0],
+                    encoderHiddenStates: arrays[1],
+                    timestep: arrays[2],
+                    guidance: hasGuidance ? arrays[3] : nil,
+                    imgIds: hasGuidance ? arrays[4] : arrays[3],
+                    txtIds: hasGuidance ? arrays[5] : arrays[4]
+                )]
+            }
+            compiledForwardKey = key
+        }
+
+        var args = [hiddenStates, encoderHiddenStates, timestep]
+        if let guidance { args.append(guidance) }
+        args.append(imgIds)
+        args.append(txtIds)
+        return compiledForward!(args)[0]
+    }
+
     /// Initialize the Flux.2 pipeline
     /// - Parameters:
     ///   - model: Model variant (dev, klein-4b, klein-9b)
@@ -566,6 +637,10 @@ public class Flux2Pipeline: @unchecked Sendable {
 
     /// Unload transformer to free memory
     private func unloadTransformer() {
+        // The compiled forward retains the transformer (and its weights) —
+        // drop it first or the unload frees nothing.
+        compiledForward = nil
+        compiledForwardKey = nil
         transformer = nil
         memoryManager.clearCache()
     }
@@ -1420,7 +1495,8 @@ public class Flux2Pipeline: @unchecked Sendable {
                 }
 
                 // Run transformer (conditional pass)
-                let noisePredCond = transformer.callAsFunction(
+                let noisePredCond = denoiseForward(
+                    transformer,
                     hiddenStates: inputLatents,
                     encoderHiddenStates: textEmbeddings,
                     timestep: t,
@@ -1435,7 +1511,8 @@ public class Flux2Pipeline: @unchecked Sendable {
                 if useClassicalCFG,
                    let negEmbeds = negativeTextEmbeddings,
                    let uncondIds = i2iUncondTextIds {
-                    let noisePredUncond = transformer.callAsFunction(
+                    let noisePredUncond = denoiseForward(
+                        transformer,
                         hiddenStates: inputLatents,
                         encoderHiddenStates: negEmbeds,
                         timestep: t,
@@ -1646,7 +1723,8 @@ public class Flux2Pipeline: @unchecked Sendable {
             }
 
             // Run transformer (conditional pass)
-            let noisePredCond = transformer.callAsFunction(
+            let noisePredCond = denoiseForward(
+                transformer,
                 hiddenStates: packedLatents,
                 encoderHiddenStates: textEmbeddings,
                 timestep: t,
@@ -1661,7 +1739,8 @@ public class Flux2Pipeline: @unchecked Sendable {
             if useClassicalCFG,
                let negEmbeds = negativeTextEmbeddings,
                let uncondIds = uncondTextIds {
-                let noisePredUncond = transformer.callAsFunction(
+                let noisePredUncond = denoiseForward(
+                    transformer,
                     hiddenStates: packedLatents,
                     encoderHiddenStates: negEmbeds,
                     timestep: t,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -503,6 +503,48 @@ Model Status:
 | Minimal | 4bit | qint8 | ~47GB | 48GB Macs |
 | Ultra-Minimal | 4bit | int4 | ~30GB | 32GB Macs |
 
+> **Quantization ≠ speed.** Measured on klein-9b (M3 Max, 1 MP, 4 steps):
+> qint8 steps are NOT faster than bf16 (~14.9 vs ~13.6 s/step) — the
+> denoising step is large-GEMM-bound, unlike LLM decode. Quantization buys
+> **memory**, not step time. Quality on klein-**9B** qint8 is near-identical
+> to bf16 (mean RGB delta 1.7/255 at equal seed); the historical qint8
+> color-drift affects klein-**4B**. Avoid `mxfp8` for inference on 9B: ~2×
+> slower AND visibly degraded (as of mlx-swift 0.31.6 / core 0.31.1).
+
+---
+
+## Benchmarking & Experimental Flags (`inpaint`)
+
+Flags added for performance investigation — useful to reproduce app
+generations and separate cold-start from steady-state:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--profile` | false | Per-phase report: model loads, text encoding, VAE encodes (source + references), per-step timings, decode, composite |
+| `--repeat-count <n>` | 1 | Run the chain N times in one process (run 1 = cold: file cache, kernel JIT; runs 2+ = steady-state) |
+| `--cleanup-between-runs` | false | Clear the MLX buffer cache between repeated runs (diagnostic) |
+| `--compile-step` | false | **Experimental, benchmarking only.** Compile the denoising forward with `MLX.compile` |
+
+### `--compile-step` — read before enabling
+
+Measured neutral on klein-9b bf16 (steady-state 13.2 s/step compiled vs
+12.5–13.6 s baseline; output numerically identical, mean RGB delta
+0.01/255): the elementwise chains `compile` would fuse (AdaLN modulation,
+gates, RoPE arithmetic) are already hand-optimized in this codebase, and the
+remaining step time is GEMM/SDPA-bound. The switch is kept for
+experimentation with future mlx-swift versions or modified forward paths.
+
+Side effects when enabled:
+- the transformer's `memoryOptimization` is forced to `.disabled`
+  (intra-forward `eval()` segmentation is illegal under compile tracing) —
+  **peak memory rises**; do not combine with low-memory configurations;
+- the first step after each (re)trace pays ~1–2 s (new resolution, text
+  length, or transformer instance triggers a re-trace);
+- the KV-cached path (`klein-9b-kv`) is unaffected.
+
+Library equivalent: `Flux2Pipeline.compileDenoisingStep = true` (see the
+property's doc comment in `Flux2Pipeline.swift`).
+
 ---
 
 ## Custom Models Directory


### PR DESCRIPTION
## Décision

Suite au bench : le `compile` du forward de denoising est **neutre en vitesse** sur klein-9b bf16, mais on garde l'option dans le framework en **opt-in explicite, jamais par défaut** — utile pour ré-évaluer sur de futures versions de mlx-swift, d'autres variantes de modèle, ou des forwards modifiés.

Stackée sur #112 (réutilise `--repeat-count`/`--profile` pour l'A/B).

## Ce que fait la PR

- `Flux2Pipeline.compileDenoisingStep` (défaut `false`) : closure compilée cachée sur le pipeline, re-trace automatique par MLX au changement de shapes (résolution / longueur de texte), reconstruction si l'instance du transformer ou l'arité guidance change. Chemin KV (`klein-9b-kv`) exclu.
- Invalidations sûres : la closure compilée retient le transformer → elle est libérée dans `unloadTransformer()` (sinon 17 GB retenus après unload).
- `memoryOptimization` forcé à `.disabled` quand le flag est actif : les `eval()` intra-forward (segmentation de graphe) sont illégaux sous traçage compile. Effet de bord documenté : pic mémoire au niveau non-segmenté.
- CLI : flag `--compile-step` sur `flux2 inpaint`, marqué « benchmarking only ».
- Documentation à trois niveaux (doc comment de la property, help CLI, section `docs/CLI.md`) qui annonce le résultat mesuré d'entrée, plus une note « quantization ≠ vitesse » issue de la même campagne.

## Mesures (M3 Max 96 GB, klein-9b bf16, inpaint 1 MP, 4 steps, seed fixe)

| | s/step régime établi | Sortie vs baseline |
|---|---|---|
| baseline | 12,5–13,6 s | — |
| compilé | 13,2 s | identique (ΔRGB moyen 0,01/255) |

Trace : ~1–2 s, payée une fois au premier step après chaque (re)trace.

**Pourquoi c'est neutre** : les chaînes elementwise que `compile` fusionnerait (modulation AdaLN, gates, arithmétique RoPE) sont déjà optimisées à la main dans ce repo (modulation précalculée hors boucle de blocs, kernel Metal RoPE fusionné, rmsNorm/SDPA MLXFast) ; le reste du step est borné par les GEMM/SDPA, que `compile` n'accélère pas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)