### PR TITLE
feat(loading): checkpoints MLX pré-quantifiés — sauvegarde + chargement automatique

### DIFF
--- a/Sources/Flux2CLI/ExportQuantizedCommand.swift
+++ b/Sources/Flux2CLI/ExportQuantizedCommand.swift
@@ -1,0 +1,66 @@
+// ExportQuantizedCommand.swift — `flux2 export-quantized`
+// Copyright 2026 Vincent Gourbin
+//
+// Loads a transformer with on-the-fly quantization (paying the standard
+// bf16 read + quantize pass ONCE), then writes the resulting MLX-native
+// pre-quantized checkpoint next to the source weights. Subsequent loads
+// with the same model/quantization pick it up automatically and skip both
+// the bf16 read and the quantize pass — the win is largest on machines
+// whose page cache cannot hold the bf16 file (16-32 GB Macs), where every
+// load is otherwise a cold load.
+
+import Foundation
+import ArgumentParser
+import Flux2Core
+
+struct ExportQuantized: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "export-quantized",
+        abstract: "Export a pre-quantized MLX transformer checkpoint (skips bf16 read + quantize pass on later loads)"
+    )
+
+    @Option(name: .long, help: "Custom models directory (for sandboxed apps or custom storage).")
+    var modelsDir: String?
+
+    @Option(name: .long, help: "FLUX.2 model: klein-9b | klein-9b-base | klein-9b-kv | dev | klein-4b | klein-4b-base.")
+    var fluxModel: String = "klein-9b"
+
+    @Option(name: .long, help: "Transformer quantization to export (bf16 is rejected — the original checkpoint already is bf16): \(TransformerQuantization.cliValueList)")
+    var transformerQuant: String = "qint8"
+
+    func run() async throws {
+        configureModelsDirectory(modelsDir)
+
+        let modelChoice: Flux2Model
+        switch fluxModel.lowercased() {
+        case "klein-9b", "klein9b":               modelChoice = .klein9B
+        case "klein-9b-base", "klein9b-base":     modelChoice = .klein9BBase
+        case "klein-9b-kv", "klein9b-kv":         modelChoice = .klein9BKV
+        case "klein-4b", "klein4b":               modelChoice = .klein4B
+        case "klein-4b-base", "klein4b-base":     modelChoice = .klein4BBase
+        case "dev":                               modelChoice = .dev
+        default:
+            throw ValidationError("Unsupported --flux-model '\(fluxModel)'.")
+        }
+
+        let quant = try TransformerQuantization.parseCLI(transformerQuant)
+        guard quant != .bf16 else {
+            throw ValidationError("--transformer-quant bf16 makes no sense for a pre-quantized export.")
+        }
+
+        // Text encoder config is irrelevant here (never loaded), any value works.
+        let pipeline = Flux2Pipeline(
+            model: modelChoice,
+            quantization: Flux2QuantizationConfig(textEncoder: .mlx4bit, transformer: quant),
+            vaeVariant: .smallDecoder
+        )
+
+        print("Loading \(modelChoice.displayName) with on-the-fly \(quant.rawValue) quantization (one-time cost)...")
+        let start = Date()
+        let url = try await pipeline.exportPrequantizedTransformer()
+        print("✓ Export done in \(String(format: "%.1fs", Date().timeIntervalSince(start)))")
+        print("✓ Checkpoint: \(url.path)")
+        print("Subsequent loads of \(modelChoice.displayName) with --transformer-quant \(quant.rawValue) will use it automatically.")
+        print("To reclaim the disk space, delete the model's 'mlx-prequantized/' subdirectory.")
+    }
+}

