### PR TITLE
fix(training): TrainingTextEncoder load/unload off @MainActor (closes #105)

### DIFF
--- a/Sources/Flux2Core/Loading/TrainingTextEncoder.swift
+++ b/Sources/Flux2Core/Loading/TrainingTextEncoder.swift
@@ -18,8 +18,11 @@ public protocol TrainingTextEncoder: AnyObject, Sendable {
     /// Estimated memory usage in GB
     var estimatedMemoryGB: Int { get }
 
-    /// Load the model (if not already loaded)
-    @MainActor
+    /// Load the model (if not already loaded).
+    ///
+    /// Nonisolated since #105 (aligned with #103/#104): weight loading runs
+    /// off the main actor so a hosting UI never blocks on it. Callers
+    /// sequence load → encode themselves (see `LoRATrainingHelper`).
     func load() async throws
 
     /// Encode a text prompt to embeddings for training
@@ -28,15 +31,14 @@ public protocol TrainingTextEncoder: AnyObject, Sendable {
     func encodeForTraining(_ prompt: String) throws -> MLXArray
 
     /// Unload the model to free memory
-    @MainActor
     func unload()
 }
 
 // MARK: - KleinTextEncoder Conformance
 
 extension KleinTextEncoder: TrainingTextEncoder {
-    /// Load the model (protocol conformance wrapper)
-    @MainActor
+    /// Load the model (protocol conformance wrapper). Nonisolated — the
+    /// underlying `load(from:)` has been off-main since #104.
     public func load() async throws {
         try await load(from: nil)
     }
@@ -50,8 +52,8 @@ extension KleinTextEncoder: TrainingTextEncoder {
 // MARK: - DevTextEncoder Conformance
 
 extension DevTextEncoder: TrainingTextEncoder {
-    /// Load the model (protocol conformance wrapper)
-    @MainActor
+    /// Load the model (protocol conformance wrapper). Nonisolated — the
+    /// underlying `load(from:)` has been off-main since #104.
     public func load() async throws {
         try await load(from: nil)
     }


### PR DESCRIPTION
Closes #105 — le reliquat volontaire de #103/#104.

## Changement

Retrait des 4 annotations `@MainActor` : les exigences `load()`/`unload()` du protocole `TrainingTextEncoder` et les deux wrappers de conformance sans argument (`KleinTextEncoder`, `DevTextEncoder`). Les corps n'appellent que `load(from:)`, nonisolated depuis #104 — le chemin d'entraînement ne fait donc plus de hop vers le main thread pour charger l'encodeur de texte.

## Vérification (critères d'acceptation de l'issue, tous passés)

- ✅ Build `xcodebuild` OK (CLI)
- ✅ Suite Metal complète verte (Core + Chains + TextEncoders — `** TEST SUCCEEDED **`)
- ✅ **Vraie boucle d'entraînement** : Klein 4B, cat-toy, 15 steps, DOP actif — termine proprement, loss cohérentes (0,35–1,07 en bell-shaped, zéro NaN), `checkpoint_000015` + `lora_final.safetensors` + learning curve produits
- ✅ **Off-main prouvé** : sonde temporaire `pthread_main_np()` en tête de `KleinTextEncoder.load(from:)` → **0 (off-main) sur les 6 chargements** de l'encodeur pendant le run (sonde non commitée). À noter pour la postérité : `Thread.isMainThread` est `NS_SWIFT_UNAVAILABLE_FROM_ASYNC` en Swift 6, d'où `pthread_main_np()`.

## Points de vigilance (inchangés vs #103/#104)

- SE-0461 : le comportement off-main repose sur `NonisolatedNonsendingByDefault` non activé (Swift 6.0 language mode, pas de `swiftSettings`).
- Pas de lock ajouté : la sérialisation implicite du main actor disparaît ; l'entraînement séquence déjà `isLoaded` → load → encode (LoRATrainingHelper L192/L228).

🤖 Generated with [Claude Code](https://claude.com/claude-code)