### PR TITLE
perf(loading): TE résident optionnel + stats debug gatées + purge cache fin de génération

### DIFF
--- a/Sources/Flux2CLI/InpaintCommand.swift
+++ b/Sources/Flux2CLI/InpaintCommand.swift
@@ -134,6 +134,9 @@ struct Inpaint: AsyncParsableCommand {
     @Flag(name: .long, help: "Composite the generated canvas back onto the original in pixel space using the soft mask (kept pixels stay bit-identical, no VAE roundtrip). Implied by --mask-crop-padding.")
     var compositeOnOriginal: Bool = false
 
+    @Flag(name: .long, help: "Keep the text encoder loaded between generations instead of reloading it each time (memory-first default). Saves ~1s warm / several seconds cold per generation at the cost of encoder + transformer resident simultaneously (Klein-9B: ≈ +5 GB). Enable on machines with RAM headroom.")
+    var keepTextEncoder: Bool = false
+
     func run() async throws {
         @Sendable func logErr(_ msg: String) {
             FileHandle.standardError.write(Data((msg + "\n").utf8))
@@ -213,6 +216,7 @@ struct Inpaint: AsyncParsableCommand {
             vaeVariant: .smallDecoder
         )
         pipeline.compileDenoisingStep = compileStep
+        pipeline.keepTextEncoderLoaded = keepTextEncoder
         let loadStart = Date()
         try await pipeline.loadModels()
         logErr("✓ Flux2 pipeline ready in \(String(format: "%.1fs", Date().timeIntervalSince(loadStart)))")

--- a/Sources/Flux2Core/Loading/WeightLoader.swift
+++ b/Sources/Flux2Core/Loading/WeightLoader.swift
@@ -222,23 +222,28 @@ public class Flux2WeightLoader {
             Flux2Debug.verbose("  - \(key): \(mapped[key]!.shape)")
         }
 
-        // DEBUG: Print raw BFL weight statistics BEFORE conversion
-        Flux2Debug.log("=== Raw BFL Weight Statistics (BEFORE conversion) ===")
-        for key in ["xEmbedder.weight", "contextEmbedder.weight",
-                    "transformerBlocks.0.attn.toQ.weight",
-                    "transformerBlocks.0.ff.activation.proj.weight",
-                    "singleTransformerBlocks.0.attn.toQkvMlp.weight"] {
-            if let w = mapped[key] {
-                eval(w)
-                // Convert to float32 for accurate stats
-                let wf32 = w.asType(.float32)
-                let absVal = MLX.abs(wf32)
-                let meanVal = mean(absVal).item(Float.self)
-                let maxVal = MLX.max(absVal).item(Float.self)
-                let minVal = MLX.min(absVal).item(Float.self)
-                let hasNaN = any(isNaN(wf32)).item(Bool.self)
-                let numInf = sum(MLX.abs(wf32) .> 1e30).item(Int.self)  // Count very large values as proxy for inf
-                Flux2Debug.log("  \(key): dtype=\(w.dtype), shape=\(w.shape), mean=\(meanVal), max=\(maxVal), min=\(minVal), hasNaN=\(hasNaN), numInf=\(numInf)")
+        // DEBUG: Print raw BFL weight statistics BEFORE conversion.
+        // Gated on loggability: the stats themselves cost GPU evals + full
+        // f32 reductions over large tensors — don't pay them when the print
+        // would be filtered out anyway.
+        if Flux2Debug.isLoggable(.info) {
+            Flux2Debug.log("=== Raw BFL Weight Statistics (BEFORE conversion) ===")
+            for key in ["xEmbedder.weight", "contextEmbedder.weight",
+                        "transformerBlocks.0.attn.toQ.weight",
+                        "transformerBlocks.0.ff.activation.proj.weight",
+                        "singleTransformerBlocks.0.attn.toQkvMlp.weight"] {
+                if let w = mapped[key] {
+                    eval(w)
+                    // Convert to float32 for accurate stats
+                    let wf32 = w.asType(.float32)
+                    let absVal = MLX.abs(wf32)
+                    let meanVal = mean(absVal).item(Float.self)
+                    let maxVal = MLX.max(absVal).item(Float.self)
+                    let minVal = MLX.min(absVal).item(Float.self)
+                    let hasNaN = any(isNaN(wf32)).item(Bool.self)
+                    let numInf = sum(MLX.abs(wf32) .> 1e30).item(Int.self)  // Count very large values as proxy for inf
+                    Flux2Debug.log("  \(key): dtype=\(w.dtype), shape=\(w.shape), mean=\(meanVal), max=\(maxVal), min=\(minVal), hasNaN=\(hasNaN), numInf=\(numInf)")
+                }
             }
         }
 
@@ -262,24 +267,27 @@ public class Flux2WeightLoader {
         }
         Flux2Debug.log("Converted \(convertedCount) bfloat16 weights to float16 (direct)")
 
-        // DEBUG: Print weight statistics for key layers (AFTER processing)
-        Flux2Debug.log("=== BFL Weight Statistics (AFTER processing) ===")
-        for key in ["xEmbedder.weight", "contextEmbedder.weight",
-                    "transformerBlocks.0.attn.toQ.weight",
-                    "transformerBlocks.0.ff.activation.proj.weight",
-                    "singleTransformerBlocks.0.attn.toQkvMlp.weight"] {
-            if let w = converted[key] {
-                eval(w)
-                let wf32 = w.asType(.float32)
-                let absVal = MLX.abs(wf32)
-                let meanVal = mean(absVal).item(Float.self)
-                let maxVal = MLX.max(absVal).item(Float.self)
-                let minVal = MLX.min(absVal).item(Float.self)
-                let hasNaN = any(isNaN(wf32)).item(Bool.self)
-                let numInf = sum(MLX.abs(wf32) .> 1e30).item(Int.self)  // Count very large values as proxy for inf
-                Flux2Debug.log("  \(key): dtype=\(w.dtype), shape=\(w.shape), mean=\(meanVal), max=\(maxVal), min=\(minVal), hasNaN=\(hasNaN), numInf=\(numInf)")
-            } else {
-                Flux2Debug.log("  \(key): NOT FOUND")
+        // DEBUG: Print weight statistics for key layers (AFTER processing).
+        // Same gating as above — stats compute is not free.
+        if Flux2Debug.isLoggable(.info) {
+            Flux2Debug.log("=== BFL Weight Statistics (AFTER processing) ===")
+            for key in ["xEmbedder.weight", "contextEmbedder.weight",
+                        "transformerBlocks.0.attn.toQ.weight",
+                        "transformerBlocks.0.ff.activation.proj.weight",
+                        "singleTransformerBlocks.0.attn.toQkvMlp.weight"] {
+                if let w = converted[key] {
+                    eval(w)
+                    let wf32 = w.asType(.float32)
+                    let absVal = MLX.abs(wf32)
+                    let meanVal = mean(absVal).item(Float.self)
+                    let maxVal = MLX.max(absVal).item(Float.self)
+                    let minVal = MLX.min(absVal).item(Float.self)
+                    let hasNaN = any(isNaN(wf32)).item(Bool.self)
+                    let numInf = sum(MLX.abs(wf32) .> 1e30).item(Int.self)  // Count very large values as proxy for inf
+                    Flux2Debug.log("  \(key): dtype=\(w.dtype), shape=\(w.shape), mean=\(meanVal), max=\(maxVal), min=\(minVal), hasNaN=\(hasNaN), numInf=\(numInf)")
+                } else {
+                    Flux2Debug.log("  \(key): NOT FOUND")
+                }
             }
         }
 
@@ -361,21 +369,24 @@ public class Flux2WeightLoader {
         }
         Flux2Debug.log("Dequantized \(dequantCount) qint8 weights to float16")
 
-        // DEBUG: Print weight statistics for key layers
-        Flux2Debug.log("=== Diffusers Weight Statistics ===")
-        for key in ["xEmbedder.weight", "contextEmbedder.weight",
-                    "transformerBlocks.0.attn.toQ.weight",
-                    "transformerBlocks.0.ff.activation.proj.weight",
-                    "singleTransformerBlocks.0.attn.toQkvMlp.weight"].prefix(5) {
-            if let w = mapped[key] {
-                eval(w)
-                let absVal = MLX.abs(w)
-                let meanVal = mean(absVal).item(Float.self)
-                let maxVal = MLX.max(absVal).item(Float.self)
-                let minVal = MLX.min(absVal).item(Float.self)
-                Flux2Debug.log("  \(key): shape=\(w.shape), mean=\(meanVal), max=\(maxVal), min=\(minVal)")
-            } else {
-                Flux2Debug.log("  \(key): NOT FOUND")
+        // DEBUG: Print weight statistics for key layers.
+        // Same gating as the BFL path — stats compute is not free.
+        if Flux2Debug.isLoggable(.info) {
+            Flux2Debug.log("=== Diffusers Weight Statistics ===")
+            for key in ["xEmbedder.weight", "contextEmbedder.weight",
+                        "transformerBlocks.0.attn.toQ.weight",
+                        "transformerBlocks.0.ff.activation.proj.weight",
+                        "singleTransformerBlocks.0.attn.toQkvMlp.weight"].prefix(5) {
+                if let w = mapped[key] {
+                    eval(w)
+                    let absVal = MLX.abs(w)
+                    let meanVal = mean(absVal).item(Float.self)
+                    let maxVal = MLX.max(absVal).item(Float.self)
+                    let minVal = MLX.min(absVal).item(Float.self)
+                    Flux2Debug.log("  \(key): shape=\(w.shape), mean=\(meanVal), max=\(maxVal), min=\(minVal)")
+                } else {
+                    Flux2Debug.log("  \(key): NOT FOUND")
+                }
             }
         }
 

--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
@@ -245,6 +245,23 @@ public class Flux2Pipeline: @unchecked Sendable {
         return compiledForward!(args)[0]
     }
 
+    /// Keep the text encoder loaded between generations (default `false`).
+    ///
+    /// By default the pipeline is memory-first: the text encoder is loaded,
+    /// used, and unloaded on EVERY generation so it never coexists with the
+    /// transformer. On machines with headroom this re-load is pure waste
+    /// (~1s warm, several seconds cold for the Klein/Qwen3 encoders; much
+    /// more for the Dev/Mistral-24B encoder).
+    ///
+    /// When `true`, the encoder stays resident across generations — the
+    /// text-encoding phase of subsequent generations skips the reload
+    /// entirely. The trade-off is peak memory: encoder + transformer are
+    /// resident simultaneously during denoising (e.g. Klein-9B bf16 +
+    /// Qwen3-8B-4bit ≈ +5 GB). Policy belongs to the host: enable it based
+    /// on available RAM, leave it off on constrained machines. Releasing
+    /// the pipeline instance still frees the encoder as usual.
+    public var keepTextEncoderLoaded: Bool = false
+
     /// Initialize the Flux.2 pipeline
     /// - Parameters:
     ///   - model: Model variant (dev, klein-4b, klein-9b)
@@ -1220,9 +1237,16 @@ public class Flux2Pipeline: @unchecked Sendable {
 
             Flux2Debug.log("Text embeddings shape: \(textEmbeddings.shape)")
 
-            // Unload text encoder to free memory
+            // Unload text encoder to free memory — unless the host opted
+            // into keeping it resident (`keepTextEncoderLoaded`), in which
+            // case only the GPU buffer cache is dropped before denoising.
             profiler.start("3. Unload Text Encoder")
-            await unloadTextEncoder()
+            if keepTextEncoderLoaded {
+                Flux2Debug.log("Keeping text encoder resident (keepTextEncoderLoaded)")
+                memoryManager.fullCleanup()
+            } else {
+                await unloadTextEncoder()
+            }
             profiler.end("3. Unload Text Encoder")
         }
 
@@ -1642,6 +1666,12 @@ public class Flux2Pipeline: @unchecked Sendable {
             }
             profiler.end("8. Post-processing")
 
+            // End-of-generation hygiene: drop the transient GPU buffer cache
+            // (~3 GB measured after a 1 MP run). For a resident host app this
+            // is dead weight between generations; the next run re-warms it in
+            // milliseconds.
+            memoryManager.clearCache()
+
             if profiler.isEnabled {
                 print(profiler.generateReport())
             }
@@ -1895,6 +1925,9 @@ public class Flux2Pipeline: @unchecked Sendable {
             throw Flux2Error.imageProcessingFailed("Failed to convert output to image")
         }
         profiler.end("8. Post-processing")
+
+        // End-of-generation hygiene: see the I2I return path above.
+        memoryManager.clearCache()
 
         Flux2Debug.log("Generation complete!")
         memoryManager.logMemoryState()

--- a/Sources/Flux2Core/Utils/Flux2Debug.swift
+++ b/Sources/Flux2Core/Utils/Flux2Debug.swift
@@ -35,6 +35,14 @@ public enum Flux2Debug {
         minLevel = .warning
     }
 
+    /// Whether a message at `level` would actually be printed. Use this to
+    /// skip computations that exist only to feed debug logs (e.g. weight
+    /// statistics requiring GPU evals) — `log()` filters the print, not the
+    /// work done to build its arguments.
+    public static func isLoggable(_ level: Level) -> Bool {
+        enabled && level >= minLevel
+    }
+
     /// Log a debug message
     public static func log(_ message: String, level: Level = .info) {
         guard enabled, level >= minLevel else { return }


### PR DESCRIPTION
## Contexte

Troisième volet de la campagne perf 2026-07 (après #112 profiling et #113 compile opt-in). Le chargement est sain à chaud (transformer 17 GB en 2,5 s) mais trois coûts d'hygiène restaient mesurables. Indépendante de #112/#113 — mergeable seule.

## Changements

1. **`Flux2Pipeline.keepTextEncoderLoaded`** (défaut `false` — comportement memory-first inchangé) : ne décharge plus le text encoder entre générations. Le rechargement par génération coûte ~1 s chaud, plusieurs secondes à froid (bien plus pour l'encodeur Mistral-24B de Dev). Coût quand activé : encodeur + transformer résidents simultanément (Klein-9B + Qwen3-8B-4bit ≈ +5 GB) — la politique reste chez l'hôte, à activer selon la RAM. CLI : `--keep-text-encoder` sur `flux2 inpaint`.
2. **Stats debug du WeightLoader gatées** : les statistiques de poids (2 passes d'eval GPU + réductions f32 complètes, chemins BFL et Diffusers) tournaient à **chaque chargement de transformer même hors mode debug** — seul le print était filtré. Nouveau helper `Flux2Debug.isLoggable(_:)`, blocs gatés dessus.
3. **Purge du cache buffers MLX en fin de génération** (les deux chemins de retour de `generate`) : ~3,2 GB résiduels mesurés après un run 1 MP — du poids mort entre générations pour une app hôte résidente.

## Vérification E2E (klein-9b bf16, inpaint 1 MP, 2 runs même process)

| Effet | Avant | Après |
|---|---|---|
| Load Text Encoder au run 2 (avec `--keep-text-encoder`) | 1,06–1,21 s | **0,0 ms** |
| Cache MLX résiduel après un run | 3 272 MB | **46 MB** |
| Mémoire active avec TE résident | 17,5 GB | 21,9 GB (+4,4 GB, conforme doc) |
| Wall times | — | 57,9 / 69,6 s (plage saine, aucune régression) |

## Non inclus (follow-ups notés)

- R1 overlap `asyncEval(transformer)` pendant le text encoding : gain ~2-3 s chaud seulement, chirurgie concurrente à risque — à traiter séparément si le cold-start devient prioritaire.
- R3 checkpoint MLX-natif pré-mappé/pré-quantifié : gain froid réel mais la quantize à chaud ne coûte que 1-3 s (mesuré) — pertinent surtout pour le cold-start et la taille disque.
- R4 wired memory (`WiredMemoryManager`) : à évaluer côté app résidente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)