--- a/Sources/Flux2CLI/ExportQuantizedCommand.swift
+++ b/Sources/Flux2CLI/ExportQuantizedCommand.swift
@@ -22,27 +22,19 @@ struct ExportQuantized: AsyncParsableCommand {
     @Option(name: .long, help: "Custom models directory (for sandboxed apps or custom storage).")
     var modelsDir: String?
 
-    @Option(name: .long, help: "FLUX.2 model: klein-9b | klein-9b-base | klein-9b-kv | dev | klein-4b | klein-4b-base.")
+    @Option(name: .long, help: "\(Flux2Model.cliValueList).")
     var fluxModel: String = "klein-9b"
 
     @Option(name: .long, help: "Transformer quantization to export (bf16 is rejected — the original checkpoint already is bf16): \(TransformerQuantization.cliValueList)")
     var transformerQuant: String = "qint8"
 
+    @Flag(name: .long, help: "Regenerate from the source weights even when a checkpoint already exists (without this flag, an existing checkpoint is kept as-is and the command is a no-op).")
+    var force: Bool = false
+
     func run() async throws {
         configureModelsDirectory(modelsDir)
 
-        let modelChoice: Flux2Model
-        switch fluxModel.lowercased() {
-        case "klein-9b", "klein9b":               modelChoice = .klein9B
-        case "klein-9b-base", "klein9b-base":     modelChoice = .klein9BBase
-        case "klein-9b-kv", "klein9b-kv":         modelChoice = .klein9BKV
-        case "klein-4b", "klein4b":               modelChoice = .klein4B
-        case "klein-4b-base", "klein4b-base":     modelChoice = .klein4BBase
-        case "dev":                               modelChoice = .dev
-        default:
-            throw ValidationError("Unsupported --flux-model '\(fluxModel)'.")
-        }
-
+        let modelChoice = try Flux2Model.parseCLI(fluxModel)
         let quant = try TransformerQuantization.parseCLI(transformerQuant)
         guard quant != .bf16 else {
             throw ValidationError("--transformer-quant bf16 makes no sense for a pre-quantized export.")
@@ -55,9 +47,23 @@ struct ExportQuantized: AsyncParsableCommand {
             vaeVariant: .smallDecoder
         )
 
+        // Distinguish the no-op case up front so the user isn't told a
+        // fresh export happened when a valid checkpoint was simply kept.
+        if !force,
+           let sourcePath = Flux2ModelDownloader.findModelPath(for: .transformer(
+               ModelRegistry.TransformerVariant.variant(for: modelChoice, quantization: quant))),
+           Flux2PrequantizedCheckpoint.isValid(sourceModelPath: sourcePath, quantization: quant)
+        {
+            let url = Flux2PrequantizedCheckpoint.weightsURL(
+                sourceModelPath: sourcePath, quantization: quant)
+            print("✓ A valid pre-quantized checkpoint already exists — nothing to do (pass --force to regenerate from the source weights).")
+            print("✓ Checkpoint: \(url.path)")
+            return
+        }
+
         print("Loading \(modelChoice.displayName) with on-the-fly \(quant.rawValue) quantization (one-time cost)...")
         let start = Date()
-        let url = try await pipeline.exportPrequantizedTransformer()
+        let url = try await pipeline.exportPrequantizedTransformer(force: force)
         print("✓ Export done in \(String(format: "%.1fs", Date().timeIntervalSince(start)))")
         print("✓ Checkpoint: \(url.path)")
         print("Subsequent loads of \(modelChoice.displayName) with --transformer-quant \(quant.rawValue) will use it automatically.")

--- a/Sources/Flux2CLI/Flux2CLI.swift
+++ b/Sources/Flux2CLI/Flux2CLI.swift
@@ -30,6 +30,7 @@ struct Flux2CLI: AsyncParsableCommand {
             Outpaint.self,
             MaskSubject.self,
             Download.self,
+            ExportQuantized.self,
             Info.self,
             Profile.self,
             VLMTest.self,

--- a/Sources/Flux2CLI/InpaintCommand.swift
+++ b/Sources/Flux2CLI/InpaintCommand.swift
@@ -154,17 +154,7 @@ struct Inpaint: AsyncParsableCommand {
         logErr("Mask : \(mask) (\(maskCG.width)×\(maskCG.height))")
         logErr("Prompt: \(prompt)")
 
-        let modelChoice: Flux2Model
-        switch fluxModel.lowercased() {
-        case "klein-9b", "klein9b":               modelChoice = .klein9B
-        case "klein-9b-base", "klein9b-base":     modelChoice = .klein9BBase
-        case "klein-9b-kv", "klein9b-kv":         modelChoice = .klein9BKV
-        case "klein-4b", "klein4b":               modelChoice = .klein4B
-        case "klein-4b-base", "klein4b-base":     modelChoice = .klein4BBase
-        case "dev":                               modelChoice = .dev
-        default:
-            throw ValidationError("Unsupported --flux-model '\(fluxModel)'.")
-        }
+        let modelChoice = try Flux2Model.parseCLI(fluxModel)
 
         // Optional Qwen3.5 VLM load — only relevant when the user opts
         // into --enrich-prompt-with-vlm. The chain itself doesn't

--- a/Sources/Flux2CLI/ModelParsing.swift
+++ b/Sources/Flux2CLI/ModelParsing.swift
@@ -1,0 +1,38 @@
+// ModelParsing.swift - Shared CLI parsing for --flux-model options
+// Copyright 2026 Vincent Gourbin
+//
+// Same pattern as QuantizationParsing.swift (PR #108): one parser derived
+// from the enum so the accepted values and help text cannot drift between
+// commands (inpaint / outpaint / export-quantized all take --flux-model).
+
+import ArgumentParser
+import Flux2Core
+
+extension Flux2Model {
+    /// All accepted CLI values, derived from the enum raw values.
+    static var cliValueList: String {
+        allCases.map(\.rawValue).joined(separator: " | ")
+    }
+
+    /// Parse a CLI value. Accepts the raw values plus their no-hyphen
+    /// aliases ("klein9b" → "klein-9b", "klein9b-kv" → "klein-9b-kv", …).
+    static func parseCLI(_ value: String) throws -> Flux2Model {
+        let lowered = value.lowercased()
+        if let parsed = Flux2Model(rawValue: lowered) {
+            return parsed
+        }
+        // No-hyphen aliases: normalize "klein9b*" to "klein-9b*" etc.
+        let normalized = lowered
+            .replacingOccurrences(of: "klein9b", with: "klein-9b")
+            .replacingOccurrences(of: "klein4b", with: "klein-4b")
+        if let parsed = Flux2Model(rawValue: normalized) {
+            return parsed
+        }
+        throw ValidationError("Unsupported --flux-model '\(value)'. Use: \(cliValueList)")
+    }
+
+    /// Help text for --flux-model options.
+    static var cliHelp: String {
+        "FLUX.2 model: \(cliValueList)"
+    }
+}

--- a/Sources/Flux2CLI/OutpaintCommand.swift
+++ b/Sources/Flux2CLI/OutpaintCommand.swift
@@ -77,17 +77,7 @@ struct Outpaint: AsyncParsableCommand {
         logErr("Padding: top=\(top) bottom=\(bottom) left=\(left) right=\(right)")
         logErr("Prompt: \(prompt)")
 
-        let modelChoice: Flux2Model
-        switch fluxModel.lowercased() {
-        case "klein-9b", "klein9b":               modelChoice = .klein9B
-        case "klein-9b-base", "klein9b-base":     modelChoice = .klein9BBase
-        case "klein-9b-kv", "klein9b-kv":         modelChoice = .klein9BKV
-        case "klein-4b", "klein4b":               modelChoice = .klein4B
-        case "klein-4b-base", "klein4b-base":     modelChoice = .klein4BBase
-        case "dev":                               modelChoice = .dev
-        default:
-            throw ValidationError("Unsupported --flux-model '\(fluxModel)'.")
-        }
+        let modelChoice = try Flux2Model.parseCLI(fluxModel)
 
         let pipeline = Flux2Pipeline(
             model: modelChoice,

--- a/Sources/Flux2Core/Loading/PrequantizedCheckpoint.swift
+++ b/Sources/Flux2Core/Loading/PrequantizedCheckpoint.swift
@@ -1,0 +1,177 @@
+// PrequantizedCheckpoint.swift — save/load MLX-native pre-quantized transformer weights
+// Copyright 2026 Vincent Gourbin
+//
+// On-the-fly quantization pays, at EVERY load, the full bf16 read (17 GB for
+// Klein 9B) plus a GPU quantize pass. On machines whose page cache cannot
+// hold the bf16 file (16-32 GB Macs) every load is a cold load, so this cost
+// is structural. A pre-quantized checkpoint stores the QuantizedLinear
+// parameters (packed uint32 `weight` + `scales` + optional `biases`) plus the
+// non-quantized parameters, in the framework's OWN module naming — reloading
+// is then a plain `loadArrays` + `update(parameters:)`: no key mapping, no
+// bf16 materialization, no quantize pass, and ~half the bytes read.
+//
+// Layout: `<sourceModelDir>/mlx-prequantized/<quant>/transformer.safetensors`.
+// Living inside the source model directory keeps the artifact self-contained
+// (deleting the model removes its derivatives; host apps listing top-level
+// model directories don't see a phantom model) and sidesteps any registry
+// change. Writing is EXPLICIT ONLY (CLI `export-quantized` or
+// `Flux2Pipeline.exportPrequantizedTransformer()`) — the framework never
+// surprises the host with a multi-GB disk write; shipping/deleting exports is
+// host policy.
+
+import Foundation
+import MLX
+import MLXNN
+
+public enum Flux2PrequantizedCheckpoint {
+
+    /// Format identifier stored in (and required from) the safetensors metadata.
+    public static let format = "flux2-mlx-prequantized-v1"
+
+    static let subdirectory = "mlx-prequantized"
+    static let filename = "transformer.safetensors"
+
+    /// Location of the pre-quantized export for `quantization`, derived from
+    /// the source model directory (the one `findModelPath` resolves).
+    public static func weightsURL(
+        sourceModelPath: URL,
+        quantization: TransformerQuantization
+    ) -> URL {
+        sourceModelPath
+            .appendingPathComponent(subdirectory)
+            .appendingPathComponent(quantization.rawValue)
+            .appendingPathComponent(filename)
+    }
+
+    /// Whether an export exists for this source/quantization pair.
+    public static func exists(
+        sourceModelPath: URL,
+        quantization: TransformerQuantization
+    ) -> Bool {
+        FileManager.default.fileExists(
+            atPath: weightsURL(sourceModelPath: sourceModelPath, quantization: quantization).path)
+    }
+
+    // MARK: - Save
+
+    /// Save an already-quantized transformer as a pre-quantized checkpoint.
+    ///
+    /// The full flattened parameter set is written (quantized triplets and
+    /// plain f16 parameters alike) so the file is self-sufficient. Modes
+    /// without biases (mxfp4/mxfp8/nvfp4) simply have no `.biases` keys.
+    ///
+    /// - Returns: URL of the written safetensors file.
+    @discardableResult
+    public static func save(
+        model: Flux2Transformer2DModel,
+        sourceModelPath: URL,
+        quantization: TransformerQuantization
+    ) throws -> URL {
+        guard quantization != .bf16 else {
+            throw Flux2Error.invalidConfiguration(
+                "Pre-quantized export requires a quantized transformer (got bf16). Use the original checkpoint instead.")
+        }
+
+        var params: [String: MLXArray] = [:]
+        for (key, value) in model.parameters().flattened() {
+            params[key] = value
+        }
+        // Materialize before writing — save() would do it array by array,
+        // one batched eval lets the IO/compute pipeline overlap instead.
+        eval(params.values.map { $0 })
+
+        let url = weightsURL(sourceModelPath: sourceModelPath, quantization: quantization)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+
+        let metadata: [String: String] = [
+            "format": format,
+            "quantization": quantization.rawValue,
+            "bits": String(quantization.bits),
+            "group_size": String(quantization.groupSize),
+            "mode": quantization.mode.rawValue,
+            "source": sourceModelPath.lastPathComponent,
+            "created_by": "flux-2-swift-mlx",
+        ]
+        try MLX.save(arrays: params, metadata: metadata, url: url)
+
+        let sizeGB = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int)
+            .flatMap { Double($0 ?? 0) / 1_000_000_000 } ?? 0
+        Flux2Debug.log(
+            "Pre-quantized checkpoint saved: \(url.path) (\(params.count) tensors, \(String(format: "%.1f", sizeGB)) GB)")
+        return url
+    }
+
+    // MARK: - Load
+
+    /// Try to load a pre-quantized checkpoint into a freshly-initialized
+    /// transformer. Returns `false` (after logging why) when the checkpoint
+    /// is absent or fails validation — the caller then falls back to the
+    /// standard bf16 + on-the-fly path. Never throws for recoverable
+    /// situations: a bad export must not break generation.
+    ///
+    /// On success the model holds the loaded QuantizedLinear parameters.
+    /// Note: `quantize(model:)` is applied here only to give the model the
+    /// QuantizedLinear STRUCTURE; the lazy quantization of the random init
+    /// weights is never evaluated — `update(parameters:)` replaces those
+    /// arrays before any eval, so the structural pass costs nothing.
+    public static func load(
+        into model: Flux2Transformer2DModel,
+        sourceModelPath: URL,
+        quantization: TransformerQuantization
+    ) -> Bool {
+        let url = weightsURL(sourceModelPath: sourceModelPath, quantization: quantization)
+        guard FileManager.default.fileExists(atPath: url.path) else { return false }
+
+        let loaded: [String: MLXArray]
+        let metadata: [String: String]
+        do {
+            (loaded, metadata) = try loadArraysAndMetadata(url: url)
+        } catch {
+            Flux2Debug.warning("Pre-quantized checkpoint unreadable (\(error)) — falling back to standard load: \(url.path)")
+            return false
+        }
+
+        // Strict metadata validation — a stale or foreign file must not be
+        // silently half-applied.
+        let expected: [(String, String)] = [
+            ("format", format),
+            ("bits", String(quantization.bits)),
+            ("group_size", String(quantization.groupSize)),
+            ("mode", quantization.mode.rawValue),
+        ]
+        for (key, value) in expected where metadata[key] != value {
+            Flux2Debug.warning(
+                "Pre-quantized checkpoint metadata mismatch (\(key): \(metadata[key] ?? "nil") ≠ \(value)) — falling back to standard load: \(url.path)")
+            return false
+        }
+
+        // Give the model the QuantizedLinear structure (lazy, see doc above).
+        quantize(
+            model: model,
+            groupSize: quantization.groupSize,
+            bits: quantization.bits,
+            mode: quantization.mode)
+
+        // Full-coverage key check in BOTH directions: missing keys would
+        // leave random weights in place; extra keys mean a layout drift.
+        var modelKeys = Set<String>()
+        for (key, _) in model.parameters().flattened() {
+            modelKeys.insert(key)
+        }
+        let loadedKeys = Set(loaded.keys)
+        guard loadedKeys == modelKeys else {
+            let missing = modelKeys.subtracting(loadedKeys)
+            let extra = loadedKeys.subtracting(modelKeys)
+            Flux2Debug.warning(
+                "Pre-quantized checkpoint key set mismatch (missing \(missing.count), extra \(extra.count); e.g. \(missing.prefix(3)) / \(extra.prefix(3))) — falling back to standard load: \(url.path)")
+            return false
+        }
+
+        _ = model.update(parameters: ModuleParameters.unflattened(loaded))
+        eval(model.parameters())
+        Flux2Debug.log(
+            "Loaded pre-quantized transformer (\(quantization.rawValue), \(loaded.count) tensors) — skipped bf16 read and quantize pass")
+        return true
+    }
+}

--- a/Sources/Flux2Core/Loading/PrequantizedCheckpoint.swift
+++ b/Sources/Flux2Core/Loading/PrequantizedCheckpoint.swift
@@ -355,9 +355,17 @@ public enum Flux2PrequantizedCheckpoint {
                 "Pre-quantized checkpoint key set mismatch (missing \(missing.count), extra \(extra.count); e.g. \(missing.prefix(3)) / \(extra.prefix(3))) — falling back to standard load: \(url.path)")
             return false
         }
+        // Shapes must match exactly. Dtypes are compared by CATEGORY: the
+        // integer packing (uint32 weight, uint8 fp-mode scales) must be
+        // exact, but float parameters may legitimately differ in precision —
+        // e.g. the quanto source path leaves unquantized params in bfloat16
+        // while the BFL path converts everything to float16.
+        let floatDTypes: Set<DType> = [.float16, .bfloat16, .float32]
         for (key, expectedArray) in manifest {
             guard let actual = loaded[key] else { continue }  // covered by key check
-            if actual.shape != expectedArray.shape || actual.dtype != expectedArray.dtype {
+            let dtypeCompatible = actual.dtype == expectedArray.dtype
+                || (floatDTypes.contains(actual.dtype) && floatDTypes.contains(expectedArray.dtype))
+            if actual.shape != expectedArray.shape || !dtypeCompatible {
                 Flux2Debug.warning(
                     "Pre-quantized checkpoint tensor mismatch at \(key) (shape \(actual.shape) dtype \(actual.dtype) ≠ expected \(expectedArray.shape) \(expectedArray.dtype)) — falling back to standard load: \(url.path)")
                 return false

--- a/Sources/Flux2Core/Loading/PrequantizedCheckpoint.swift
+++ b/Sources/Flux2Core/Loading/PrequantizedCheckpoint.swift
@@ -1,4 +1,4 @@
-// PrequantizedCheckpoint.swift — save/load MLX-native pre-quantized transformer weights
+// PrequantizedCheckpoint.swift — save/load MLX-native pre-quantized weights
 // Copyright 2026 Vincent Gourbin
 //
 // On-the-fly quantization pays, at EVERY load, the full bf16 read (17 GB for
@@ -10,7 +10,7 @@
 // is then a plain `loadArrays` + `update(parameters:)`: no key mapping, no
 // bf16 materialization, no quantize pass, and ~half the bytes read.
 //
-// Layout: `<sourceModelDir>/mlx-prequantized/<quant>/transformer.safetensors`.
+// Layout: `<sourceModelDir>/mlx-prequantized/<quant>/<component>.safetensors`.
 // Living inside the source model directory keeps the artifact self-contained
 // (deleting the model removes its derivatives; host apps listing top-level
 // model directories don't see a phantom model) and sidesteps any registry
@@ -18,6 +18,18 @@
 // `Flux2Pipeline.exportPrequantizedTransformer()`) — the framework never
 // surprises the host with a multi-GB disk write; shipping/deleting exports is
 // host policy.
+//
+// Safety model (review #116 hardening):
+// - the save is ATOMIC (temp file + rename) so a crash or disk-full can never
+//   leave a truncated file at the auto-discovered path — critical because a
+//   valid-header/truncated-data safetensors would otherwise load as SILENT
+//   uninitialized weights (MLX's deferred pread errors are not surfaced);
+// - `load(into:)` validates everything (metadata, source fingerprint, key
+//   sets, shapes/dtypes) BEFORE mutating the caller's model — on any failure
+//   it returns false having touched nothing, so the standard-path fallback
+//   runs on a pristine model;
+// - LoRA-baked exports are tagged in metadata and loudly warned about at
+//   load (they intentionally restyle every generation of that model/quant).
 
 import Foundation
 import MLX
@@ -29,149 +41,340 @@ public enum Flux2PrequantizedCheckpoint {
     public static let format = "flux2-mlx-prequantized-v1"
 
     static let subdirectory = "mlx-prequantized"
-    static let filename = "transformer.safetensors"
 
     /// Location of the pre-quantized export for `quantization`, derived from
     /// the source model directory (the one `findModelPath` resolves).
+    /// `component` names the model being stored ("transformer" for the
+    /// pipeline's use; the API itself only needs `Module`, so other heavy
+    /// components can reuse it).
     public static func weightsURL(
         sourceModelPath: URL,
-        quantization: TransformerQuantization
+        quantization: TransformerQuantization,
+        component: String = "transformer"
     ) -> URL {
         sourceModelPath
             .appendingPathComponent(subdirectory)
             .appendingPathComponent(quantization.rawValue)
-            .appendingPathComponent(filename)
+            .appendingPathComponent("\(component).safetensors")
     }
 
     /// Whether an export exists for this source/quantization pair.
     public static func exists(
         sourceModelPath: URL,
-        quantization: TransformerQuantization
+        quantization: TransformerQuantization,
+        component: String = "transformer"
     ) -> Bool {
         FileManager.default.fileExists(
-            atPath: weightsURL(sourceModelPath: sourceModelPath, quantization: quantization).path)
+            atPath: weightsURL(
+                sourceModelPath: sourceModelPath, quantization: quantization,
+                component: component
+            ).path)
     }
 
-    // MARK: - Save
-
-    /// Save an already-quantized transformer as a pre-quantized checkpoint.
-    ///
-    /// The full flattened parameter set is written (quantized triplets and
-    /// plain f16 parameters alike) so the file is self-sufficient. Modes
-    /// without biases (mxfp4/mxfp8/nvfp4) simply have no `.biases` keys.
-    ///
-    /// - Returns: URL of the written safetensors file.
-    @discardableResult
-    public static func save(
-        model: Flux2Transformer2DModel,
+    /// Remove the export for this source/quantization pair (idempotent).
+    /// Used by `export(force:)` to guarantee regeneration from the source.
+    public static func remove(
         sourceModelPath: URL,
-        quantization: TransformerQuantization
-    ) throws -> URL {
-        guard quantization != .bf16 else {
-            throw Flux2Error.invalidConfiguration(
-                "Pre-quantized export requires a quantized transformer (got bf16). Use the original checkpoint instead.")
-        }
-
-        var params: [String: MLXArray] = [:]
-        for (key, value) in model.parameters().flattened() {
-            params[key] = value
-        }
-        // Materialize before writing — save() would do it array by array,
-        // one batched eval lets the IO/compute pipeline overlap instead.
-        eval(params.values.map { $0 })
-
-        let url = weightsURL(sourceModelPath: sourceModelPath, quantization: quantization)
-        try FileManager.default.createDirectory(
-            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-
-        let metadata: [String: String] = [
-            "format": format,
-            "quantization": quantization.rawValue,
-            "bits": String(quantization.bits),
-            "group_size": String(quantization.groupSize),
-            "mode": quantization.mode.rawValue,
-            "source": sourceModelPath.lastPathComponent,
-            "created_by": "flux-2-swift-mlx",
-        ]
-        try MLX.save(arrays: params, metadata: metadata, url: url)
-
-        let sizeGB = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int)
-            .flatMap { Double($0 ?? 0) / 1_000_000_000 } ?? 0
-        Flux2Debug.log(
-            "Pre-quantized checkpoint saved: \(url.path) (\(params.count) tensors, \(String(format: "%.1f", sizeGB)) GB)")
-        return url
+        quantization: TransformerQuantization,
+        component: String = "transformer"
+    ) {
+        let url = weightsURL(
+            sourceModelPath: sourceModelPath, quantization: quantization, component: component)
+        try? FileManager.default.removeItem(at: url)
     }
 
-    // MARK: - Load
+    // MARK: - Source fingerprint
 
-    /// Try to load a pre-quantized checkpoint into a freshly-initialized
-    /// transformer. Returns `false` (after logging why) when the checkpoint
-    /// is absent or fails validation — the caller then falls back to the
-    /// standard bf16 + on-the-fly path. Never throws for recoverable
-    /// situations: a bad export must not break generation.
-    ///
-    /// On success the model holds the loaded QuantizedLinear parameters.
-    /// Note: `quantize(model:)` is applied here only to give the model the
-    /// QuantizedLinear STRUCTURE; the lazy quantization of the random init
-    /// weights is never evaluated — `update(parameters:)` replaces those
-    /// arrays before any eval, so the structural pass costs nothing.
-    public static func load(
-        into model: Flux2Transformer2DModel,
-        sourceModelPath: URL,
-        quantization: TransformerQuantization
-    ) -> Bool {
-        let url = weightsURL(sourceModelPath: sourceModelPath, quantization: quantization)
-        guard FileManager.default.fileExists(atPath: url.path) else { return false }
+    /// Cheap identity of the source weights: name/size/mtime of every
+    /// `.safetensors` directly in the source directory. Detects a re-download
+    /// (new HF revision, repaired shards) or a checkpoint directory copied
+    /// under a different same-architecture model, without hashing gigabytes.
+    static func sourceFingerprint(of sourceModelPath: URL) -> String {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(atPath: sourceModelPath.path) else {
+            return "unknown"
+        }
+        let parts: [String] = entries.filter { $0.hasSuffix(".safetensors") }.sorted().map { name in
+            let attrs = try? fm.attributesOfItem(
+                atPath: sourceModelPath.appendingPathComponent(name).path)
+            let size = (attrs?[.size] as? NSNumber)?.int64Value ?? -1
+            let mtime = (attrs?[.modificationDate] as? Date)?.timeIntervalSince1970 ?? -1
+            return "\(name):\(size):\(Int(mtime))"
+        }
+        return parts.isEmpty ? "unknown" : parts.joined(separator: ",")
+    }
 
-        let loaded: [String: MLXArray]
-        let metadata: [String: String]
-        do {
-            (loaded, metadata) = try loadArraysAndMetadata(url: url)
-        } catch {
-            Flux2Debug.warning("Pre-quantized checkpoint unreadable (\(error)) — falling back to standard load: \(url.path)")
+    /// Payload integrity check: a safetensors file whose header parses but
+    /// whose tensor data is truncated (killed copy, corrupted volume) would
+    /// otherwise pass every header-derived check (metadata, keys, shapes)
+    /// and then load SILENTLY UNINITIALIZED tensors — MLX's deferred pread
+    /// errors are swallowed by the scheduler, so nothing surfaces. The
+    /// header's `data_offsets` give the exact expected payload size; compare
+    /// it against the real file size before trusting anything else.
+    static func payloadIsComplete(url: URL) -> Bool {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
+        defer { try? handle.close() }
+        guard let lenData = try? handle.read(upToCount: 8), lenData.count == 8 else { return false }
+        let headerLen = lenData.withUnsafeBytes { $0.loadUnaligned(as: UInt64.self) }  // little-endian per spec; Apple platforms are LE
+        guard headerLen > 0, headerLen < 512 * 1024 * 1024,
+              let headerData = try? handle.read(upToCount: Int(headerLen)),
+              headerData.count == Int(headerLen),
+              let header = try? JSONSerialization.jsonObject(with: headerData) as? [String: Any]
+        else { return false }
+        var maxEnd: Int64 = 0
+        for (key, value) in header where key != "__metadata__" {
+            guard let entry = value as? [String: Any],
+                  let offsets = entry["data_offsets"] as? [Any],
+                  offsets.count == 2,
+                  let end = (offsets[1] as? NSNumber)?.int64Value
+            else { return false }
+            maxEnd = max(maxEnd, end)
+        }
+        let expectedSize = Int64(8) + Int64(headerLen) + maxEnd
+        let actualSize = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize)
+            .map(Int64.init) ?? -1
+        if actualSize != expectedSize {
+            Flux2Debug.warning(
+                "Pre-quantized checkpoint payload is incomplete (\(actualSize) bytes on disk, header declares \(expectedSize)) — the file is truncated or corrupt: \(url.path)")
             return false
         }
+        return true
+    }
 
-        // Strict metadata validation — a stale or foreign file must not be
-        // silently half-applied.
+    /// Lightweight validity probe: payload-integrity + header + metadata
+    /// checks only (lazy read, no tensor materialization). Used by exports
+    /// to distinguish "a valid checkpoint already exists" (no-op without
+    /// force) from "an invalid or stale file squats the path" (regenerate) —
+    /// otherwise the load-side "re-run export-quantized" advice would loop
+    /// into a no-op.
+    public static func isValid(
+        sourceModelPath: URL,
+        quantization: TransformerQuantization,
+        component: String = "transformer"
+    ) -> Bool {
+        let url = weightsURL(
+            sourceModelPath: sourceModelPath, quantization: quantization, component: component)
+        guard FileManager.default.fileExists(atPath: url.path),
+              payloadIsComplete(url: url),
+              let (_, metadata) = try? loadArraysAndMetadata(url: url)
+        else { return false }
+        return validateMetadata(
+            metadata, url: url, sourceModelPath: sourceModelPath,
+            quantization: quantization, component: component)
+    }
+
+    /// Shared metadata validation (see `load` step 1 and `isValid`).
+    private static func validateMetadata(
+        _ metadata: [String: String],
+        url: URL,
+        sourceModelPath: URL,
+        quantization: TransformerQuantization,
+        component: String
+    ) -> Bool {
         let expected: [(String, String)] = [
             ("format", format),
+            ("quantization", quantization.rawValue),
             ("bits", String(quantization.bits)),
             ("group_size", String(quantization.groupSize)),
             ("mode", quantization.mode.rawValue),
+            ("component", component),
+            ("source", sourceModelPath.lastPathComponent),
         ]
         for (key, value) in expected where metadata[key] != value {
             Flux2Debug.warning(
                 "Pre-quantized checkpoint metadata mismatch (\(key): \(metadata[key] ?? "nil") ≠ \(value)) — falling back to standard load: \(url.path)")
             return false
         }
+        let fingerprint = sourceFingerprint(of: sourceModelPath)
+        if metadata["source_fingerprint"] != fingerprint {
+            Flux2Debug.warning(
+                "Pre-quantized checkpoint is stale (source weights changed since export — re-download or update?) — falling back to standard load. Re-run `flux2 export-quantized` with force to refresh: \(url.path)")
+            return false
+        }
+        return true
+    }
 
-        // Give the model the QuantizedLinear structure (lazy, see doc above).
+    // MARK: - Save
+
+    /// Save an already-quantized model as a pre-quantized checkpoint.
+    ///
+    /// The full flattened parameter set is written (quantized triplets and
+    /// plain f16 parameters alike) so the file is self-sufficient. Modes
+    /// without biases (mxfp4/mxfp8/nvfp4) simply have no `.biases` keys.
+    ///
+    /// The write is atomic: data goes to a temporary file in the destination
+    /// directory, then replaces the final path in one rename. On any error
+    /// the temporary file is removed and the previous checkpoint (if any) is
+    /// left untouched.
+    ///
+    /// - Parameter loRABaked: set when the model contains merged LoRA
+    ///   weights; recorded in metadata so `load` can warn (the export then
+    ///   intentionally restyles every generation of that model/quant).
+    /// - Returns: URL of the written safetensors file.
+    @discardableResult
+    public static func save(
+        model: Module,
+        sourceModelPath: URL,
+        quantization: TransformerQuantization,
+        component: String = "transformer",
+        loRABaked: Bool = false
+    ) throws -> URL {
+        guard quantization != .bf16 else {
+            throw Flux2Error.invalidConfiguration(
+                "Pre-quantized export requires a quantized model (got bf16). Use the original checkpoint instead.")
+        }
+
+        let params = Dictionary(uniqueKeysWithValues: Array(model.parameters().flattened()))
+        eval(Array(params.values))
+
+        let url = weightsURL(
+            sourceModelPath: sourceModelPath, quantization: quantization, component: component)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+
+        var metadata: [String: String] = [
+            "format": format,
+            "quantization": quantization.rawValue,
+            "bits": String(quantization.bits),
+            "group_size": String(quantization.groupSize),
+            "mode": quantization.mode.rawValue,
+            "component": component,
+            "source": sourceModelPath.lastPathComponent,
+            "source_fingerprint": sourceFingerprint(of: sourceModelPath),
+            "created_by": "flux-2-swift-mlx",
+        ]
+        if loRABaked {
+            metadata["lora_baked"] = "true"
+        }
+
+        // Atomic write: never leave a truncated file at the discovered path.
+        let tmpURL = url.deletingLastPathComponent()
+            .appendingPathComponent(".tmp-\(url.lastPathComponent)")
+        try? FileManager.default.removeItem(at: tmpURL)
+        do {
+            try MLX.save(arrays: params, metadata: metadata, url: tmpURL)
+            _ = try FileManager.default.replaceItemAt(url, withItemAt: tmpURL)
+        } catch {
+            try? FileManager.default.removeItem(at: tmpURL)
+            throw error
+        }
+
+        let sizeBytes = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        Flux2Debug.log(
+            "Pre-quantized checkpoint saved: \(url.path) (\(params.count) tensors, \(String(format: "%.1f", Double(sizeBytes) / 1_000_000_000)) GB\(loRABaked ? ", LoRA-baked" : ""))")
+        return url
+    }
+
+    // MARK: - Load
+
+    /// Try to load a pre-quantized checkpoint into a freshly-initialized,
+    /// NOT-yet-quantized model. Returns `false` (after logging why) when the
+    /// checkpoint is absent or fails validation — in that case the model has
+    /// NOT been mutated in any way, so the caller can safely fall back to
+    /// the standard load path on the same instance. Never throws for
+    /// recoverable situations: a bad export must not break generation.
+    ///
+    /// Validation order (everything before any mutation):
+    /// 0. payload integrity (file size vs header `data_offsets` — the only
+    ///    gate a valid-header/truncated-data file cannot pass);
+    /// 1. metadata: format, quantization identity, bits/group/mode, source
+    ///    name + fingerprint, LoRA-bake warning;
+    /// 2. key sets in both directions against the post-quantization
+    ///    parameter manifest — computed on a THROWAWAY structure clone, not
+    ///    on the caller's model;
+    /// 3. shapes and dtypes of every tensor against that manifest (the
+    ///    update below runs unverified, so this is the only shape gate).
+    /// Only then is the caller's model quantized (structure only, lazy —
+    /// `update(parameters:)` replaces the arrays before anything evaluates)
+    /// and updated.
+    public static func load(
+        into model: Module,
+        makeStructureClone: () -> Module,
+        sourceModelPath: URL,
+        quantization: TransformerQuantization,
+        component: String = "transformer"
+    ) -> Bool {
+        let url = weightsURL(
+            sourceModelPath: sourceModelPath, quantization: quantization, component: component)
+        guard FileManager.default.fileExists(atPath: url.path) else { return false }
+
+        // 0. Payload integrity — MUST precede everything: all later checks
+        // are header-derived and would pass on a truncated-data file.
+        guard payloadIsComplete(url: url) else { return false }
+
+        let loaded: [String: MLXArray]
+        let metadata: [String: String]
+        do {
+            (loaded, metadata) = try loadArraysAndMetadata(url: url)
+        } catch {
+            Flux2Debug.warning(
+                "Pre-quantized checkpoint unreadable (\(error)) — falling back to standard load: \(url.path)")
+            return false
+        }
+
+        // 1. Strict metadata validation — a stale or foreign file must not
+        // be silently half-applied.
+        guard validateMetadata(
+            metadata, url: url, sourceModelPath: sourceModelPath,
+            quantization: quantization, component: component)
+        else {
+            return false
+        }
+        if metadata["lora_baked"] == "true" {
+            Flux2Debug.warning(
+                "Pre-quantized checkpoint has LoRA weights BAKED IN — every generation of this model/quant will carry that LoRA's style. Delete \(url.deletingLastPathComponent().path) if this is not intended.")
+        }
+
+        // 2+3. Build the expected post-quantization manifest on a throwaway
+        // structure clone so the caller's model stays pristine until every
+        // check has passed. The clone's random weights are lazy and never
+        // evaluated — only key names, shapes and dtypes are consulted.
+        // Cast the clone to float16 first: the standard load path converts
+        // every parameter to f16 before quantizing (WeightLoader), while a
+        // fresh init is f32 — without the cast the manifest's scales/biases
+        // dtypes would spuriously mismatch every legitimate checkpoint.
+        let reference = makeStructureClone()
+        let castParams = Dictionary(
+            uniqueKeysWithValues: reference.parameters().flattened().map {
+                ($0.0, $0.1.asType(.float16))
+            })
+        _ = reference.update(parameters: ModuleParameters.unflattened(castParams))
+        quantize(
+            model: reference,
+            groupSize: quantization.groupSize,
+            bits: quantization.bits,
+            mode: quantization.mode)
+        let manifest = Dictionary(uniqueKeysWithValues: Array(reference.parameters().flattened()))
+
+        let manifestKeys = Set(manifest.keys)
+        let loadedKeys = Set(loaded.keys)
+        guard loadedKeys == manifestKeys else {
+            let missing = manifestKeys.subtracting(loadedKeys)
+            let extra = loadedKeys.subtracting(manifestKeys)
+            Flux2Debug.warning(
+                "Pre-quantized checkpoint key set mismatch (missing \(missing.count), extra \(extra.count); e.g. \(missing.prefix(3)) / \(extra.prefix(3))) — falling back to standard load: \(url.path)")
+            return false
+        }
+        for (key, expectedArray) in manifest {
+            guard let actual = loaded[key] else { continue }  // covered by key check
+            if actual.shape != expectedArray.shape || actual.dtype != expectedArray.dtype {
+                Flux2Debug.warning(
+                    "Pre-quantized checkpoint tensor mismatch at \(key) (shape \(actual.shape) dtype \(actual.dtype) ≠ expected \(expectedArray.shape) \(expectedArray.dtype)) — falling back to standard load: \(url.path)")
+                return false
+            }
+        }
+
+        // All checks passed — NOW mutate the caller's model: structural
+        // quantize (lazy, never evaluated) then replace all parameters.
         quantize(
             model: model,
             groupSize: quantization.groupSize,
             bits: quantization.bits,
             mode: quantization.mode)
-
-        // Full-coverage key check in BOTH directions: missing keys would
-        // leave random weights in place; extra keys mean a layout drift.
-        var modelKeys = Set<String>()
-        for (key, _) in model.parameters().flattened() {
-            modelKeys.insert(key)
-        }
-        let loadedKeys = Set(loaded.keys)
-        guard loadedKeys == modelKeys else {
-            let missing = modelKeys.subtracting(loadedKeys)
-            let extra = loadedKeys.subtracting(modelKeys)
-            Flux2Debug.warning(
-                "Pre-quantized checkpoint key set mismatch (missing \(missing.count), extra \(extra.count); e.g. \(missing.prefix(3)) / \(extra.prefix(3))) — falling back to standard load: \(url.path)")
-            return false
-        }
-
         _ = model.update(parameters: ModuleParameters.unflattened(loaded))
         eval(model.parameters())
         Flux2Debug.log(
-            "Loaded pre-quantized transformer (\(quantization.rawValue), \(loaded.count) tensors) — skipped bf16 read and quantize pass")
+            "Loaded pre-quantized \(component) (\(quantization.rawValue), \(loaded.count) tensors) — skipped source read and quantize pass")
         return true
     }
 }

--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
@@ -143,6 +143,10 @@ public class Flux2Pipeline: @unchecked Sendable {
     /// LoRA adapter manager
     private var loraManager: LoRAManager?
 
+    /// Source directory the transformer weights were resolved from (set by
+    /// `loadTransformer`) — anchor for pre-quantized checkpoint exports.
+    private var transformerSourcePath: URL?
+
     /// Active LoRA scheduler overrides (from loaded LoRA config)
     private var loraSchedulerOverrides: SchedulerOverrides?
 
@@ -490,6 +494,31 @@ public class Flux2Pipeline: @unchecked Sendable {
             memoryOptimization: memoryOptimization
         )
         Flux2Debug.log("Memory optimization: \(memoryOptimization)")
+        transformerSourcePath = modelPath
+
+        // Fast path: a pre-quantized MLX checkpoint exported earlier (see
+        // Flux2PrequantizedCheckpoint / `flux2 export-quantized`) skips the
+        // bf16 read, the key mapping, and the quantize pass entirely. Falls
+        // through to the standard path on absence or validation failure.
+        if quantization.transformer != .bf16,
+           Flux2PrequantizedCheckpoint.load(
+               into: transformer!,
+               sourceModelPath: modelPath,
+               quantization: quantization.transformer
+           ) {
+            memoryManager.fullCleanup()
+            // Merge LoRA weights if any are loaded (same as the standard path)
+            if let loraManager = loraManager, loraManager.count > 0 {
+                MLX.Memory.peakMemory = 0
+                Flux2WeightLoader.mergeLoRAWeights(from: loraManager, into: transformer!)
+                loraManager.clearWeightsAfterFusion()
+                memoryManager.fullCleanup()
+            }
+            eval(transformer!.parameters())
+            memoryManager.logMemoryState()
+            Flux2Debug.log("Transformer loaded successfully (pre-quantized checkpoint)")
+            return
+        }
 
         // Load weights with explicit memory management
         // For large models (Dev), this can temporarily use 2x memory during mapping
@@ -669,6 +698,40 @@ public class Flux2Pipeline: @unchecked Sendable {
         eval(vae!.parameters())
 
         Flux2Debug.log("VAE loaded successfully (\(vaeVariant.displayName), decoder: \(vaeConfig.effectiveDecoderChannels))")
+    }
+
+    /// Export the transformer as a pre-quantized MLX checkpoint next to its
+    /// source weights, so subsequent loads with the same quantization skip
+    /// the bf16 read and the quantize pass (see `Flux2PrequantizedCheckpoint`).
+    ///
+    /// Loads the transformer first if needed (paying the standard on-the-fly
+    /// path once). Requires a non-bf16 transformer quantization. The write is
+    /// explicit by design — call this from the host when trading disk for
+    /// load time is wanted (roughly the quantized model size on disk, e.g.
+    /// ~9.6 GB for Klein 9B qint8). Delete the model's `mlx-prequantized/`
+    /// subdirectory to reclaim the space.
+    ///
+    /// - Parameter allowLoRABaked: exporting while LoRAs are merged would
+    ///   bake them into the checkpoint; refused unless explicitly allowed.
+    /// - Returns: URL of the written safetensors file.
+    @discardableResult
+    public func exportPrequantizedTransformer(allowLoRABaked: Bool = false) async throws -> URL {
+        guard quantization.transformer != .bf16 else {
+            throw Flux2Error.invalidConfiguration(
+                "exportPrequantizedTransformer requires a quantized transformer configuration (current: bf16)")
+        }
+        if !allowLoRABaked, let loraManager, loraManager.count > 0 {
+            throw Flux2Error.invalidConfiguration(
+                "LoRAs are loaded — the export would bake them into the base checkpoint. Pass allowLoRABaked: true if that is intended.")
+        }
+        try await loadTransformer()
+        guard let transformer, let sourcePath = transformerSourcePath else {
+            throw Flux2Error.modelNotLoaded("Transformer not loaded — cannot export")
+        }
+        return try Flux2PrequantizedCheckpoint.save(
+            model: transformer,
+            sourceModelPath: sourcePath,
+            quantization: quantization.transformer)
     }
 
     /// Unload transformer to free memory

--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
@@ -147,6 +147,21 @@ public class Flux2Pipeline: @unchecked Sendable {
     /// `loadTransformer`) — anchor for pre-quantized checkpoint exports.
     private var transformerSourcePath: URL?
 
+    /// When set, `loadTransformer` ignores any pre-quantized checkpoint and
+    /// loads from the source weights. Used by exports to guarantee the
+    /// result is derived from the source, never from a previous export.
+    private var skipPrequantizedCheckpoint = false
+
+    /// Whether the currently loaded transformer came from a pre-quantized
+    /// checkpoint (informational; also guards export round-trips).
+    public private(set) var transformerLoadedFromPrequantized = false
+
+    /// Whether LoRA weights have been merged into the CURRENT transformer
+    /// instance. Unlike `loraManager.count`, this survives `unloadLoRA` —
+    /// merged weights cannot be un-merged without reloading the base model,
+    /// so this is the flag export safety checks must consult.
+    public private(set) var transformerHasMergedLoRAs = false
+
     /// Active LoRA scheduler overrides (from loaded LoRA config)
     private var loraSchedulerOverrides: SchedulerOverrides?
 
@@ -495,85 +510,100 @@ public class Flux2Pipeline: @unchecked Sendable {
         )
         Flux2Debug.log("Memory optimization: \(memoryOptimization)")
         transformerSourcePath = modelPath
+        transformerHasMergedLoRAs = false  // fresh instance, nothing merged yet
 
         // Fast path: a pre-quantized MLX checkpoint exported earlier (see
         // Flux2PrequantizedCheckpoint / `flux2 export-quantized`) skips the
-        // bf16 read, the key mapping, and the quantize pass entirely. Falls
-        // through to the standard path on absence or validation failure.
-        if quantization.transformer != .bf16,
-           Flux2PrequantizedCheckpoint.load(
-               into: transformer!,
-               sourceModelPath: modelPath,
-               quantization: quantization.transformer
-           ) {
-            memoryManager.fullCleanup()
-            // Merge LoRA weights if any are loaded (same as the standard path)
-            if let loraManager = loraManager, loraManager.count > 0 {
-                MLX.Memory.peakMemory = 0
-                Flux2WeightLoader.mergeLoRAWeights(from: loraManager, into: transformer!)
-                loraManager.clearWeightsAfterFusion()
+        // bf16 read, the key mapping, and the quantize pass entirely. Its
+        // validation runs BEFORE any model mutation, so on failure the same
+        // pristine instance falls through to the standard path below.
+        // Exports set `skipPrequantizedCheckpoint` to guarantee the result
+        // derives from the source weights, never from a previous export.
+        var loadedFromPrequantized = false
+        if quantization.transformer != .bf16, !skipPrequantizedCheckpoint {
+            loadedFromPrequantized = Flux2PrequantizedCheckpoint.load(
+                into: transformer!,
+                makeStructureClone: {
+                    Flux2Transformer2DModel(
+                        config: self.model.transformerConfig,
+                        memoryOptimization: self.memoryOptimization)
+                },
+                sourceModelPath: modelPath,
+                quantization: quantization.transformer
+            )
+            if loadedFromPrequantized {
                 memoryManager.fullCleanup()
             }
-            eval(transformer!.parameters())
-            memoryManager.logMemoryState()
-            Flux2Debug.log("Transformer loaded successfully (pre-quantized checkpoint)")
-            return
         }
+        transformerLoadedFromPrequantized = loadedFromPrequantized
 
-        // Load weights with explicit memory management
-        // For large models (Dev), this can temporarily use 2x memory during mapping
-        Flux2Debug.log("Loading transformer weights from disk...")
-        var weights = try Flux2WeightLoader.loadWeights(from: modelPath)
+        if !loadedFromPrequantized {
+            // Load weights with explicit memory management
+            // For large models (Dev), this can temporarily use 2x memory during mapping
+            Flux2Debug.log("Loading transformer weights from disk...")
+            var weights = try Flux2WeightLoader.loadWeights(from: modelPath)
 
-        Flux2Debug.log("Applying weights to model...")
-        try Flux2WeightLoader.applyTransformerWeights(&weights, to: transformer!)
+            Flux2Debug.log("Applying weights to model...")
+            try Flux2WeightLoader.applyTransformerWeights(&weights, to: transformer!)
 
-        // Explicitly release the raw weights dictionary to free memory
-        // This is important for Dev model where weights can be ~32GB
-        weights.removeAll()
-        eval([])  // Sync to ensure weights are released
-        memoryManager.fullCleanup()
-        Flux2Debug.log("Raw weights released from memory")
-
-        // Quantize transformer to native MLX QuantizedLinear if requested
-        // This handles both:
-        // 1. Pre-quantized weights (quanto→float16→MLX qint8): negligible precision loss
-        // 2. On-the-fly quantization from bf16 (e.g. Klein 9B qint8, any model int4)
-        // The quantization uses MLX's native QuantizedLinear format which:
-        // - Reduces memory usage proportionally to bit width (8-bit: ~50%, 4-bit: ~75%)
-        // - Uses optimized quantizedMM() for faster inference on Apple Silicon
-        // - Enables efficient dequant→merge→requant for LoRA weight merging
-        if quantization.transformer != .bf16 {
-            let bits = quantization.transformer.bits
-            let groupSize = quantization.transformer.groupSize
-            let mode = quantization.transformer.mode
-            Flux2Debug.log("Quantizing transformer on-the-fly to \(bits)-bit (groupSize=\(groupSize), mode=\(mode.rawValue))...")
-            memoryManager.logMemoryState()
-            quantize(model: transformer!, groupSize: groupSize, bits: bits, mode: mode)
-            eval(transformer!.parameters())
+            // Explicitly release the raw weights dictionary to free memory
+            // This is important for Dev model where weights can be ~32GB
+            weights.removeAll()
+            eval([])  // Sync to ensure weights are released
             memoryManager.fullCleanup()
-            memoryManager.logMemoryState()
-            Flux2Debug.log("Transformer quantized to QuantizedLinear (\(bits)-bit, \(mode.rawValue))")
+            Flux2Debug.log("Raw weights released from memory")
+
+            // Quantize transformer to native MLX QuantizedLinear if requested
+            // This handles both:
+            // 1. Pre-quantized weights (quanto→float16→MLX qint8): negligible precision loss
+            // 2. On-the-fly quantization from bf16 (e.g. Klein 9B qint8, any model int4)
+            // The quantization uses MLX's native QuantizedLinear format which:
+            // - Reduces memory usage proportionally to bit width (8-bit: ~50%, 4-bit: ~75%)
+            // - Uses optimized quantizedMM() for faster inference on Apple Silicon
+            // - Enables efficient dequant→merge→requant for LoRA weight merging
+            if quantization.transformer != .bf16 {
+                let bits = quantization.transformer.bits
+                let groupSize = quantization.transformer.groupSize
+                let mode = quantization.transformer.mode
+                Flux2Debug.log("Quantizing transformer on-the-fly to \(bits)-bit (groupSize=\(groupSize), mode=\(mode.rawValue))...")
+                memoryManager.logMemoryState()
+                quantize(model: transformer!, groupSize: groupSize, bits: bits, mode: mode)
+                eval(transformer!.parameters())
+                memoryManager.fullCleanup()
+                memoryManager.logMemoryState()
+                Flux2Debug.log("Transformer quantized to QuantizedLinear (\(bits)-bit, \(mode.rawValue))")
+            }
         }
 
-        // Merge LoRA weights if any are loaded
+        // Merge LoRA weights if any are loaded — common tail, shared by both
+        // load paths so their behavior cannot drift.
         if let loraManager = loraManager, loraManager.count > 0 {
-            MLX.Memory.peakMemory = 0
-            Flux2Debug.log("[LoRA] Before merge:")
-            memoryManager.logMemoryState()
-            Flux2WeightLoader.mergeLoRAWeights(from: loraManager, into: transformer!)
-            // Free LoRA matrices from memory after fusion (they're now baked into base weights)
-            loraManager.clearWeightsAfterFusion()
-            memoryManager.fullCleanup()
-            Flux2Debug.log("[LoRA] After merge:")
-            memoryManager.logMemoryState()
+            if loraManager.loadedLayerPaths.isEmpty {
+                // A previous fusion already consumed the LoRA weights
+                // (clearWeightsAfterFusion). This freshly loaded transformer
+                // holds BASE weights only — merging would silently no-op
+                // while hasLoRA still reports LoRAs active.
+                Flux2Debug.warning(
+                    "[LoRA] \(loraManager.count) LoRA(s) registered but their weights were already fused into a previous transformer instance and cleared — the reloaded transformer has NO LoRA applied. Reload the LoRA adapters to re-merge.")
+            } else {
+                MLX.Memory.peakMemory = 0
+                Flux2Debug.log("[LoRA] Before merge:")
+                memoryManager.logMemoryState()
+                Flux2WeightLoader.mergeLoRAWeights(from: loraManager, into: transformer!)
+                // Free LoRA matrices from memory after fusion (they're now baked into base weights)
+                loraManager.clearWeightsAfterFusion()
+                transformerHasMergedLoRAs = true
+                memoryManager.fullCleanup()
+                Flux2Debug.log("[LoRA] After merge:")
+                memoryManager.logMemoryState()
+            }
         }
 
         // Ensure weights are evaluated
         eval(transformer!.parameters())
 
         memoryManager.logMemoryState()
-        Flux2Debug.log("Transformer loaded successfully")
+        Flux2Debug.log("Transformer loaded successfully\(loadedFromPrequantized ? " (pre-quantized checkpoint)" : "")")
     }
 
     // MARK: - LoRA Support
@@ -623,6 +653,7 @@ public class Flux2Pipeline: @unchecked Sendable {
             Flux2WeightLoader.mergeLoRAWeights(from: loraManager!, into: transformer)
             // Free LoRA matrices from memory after fusion (they're now baked into base weights)
             loraManager!.clearWeightsAfterFusion()
+            transformerHasMergedLoRAs = true
         }
 
         return info
@@ -704,34 +735,88 @@ public class Flux2Pipeline: @unchecked Sendable {
     /// source weights, so subsequent loads with the same quantization skip
     /// the bf16 read and the quantize pass (see `Flux2PrequantizedCheckpoint`).
     ///
-    /// Loads the transformer first if needed (paying the standard on-the-fly
-    /// path once). Requires a non-bf16 transformer quantization. The write is
-    /// explicit by design — call this from the host when trading disk for
-    /// load time is wanted (roughly the quantized model size on disk, e.g.
-    /// ~9.6 GB for Klein 9B qint8). Delete the model's `mlx-prequantized/`
-    /// subdirectory to reclaim the space.
+    /// The export always derives from the SOURCE weights (never from a
+    /// previous export): the fast path is disabled for the internal load and
+    /// a checkpoint-loaded resident transformer is dropped first. If a
+    /// checkpoint already exists, the call is a no-op returning its URL
+    /// unless `force` is set. Requires a non-bf16 transformer quantization.
+    /// The write is explicit by design — call this from the host when
+    /// trading disk for load time is wanted (roughly the quantized model
+    /// size on disk, e.g. ~9.6 GB for Klein 9B qint8). Delete the model's
+    /// `mlx-prequantized/` subdirectory to reclaim the space.
     ///
-    /// - Parameter allowLoRABaked: exporting while LoRAs are merged would
-    ///   bake them into the checkpoint; refused unless explicitly allowed.
-    /// - Returns: URL of the written safetensors file.
+    /// - Parameters:
+    ///   - allowLoRABaked: the bake check runs AFTER the load against
+    ///     `transformerHasMergedLoRAs` (merged weights survive `unloadLoRA`);
+    ///     when allowed, the export is tagged `lora_baked` in metadata and
+    ///     `load` warns loudly on every use.
+    ///   - force: delete and regenerate an existing checkpoint.
+    /// - Returns: URL of the written (or already existing) safetensors file.
     @discardableResult
-    public func exportPrequantizedTransformer(allowLoRABaked: Bool = false) async throws -> URL {
+    public func exportPrequantizedTransformer(
+        allowLoRABaked: Bool = false,
+        force: Bool = false
+    ) async throws -> URL {
         guard quantization.transformer != .bf16 else {
             throw Flux2Error.invalidConfiguration(
                 "exportPrequantizedTransformer requires a quantized transformer configuration (current: bf16)")
         }
-        if !allowLoRABaked, let loraManager, loraManager.count > 0 {
-            throw Flux2Error.invalidConfiguration(
-                "LoRAs are loaded — the export would bake them into the base checkpoint. Pass allowLoRABaked: true if that is intended.")
+
+        // Resolve the source directory up-front (same resolution as
+        // loadTransformer) so the exists/force decision precedes any load.
+        let variant = ModelRegistry.TransformerVariant.variant(
+            for: model, quantization: quantization.transformer)
+        guard let sourcePath = Flux2ModelDownloader.findModelPath(for: .transformer(variant)) else {
+            throw Flux2Error.modelNotLoaded(
+                "\(model.displayName) transformer weights not found — download the model before exporting")
         }
+
+        if Flux2PrequantizedCheckpoint.exists(
+            sourceModelPath: sourcePath, quantization: quantization.transformer)
+        {
+            // Without force, only a VALID existing checkpoint is a no-op; an
+            // invalid/stale squatter is regenerated (the load-side warning
+            // tells users to re-run the export — that advice must work).
+            if !force,
+               Flux2PrequantizedCheckpoint.isValid(
+                   sourceModelPath: sourcePath, quantization: quantization.transformer)
+            {
+                let url = Flux2PrequantizedCheckpoint.weightsURL(
+                    sourceModelPath: sourcePath, quantization: quantization.transformer)
+                Flux2Debug.log(
+                    "Pre-quantized checkpoint already exists and is valid — nothing to do (pass force to regenerate from the source weights): \(url.path)")
+                return url
+            }
+            Flux2PrequantizedCheckpoint.remove(
+                sourceModelPath: sourcePath, quantization: quantization.transformer)
+        }
+
+        // The export must derive from the SOURCE weights, never from a
+        // previous export: drop a checkpoint-loaded resident transformer and
+        // disable the fast path for the (re)load below.
+        if transformerLoadedFromPrequantized {
+            unloadTransformer()
+        }
+        skipPrequantizedCheckpoint = true
+        defer { skipPrequantizedCheckpoint = false }
         try await loadTransformer()
-        guard let transformer, let sourcePath = transformerSourcePath else {
+
+        guard let transformer, let loadedSourcePath = transformerSourcePath else {
             throw Flux2Error.modelNotLoaded("Transformer not loaded — cannot export")
+        }
+        // Bake check AFTER the load, against the instance actually being
+        // saved: `transformerHasMergedLoRAs` survives unloadLoRA (merged
+        // weights cannot be un-merged) and covers merges that happened
+        // during the load above — `loraManager.count` alone covers neither.
+        if !allowLoRABaked, transformerHasMergedLoRAs {
+            throw Flux2Error.invalidConfiguration(
+                "The loaded transformer contains merged LoRA weights (merges survive unloadLoRA) — the export would bake them into the base checkpoint for every future load. Pass allowLoRABaked: true only if that is intended.")
         }
         return try Flux2PrequantizedCheckpoint.save(
             model: transformer,
-            sourceModelPath: sourcePath,
-            quantization: quantization.transformer)
+            sourceModelPath: loadedSourcePath,
+            quantization: quantization.transformer,
+            loRABaked: transformerHasMergedLoRAs)
     }
 
     /// Unload transformer to free memory
@@ -741,6 +826,8 @@ public class Flux2Pipeline: @unchecked Sendable {
         compiledForward = nil
         compiledForwardKey = nil
         transformer = nil
+        transformerHasMergedLoRAs = false
+        transformerLoadedFromPrequantized = false
         memoryManager.clearCache()
     }
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -425,11 +425,20 @@ flux2 export-quantized --flux-model klein-9b --transformer-quant qint8
 - Output is bit-identical to the on-the-fly path (quantization is
   deterministic; verified at equal seed).
 - Layout: `<model dir>/mlx-prequantized/<quant>/transformer.safetensors`,
-  with strict metadata validation (bits/group size/mode) and automatic
-  fallback to the standard path on any mismatch. Delete the
-  `mlx-prequantized/` subdirectory to reclaim disk space.
-- Library API: `Flux2Pipeline.exportPrequantizedTransformer()` (refuses to
-  bake merged LoRAs unless `allowLoRABaked: true`).
+  with validation before any model mutation — payload integrity (truncation
+  detection), metadata identity (bits/group size/mode/source + a source
+  fingerprint that detects re-downloaded base weights), key sets, and tensor
+  shapes — and automatic fallback to the standard path on any mismatch.
+  Writes are atomic (temp file + rename). Delete the `mlx-prequantized/`
+  subdirectory to reclaim disk space.
+- Re-running the command is a fast no-op while a valid checkpoint exists;
+  pass `--force` to regenerate from the source weights (exports never derive
+  from a previous export).
+- Library API: `Flux2Pipeline.exportPrequantizedTransformer(force:)`. LoRA
+  safety: the export refuses when LoRA weights are merged into the loaded
+  transformer (`transformerHasMergedLoRAs`, which survives `unloadLoRA`)
+  unless `allowLoRABaked: true` — such exports are tagged `lora_baked` in
+  metadata and warned about on every load.
 - Works for all quantized modes (`qint8`, `int4`, `mxfp8`, `mxfp4`,
   `nvfp4`) — fp modes have no `.biases` tensors, which is expected.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -406,6 +406,35 @@ flux2 download --transformer-quant bf16
 
 ---
 
+## Pre-Quantized Checkpoints (`export-quantized`)
+
+On-the-fly quantization re-pays, at every load, the full bf16 read (17 GB
+for Klein 9B) plus a quantize pass. `export-quantized` writes an MLX-native
+pre-quantized checkpoint next to the source weights; subsequent loads with
+the same model/quantization pick it up **automatically** and skip both.
+
+```bash
+# One-time export (pays the standard load once, then writes ~9.6 GB)
+flux2 export-quantized --flux-model klein-9b --transformer-quant qint8
+# From now on, any qint8 load of klein-9b uses it automatically.
+```
+
+- Biggest win on machines whose page cache cannot hold the bf16 file
+  (16–32 GB Macs): every load there is a cold load, and the checkpoint
+  halves the bytes read on top of skipping the quantize pass.
+- Output is bit-identical to the on-the-fly path (quantization is
+  deterministic; verified at equal seed).
+- Layout: `<model dir>/mlx-prequantized/<quant>/transformer.safetensors`,
+  with strict metadata validation (bits/group size/mode) and automatic
+  fallback to the standard path on any mismatch. Delete the
+  `mlx-prequantized/` subdirectory to reclaim disk space.
+- Library API: `Flux2Pipeline.exportPrequantizedTransformer()` (refuses to
+  bake merged LoRAs unless `allowLoRABaked: true`).
+- Works for all quantized modes (`qint8`, `int4`, `mxfp8`, `mxfp4`,
+  `nvfp4`) — fp modes have no `.biases` tensors, which is expected.
+
+---
+
 ## LoRA Adapters
 
 Apply LoRA (Low-Rank Adaptation) weights to customize model behavior for specific tasks.


### PR DESCRIPTION
## Contexte

R3 de la campagne perf, généralisé sur décision : le framework sait maintenant **sauvegarder** des poids MLX pré-quantifiés (capacité générique), et les recharger automatiquement. La quantization à la volée repaie à chaque chargement la lecture bf16 complète (17 GB pour Klein 9B) + un pass de quantize ; sur les Macs 16–32 GB, le bf16 ne tient jamais dans le page cache donc **chaque** chargement est froid — c'est le public principal de cette feature.

## Changements

- **`Flux2PrequantizedCheckpoint`** (nouveau) : export du jeu complet de paramètres du transformer quantifié (triplets packés `weight`/`scales`/`biases` + params f16) en un safetensors unique, **nommage natif framework** (zéro mapping au reload), sous `<dossier modèle>/mlx-prequantized/<quant>/`. Métadonnées strictes (format/bits/group_size/mode) ; validation bidirectionnelle des jeux de clés ; **fallback loggué vers le chemin standard** sur toute anomalie — un export corrompu ne casse jamais une génération.
- **`loadTransformer`** : détection automatique du checkpoint pour la quantization demandée → saute lecture bf16, mapping et quantize. Le `quantize()` structurel appliqué avant `update(parameters:)` reste **lazy** (jamais évalué) — coût nul.
- **Écriture explicite uniquement** (politique à l'hôte) : commande `flux2 export-quantized` + `Flux2Pipeline.exportPrequantizedTransformer()` (refuse d'embarquer des LoRAs mergés sauf `allowLoRABaked: true`).
- Modes fp (mxfp8/mxfp4/nvfp4) gérés (pas de `.biases`, attendu). Doc : section `docs/CLI.md`.

## Vérification E2E (klein-9b qint8, M3 Max 96 GB)

| Étape | Résultat |
|---|---|
| Export | **14,7 s** one-time, 9,65 GB écrits à l'emplacement prévu |
| Rechargement | chemin rapide **prouvé par atime** (bf16 jamais lu, checkpoint lu) ; Load Transformer **1,36 s** (9,6 GB lus au lieu de 17, zéro quantize) |
| Correction | génération même seed **bit-identique** au qint8 on-the-fly (ΔRGB 0,00 / RMSE 0,00) |

## Follow-up (hors PR)

Consommer les checkpoints packés de l'écosystème (mlx-community/mflux — packing identique, clés snake_case déjà couvertes par le mapper diffusers ; vérifiés compatibles : `flux2-klein-9b-8bit` = affine 8-bit groupe 64, 9,6 GB). Réserves notées : licence du repo 9B (taggé apache-2.0 alors que l'amont est gated) et validation qualité E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)