### PR TITLE
docs(knowledge): base de connaissance OKF — baselines, décisions, pièges, playbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A native Swift implementation of [Flux.2](https://blackforestlabs.ai/) image gen
 - **Image-to-Image Training**: Train paired I2I LoRAs (e.g. style transfer, image restoration)
 - **CLI Tool**: Full-featured command-line interface (`Flux2CLI`)
 - **macOS App**: Demo SwiftUI application (`Flux2App`) with T2I, I2I, and chat
+- **Engineering knowledge base**: measured baselines, decisions and verified pitfalls ([docs/knowledge](docs/knowledge/index.md), OKF-structured — readable by humans and agents)
 
 ### Chains (Flux2Chains)
 - **`Flux2Chain` protocol**: composable, single-shot inference jobs returning

--- a/docs/knowledge/benchmarks/klein9b-baselines.md
+++ b/docs/knowledge/benchmarks/klein9b-baselines.md
@@ -1,0 +1,44 @@
+---
+type: Benchmark
+title: Klein 9B generation baselines (M3 Max)
+description: Healthy per-step and wall-clock numbers; durations far above these indicate contention, not an engine regression.
+tags: [klein-9b, klein-4b, baseline, performance]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+Measured on an M3 Max (14 cores, 96 GB), macOS 26.5, mlx-swift 0.31.6, on a
+quiet machine. Configuration: `Flux2MaskedInpaintingChain` at app parity
+(crop-and-stitch padding 48, 1 MP working canvas, 4 steps, guidance 1.0)
+unless noted.
+
+# Baselines
+
+| Config | Per step | Wall (4 steps) |
+|--------|----------|----------------|
+| klein-9b bf16/bf16, ~1 MP canvas | **13-15 s** | **~60-66 s** |
+| klein-4b qint8 ("Balanced"), 2048x2048 t2i | ~8 s | ~32 s |
+| klein-9b bf16, 2048x1536 source, inpaint 1 MP crop | 13-15 s | ~70 s |
+
+Overhead outside denoising (all loads + encodes + decode + composite):
+**6-10 s warm**. Denoising is ~85% of a healthy run.
+
+# Interpretation rule
+
+A `generationDuration` far above these numbers (2x or more) on the same
+config is **contention or host-app state, not the engine** — see the
+[GPU contention playbook](/docs/knowledge/playbooks/gpu-contention-diagnosis.md)
+and the [July 2026 investigation](/docs/knowledge/investigations/generation-slowness-2026-07.md)
+that established this: identical engine commits produced 64 s and 577 s runs
+depending solely on a competing GPU consumer.
+
+# Notes
+
+- First run in a process pays Metal kernel JIT — included in these numbers
+  (the cold first run measured 63.8 s vs 60-66 s steady; the difference is
+  noise-level). See [Metal full-JIT pitfall](/docs/knowledge/pitfalls/metal-full-jit.md).
+- Step time is GEMM/SDPA-bound: neither quantization nor `MLX.compile`
+  reduces it. See [quantization verdicts](/docs/knowledge/decisions/quantization-verdicts.md)
+  and the [compile decision](/docs/knowledge/decisions/compile-step-neutral.md).
+- Benchmarking method: per-phase profiler (`--profile`), repeated runs in one
+  process (`--repeat-count`), and a GPU-quiet gate before each run —
+  benchmarks on a machine running Xcode builds or an active UI are unusable.

--- a/docs/knowledge/benchmarks/loading-costs.md
+++ b/docs/knowledge/benchmarks/loading-costs.md
@@ -1,0 +1,43 @@
+---
+type: Benchmark
+title: Model loading costs (warm/cold)
+description: What each loading phase costs and where load time actually goes; loading is NOT a bottleneck warm.
+tags: [loading, safetensors, page-cache, prequantized]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+Measured on M3 Max 96 GB, mlx-swift 0.31.6 (klein-9b unless noted).
+
+# Warm costs (file in page cache)
+
+| Phase | Cost |
+|-------|------|
+| Transformer bf16, 17 GB, incl. QKV split + bf16→f16 conversion | **2.5-3.3 s** |
+| Transformer + on-the-fly qint8 quantize | 1.3 s |
+| Transformer + on-the-fly mxfp8 quantize | 3.0 s |
+| Text encoder (Qwen3-8B-4bit, 4.3 GB) | 1.1-1.2 s |
+| Pre-quantized checkpoint (9.6 GB, no mapping, no quantize) | 1.4-1.5 s |
+| VAE (small decoder) | ~0 s |
+
+`loadArrays` is lazy (header only); real IO happens at `eval` as parallel
+32 MB preads straight into unified memory. On 96 GB the page cache makes
+warm loads nearly free — **loading is not a bottleneck on large-RAM
+machines**.
+
+# Where it matters: small machines and cold starts
+
+On 16-32 GB Macs the 17 GB bf16 file never stays in page cache, so **every**
+load is a cold load (NVMe-bound, ~6-10 s of IO plus mapping). This is the
+audience for [pre-quantized checkpoints](/docs/CLI.md) (`flux2
+export-quantized`): ~half the bytes read, no transient bf16 materialization,
+no quantize pass.
+
+# Design facts
+
+- The text encoder is reloaded on EVERY generation by default (memory-first
+  design); `Flux2Pipeline.keepTextEncoderLoaded` opts out at ~+5 GB resident
+  (PR #114).
+- Debug weight statistics used to run on every transformer load even with
+  logging off — gated since PR #114 (`Flux2Debug.isLoggable`).
+- The MLX buffer cache retains ~3 GB after a generation; purged at end of
+  generation since PR #114.

--- a/docs/knowledge/decisions/compile-step-neutral.md
+++ b/docs/knowledge/decisions/compile-step-neutral.md
@@ -1,0 +1,47 @@
+---
+type: Decision
+title: "MLX.compile on the denoising forward: measured neutral, kept opt-in"
+description: Compiling the transformer step wins nothing here because the elementwise hot spots are already hand-fused; do not re-attempt without new evidence.
+tags: [mlx-compile, performance, wontfix]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+Decision (2026-07-14, PR #113): `Flux2Pipeline.compileDenoisingStep` /
+`--compile-step` exists but is **opt-in and never the default**. Measured
+neutral — do not re-litigate without new evidence (e.g. a future mlx-swift
+with materially different compile behavior).
+
+# Measurements (klein-9b bf16, 1 MP, 4 steps, M3 Max)
+
+| | Steady-state step | Output |
+|---|---|---|
+| baseline | 12.5-13.6 s | reference |
+| compiled | 13.2 s | bit-identical (mean RGB Δ 0.01/255) |
+
+One-time trace: ~1-2 s on the first step after each (re)trace.
+
+# Why it is neutral
+
+The 5-15% wins reported for `compile` elsewhere come from fusing elementwise
+chains. This codebase already hand-optimized those: modulation precomputed
+outside the block loop, fused RoPE Metal kernel, `MLXFast` rmsNorm/SDPA.
+What remains of a step is GEMM/SDPA, which `compile` does not accelerate.
+
+# Traps if ever revisited
+
+- Intra-forward `eval()` (the `memoryOptimization` graph segmentation) is
+  **illegal under compile tracing** — the flag forces `.disabled`, raising
+  peak memory to the unsegmented level.
+- The compiled closure **retains the transformer** (17 GB) — it must be
+  invalidated in `unloadTransformer()` or unload frees nothing.
+- Guidance arity changes the traced signature; shapes re-trace automatically.
+
+# Related
+
+- Same conclusion family as [quantization verdicts](/docs/knowledge/decisions/quantization-verdicts.md):
+  the klein-9b step time is at the hardware floor on M3 Max; remaining gains
+  are in loading/UX and in adopting `klein-9b-kv` for multi-reference I2I
+  (~2.66x on steps, already in the framework).
+- The asyncEval load/encode overlap idea (R1) was also dropped: ≤2-3 s once
+  per session since the text encoder can stay resident (PR #114), against
+  risky concurrency surgery in the pipeline.

--- a/docs/knowledge/decisions/quantization-verdicts.md
+++ b/docs/knowledge/decisions/quantization-verdicts.md
@@ -1,0 +1,39 @@
+---
+type: Decision
+title: Quantization verdicts for inference
+description: Quantization buys memory, not step time; qint8 is quality-transparent on 9B; avoid mxfp8 for inference.
+tags: [quantization, qint8, mxfp8, int4, benchmark]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+Benchmarked 2026-07-14 (klein-9b, 1 MP inpaint, 4 steps, equal seed, M3 Max;
+mlx-swift 0.31.6 / core 0.31.1). Quality deltas measured on the inpainted
+region against the bf16 output.
+
+# Verdicts
+
+| Mode | Speed vs bf16 | Quality vs bf16 | Verdict |
+|------|--------------|-----------------|---------|
+| qint8 (affine 8-bit, g64) | ~equal (14.9 vs 13.6 s/step) | near-identical on **9B** (mean RGB Δ 1.7/255, Δsat −0.002) | Use for **memory** (−47% active), not speed |
+| mxfp8 (microscaling) | **~2x slower** (24-29 s/step) | **visibly degraded** (washed out, blurry; Δ 36/255) | **Avoid for inference** as of core 0.31.1 |
+| int4 | not benchmarked for speed | aggressive | niche (32 GB Macs) |
+
+# Why quantization does not speed up diffusion steps
+
+LLM decode is GEMV/memory-bound, where 8-bit weights halve the traffic.
+A diffusion denoising step is large-GEMM/SDPA-bound (compute-bound on
+M-series): weight bandwidth is not the limiter, so `quantizedMM` wins
+nothing. Measured, not theorized.
+
+# Historical note
+
+The qint8 color-drift issue (desaturation) is specific to **klein-4B**
+(measured Δ −24 on blue vs 9B bf16 Δ −1); klein-9B qint8 does not exhibit it.
+Do not generalize 4B quality findings to 9B or vice versa.
+
+# Related
+
+- On-the-fly quantize is cheap warm (1.3-3.0 s) — see
+  [loading costs](/docs/knowledge/benchmarks/loading-costs.md).
+- Pre-quantized checkpoints reload bit-identically to on-the-fly
+  quantization (deterministic): mean RGB Δ 0.00 at equal seed.

--- a/docs/knowledge/index.md
+++ b/docs/knowledge/index.md
@@ -1,0 +1,41 @@
+---
+okf_version: "0.1"
+---
+
+# Engineering Knowledge Base
+
+Durable, measured engineering knowledge about this framework: benchmarks,
+decisions with their rationale, verified pitfalls, and diagnostic playbooks.
+Structured as an [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+knowledge bundle — plain markdown with YAML frontmatter, readable by humans
+and agents alike. This is the **knowledge layer**: what is true and why. The
+user docs in [`docs/`](../) explain how to use the framework; concepts here
+record what was measured and decided so it is never re-derived or re-litigated.
+
+# Benchmarks
+
+* [Klein 9B generation baselines](benchmarks/klein9b-baselines.md) - healthy per-step and wall-clock numbers on M3 Max; anything far above them is contention, not the engine
+* [Model loading costs](benchmarks/loading-costs.md) - what each loading phase costs warm/cold, and where the time actually goes
+
+# Decisions
+
+* [Quantization verdicts for inference](decisions/quantization-verdicts.md) - qint8/mxfp8/int4 speed and quality, measured; quantization buys memory, not step time
+* [MLX.compile on the denoising forward: neutral, kept opt-in](decisions/compile-step-neutral.md) - why compiling the step wins nothing here, and the traps if it is ever revisited
+
+# Pitfalls
+
+* [MLX swallows deferred read errors](pitfalls/mlx-swallowed-read-errors.md) - a truncated safetensors with a valid header loads silently uninitialized tensors
+* [Module.update() does not verify shapes](pitfalls/module-update-no-verify.md) - parameter updates apply blindly by default
+* [quantize() skips already-quantized layers](pitfalls/quantize-skips-quantized.md) - a "fallback" re-quantize on a mutated model is a silent no-op
+* [Quanto sources keep bf16 unquantized params](pitfalls/quanto-keeps-bf16.md) - production models are dtype-mixed depending on the checkpoint source
+* [Synchronous withWiredLimit is a no-op](pitfalls/wired-limit-sync-noop.md) - silent behavior change since mlx-swift 0.30.6
+* [Thread.isMainThread is banned in async contexts](pitfalls/thread-ismainthread-async.md) - use pthread_main_np() for thread assertions
+* [Metal kernels are full-JIT per process](pitfalls/metal-full-jit.md) - there is no persistent MLX shader cache to pre-warm
+
+# Investigations
+
+* [Generation slowness campaign (July 2026)](investigations/generation-slowness-2026-07.md) - how a suspected engine regression turned out to be GPU contention from the host app's UI
+
+# Playbooks
+
+* [Diagnosing GPU contention](playbooks/gpu-contention-diagnosis.md) - the 5-minute protocol that attributes a slow generation to its real cause

--- a/docs/knowledge/investigations/generation-slowness-2026-07.md
+++ b/docs/knowledge/investigations/generation-slowness-2026-07.md
@@ -1,0 +1,49 @@
+---
+type: Investigation
+title: Generation slowness campaign (July 2026)
+description: A suspected engine regression (3-9x slowdowns) was GPU contention from the host app's own UI render loop; the engine was innocent.
+tags: [performance, contention, fluxforge-studio, root-cause]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Symptom
+
+Host app (FluxForge Studio) reported generations 3-9x slower than usual on
+identical configs (klein-9b bf16, 2048x1536, 4 steps: 85 s on July 9 vs
+364 s on July 13), with the engine commit identical between fast and slow
+runs. Initial hypothesis: cold-start / kernel-compilation cost.
+
+# Method
+
+1. Exact reproduction: the slow run's full config (prompt, seed, source
+   image, chain parameters) extracted from the app's SwiftData store and
+   replayed through `flux2 inpaint` with per-phase profiling (`--profile`,
+   `--repeat-count`, added in PR #112).
+2. Cross-suspension attribution: `kill -STOP <pid>` on suspects while
+   sampling GPU utilization (`ioreg -r -c IOAccelerator`).
+3. Live stack capture (`sample`) during in-app generations.
+
+# Findings
+
+- Healthy baseline: ~60-66 s wall for the incriminated config — see
+  [baselines](/docs/knowledge/benchmarks/klein9b-baselines.md). Loading was
+  exonerated immediately (17 GB transformer loads in 2.5 s warm).
+- The slowdowns reproduced ONLY under a competing GPU consumer: suspending
+  the host app mid-series turned a 577 s run into 57 s within the same
+  process. The app, idle at 0.3% CPU, saturated the GPU at 96-99%
+  (renderer/tiler = UI rendering, not compute).
+- Mechanism in the app: a SwiftUI animation clock that never stopped
+  (`repeatForever` indicators; layout storm re-rendering whatever view was
+  frontmost, confirmed by sampled stacks). Fixed app-side.
+- The cold-start hypothesis was **disproved**: cold first runs were the
+  FAST ones (see [Metal full-JIT](/docs/knowledge/pitfalls/metal-full-jit.md)).
+- A methodological trap encountered twice: benchmarks run while the machine
+  had ambient GPU/CPU load (Xcode builds, active UI) produced 2-4x inflated
+  and erratic step times. Hence the GPU-quiet gate in the
+  [contention playbook](/docs/knowledge/playbooks/gpu-contention-diagnosis.md).
+
+# Outcome
+
+Framework PRs #112 (per-phase profiling + reproduction tooling), #113
+(compile decision), #114 (loading hygiene), #115 (training TE off-main),
+#116 (pre-quantized checkpoints) all grew out of this campaign.

--- a/docs/knowledge/log.md
+++ b/docs/knowledge/log.md
@@ -1,0 +1,9 @@
+# Directory Update Log
+
+## 2026-07-15
+
+* **Creation**: Bootstrapped the knowledge bundle from the July 2026
+  performance campaign (PRs #112-#116). Initial concepts: baselines, loading
+  costs, quantization verdicts, the compile-step decision, seven verified
+  pitfalls, the [generation slowness investigation](/docs/knowledge/investigations/generation-slowness-2026-07.md)
+  and the [GPU contention playbook](/docs/knowledge/playbooks/gpu-contention-diagnosis.md).

--- a/docs/knowledge/pitfalls/metal-full-jit.md
+++ b/docs/knowledge/pitfalls/metal-full-jit.md
@@ -1,0 +1,26 @@
+---
+type: Pitfall
+title: MLX Metal kernels are full-JIT per process
+description: There is no persistent MLX shader cache and no pre-warm API; first use of each kernel family pays compilation.
+tags: [mlx-swift, metal, jit, cold-start]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+mlx-swift builds with JIT kernels only (no precompiled metallib ships, no
+`MTLBinaryArchive` anywhere in the Metal backend as of core 0.31.1). Every
+kernel family (GEMM, SDPA, quantized matmul, elementwise…) is compiled from
+embedded source at **first use in each process**.
+
+# Practical implications
+
+- Cross-launch relief comes only from the **OS-level** Metal shader cache
+  (source-hash → binary, system-wide): launch N+1 of the same binary is
+  faster than the first launch after boot/OS-update/app-update. Not
+  controllable from the app.
+- There is **no pre-warm API**; the only pre-warm is running a tiny
+  generation at startup.
+- Measured impact here: small — the cold first run of klein-9b (63.8 s) was
+  within noise of steady state (60-66 s), so kernel JIT is NOT a plausible
+  explanation for multi-x slowdowns. See
+  [the July 2026 investigation](/docs/knowledge/investigations/generation-slowness-2026-07.md),
+  which explicitly disproved the "cold-start kernel compilation" hypothesis.

--- a/docs/knowledge/pitfalls/mlx-swallowed-read-errors.md
+++ b/docs/knowledge/pitfalls/mlx-swallowed-read-errors.md
@@ -1,0 +1,32 @@
+---
+type: Pitfall
+title: MLX swallows deferred safetensors read errors
+description: A truncated safetensors with a valid header loads silently uninitialized tensors — no crash, no exception.
+resource: https://github.com/ml-explore/mlx
+tags: [mlx, safetensors, corruption, silent-failure]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+Verified in mlx core 0.31.1 source (bundled by mlx-swift 0.31.6).
+
+# The failure mode
+
+`loadArrays` is lazy: tensor reads become `Load` primitives executed at
+`eval`. `Load::eval_cpu` enqueues the pread on the IO thread pool via a
+`std::packaged_task` and the scheduler only calls `fut.wait()` — **never
+`get()`** — so a short-read exception is silently absorbed by the future's
+shared state (`mlx/backend/common/load.cpp:53`). The pre-`malloc`ed output
+buffer stays **uninitialized**; generation proceeds and produces garbage
+with zero diagnostics.
+
+A file with a *truncated header* fails loudly (header is read eagerly and
+throws). The dangerous case is **valid header + truncated data**: every
+header-derived check (metadata, key names, shapes) passes.
+
+# The defense
+
+Compare actual file size against `8 + header_len + max(data_offsets)` from
+the header **before** trusting anything else. Implemented as
+`Flux2PrequantizedCheckpoint.payloadIsComplete` (PR #116); apply the same
+gate to any safetensors of uncertain provenance. Writing files atomically
+(temp + rename) prevents creating such files in the first place.

--- a/docs/knowledge/pitfalls/module-update-no-verify.md
+++ b/docs/knowledge/pitfalls/module-update-no-verify.md
@@ -1,0 +1,20 @@
+---
+type: Pitfall
+title: Module.update(parameters:) does not verify shapes or dtypes
+description: Parameter updates apply blindly by default; wrong-shaped tensors surface later as Metal errors or garbage output.
+tags: [mlx-swift, module, update, validation]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+`Module.update(parameters:)` in mlx-swift defaults to `verify: .none`
+(Module.swift:406): no shape or dtype check. Loading externally-produced
+weights through it applies mismatched tensors silently; the failure surfaces
+mid-first-forward as a Metal shape error, or not at all (garbage output).
+
+# The defense
+
+Validate key sets AND shapes/dtypes against an expected manifest before
+calling `update` (see `Flux2PrequantizedCheckpoint.load`, PR #116). When
+comparing dtypes, compare by **category** — see
+[quanto sources keep bf16](/docs/knowledge/pitfalls/quanto-keeps-bf16.md)
+for why strict dtype equality produces false rejections.

--- a/docs/knowledge/pitfalls/quantize-skips-quantized.md
+++ b/docs/knowledge/pitfalls/quantize-skips-quantized.md
@@ -1,0 +1,28 @@
+---
+type: Pitfall
+title: quantize() silently skips already-quantized layers
+description: A fallback re-quantize on a partially mutated model is a no-op, not a repair.
+tags: [mlx-swift, quantization, fallback]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+`quantizeSingle` in MLXNN returns nil for layers that are already
+`Quantized` (mlx-swift Quantized.swift:34), so `quantize(model:)` on a model
+whose structure was already (even partially) quantized silently does
+nothing for those layers.
+
+# Why it bites
+
+Any "validate-after-mutate then fall back" pattern is broken by this: if a
+loader quantizes a model's structure and THEN discovers the weights are
+unusable, the standard path cannot repair the instance — its own quantize
+call no-ops, and full-precision weights get written into packed
+`QuantizedLinear.weight` slots (which update() accepts blindly — see
+[no-verify pitfall](/docs/knowledge/pitfalls/module-update-no-verify.md)).
+
+# The defense
+
+Validate everything BEFORE mutating the model (build the expected manifest
+on a throwaway structure clone — its lazy random weights are never
+evaluated, so this is free), or recreate the model instance after a failed
+mutating load. Implemented in `Flux2PrequantizedCheckpoint.load` (PR #116).

--- a/docs/knowledge/pitfalls/quanto-keeps-bf16.md
+++ b/docs/knowledge/pitfalls/quanto-keeps-bf16.md
@@ -1,0 +1,32 @@
+---
+type: Pitfall
+title: Quanto-sourced models keep unquantized params in bfloat16
+description: Production models are dtype-mixed depending on checkpoint source; never validate dtypes by strict equality.
+tags: [quanto, dtype, bf16, float16, diffusers]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+The two weight-mapping paths in `Flux2WeightLoader` differ in dtype policy:
+
+- **BFL path** (bf16 checkpoints, e.g. klein-9b): converts EVERY parameter
+  bf16 → float16.
+- **Diffusers/quanto path** (pre-quantized sources, e.g. klein-4b 8bit):
+  converts only the *quantized* tensors to f16 during dequantization —
+  unquantized params (norms, embedders) **stay bfloat16**.
+
+So a production model is f16-uniform or f16/bf16-mixed depending on where
+its checkpoint came from.
+
+# Why it bites
+
+Any dtype validation using strict equality against a single-dtype reference
+rejects legitimate quanto-sourced models. This caused a silent
+"always-fallback" bug in the pre-quantized checkpoint loader (caught by the
+multi-model test matrix, fixed in PR #116): outputs stayed correct via the
+fallback, so nothing looked wrong without reading the warnings.
+
+# The defense
+
+Compare dtypes by **category**: integer packing (uint32 weights, uint8
+fp-mode scales) must match exactly; float params accept f16/bf16/f32
+variants. Shapes stay strict.

--- a/docs/knowledge/pitfalls/thread-ismainthread-async.md
+++ b/docs/knowledge/pitfalls/thread-ismainthread-async.md
@@ -1,0 +1,26 @@
+---
+type: Pitfall
+title: Thread.isMainThread is unavailable in Swift async contexts
+description: Swift 6 bans the property where you most want it; use pthread_main_np() for thread assertions in async code.
+tags: [swift6, concurrency, diagnostics]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+`Thread.isMainThread` is `NS_SWIFT_UNAVAILABLE_FROM_ASYNC` — the compiler
+rejects it inside `async` functions ("Work intended for the main actor
+should be marked with @MainActor"). Ironically this is exactly where you
+want it when *proving* that supposedly off-main work really runs off-main
+(e.g. validating the #103/#104/#105 nonisolated-loading work).
+
+# The workaround
+
+`pthread_main_np()` (C API, no async restriction): returns 1 on the main
+thread, 0 otherwise. Used to verify issue #105: 6/6 text-encoder loads
+during a real LoRA training run logged `pthread_main_np=0`.
+
+# Related caveat
+
+The off-main behavior of `nonisolated async` functions awaited from
+`@MainActor` contexts depends on `NonisolatedNonsendingByDefault` (SE-0461)
+NOT being enabled — this project's Swift 6.0 language mode does not enable
+it. If that build setting ever changes, re-verify with the probe above.

--- a/docs/knowledge/pitfalls/wired-limit-sync-noop.md
+++ b/docs/knowledge/pitfalls/wired-limit-sync-noop.md
@@ -1,0 +1,20 @@
+---
+type: Pitfall
+title: Synchronous withWiredLimit is a silent no-op since mlx-swift 0.30.6
+description: The old wired-memory API was deprecated into a no-op; wiring requires the WiredMemoryManager actor.
+tags: [mlx-swift, wired-memory, api-migration]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+mlx-swift 0.30.6 (Feb 2026, PR #348) replaced the wired-memory API with a
+coordinator (`WiredMemoryManager` actor, tickets, policies). The old
+**synchronous** `Memory.withWiredLimit(_:_:)` / `GPU.withWiredLimit` still
+compiles but is a **deprecated no-op** — code using it silently stopped
+wiring memory. Only the async overload routes through the manager.
+
+# Status in this framework
+
+Neither API is used today (weights are not wired). If wiring is ever added
+(the R4 follow-up: prevent macOS from evicting resident model weights in a
+long-lived host app), use `WiredMemoryManager` tickets — and gate by
+available RAM: wiring 17 GB on a 16 GB Mac would be catastrophic.

--- a/docs/knowledge/playbooks/gpu-contention-diagnosis.md
+++ b/docs/knowledge/playbooks/gpu-contention-diagnosis.md
@@ -1,0 +1,47 @@
+---
+type: Playbook
+title: Diagnosing GPU contention
+description: The 5-minute protocol to attribute a slow generation to its real cause instead of suspecting the engine.
+tags: [diagnostics, gpu, contention, protocol]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+Use when a generation runs far above the
+[baselines](/docs/knowledge/benchmarks/klein9b-baselines.md), or a machine
+feels GPU-busy with nothing obviously running.
+
+# Protocol
+
+```bash
+# 1. Is the GPU saturated, and by rendering or compute?
+ioreg -r -c IOAccelerator -w0 | grep -E 'Utilization'
+#    Renderer/Tiler high => UI rendering; Device high alone => compute.
+
+# 2. Attribute by suspension (reversible, safe): suspend the suspect,
+#    watch utilization. Repeat per suspect. SUSPEND THE BINARY, not its
+#    zsh wrapper (pgrep -f matches the wrapper's command line too).
+PID=$(pgrep -x "Fluxforge Studio"); kill -STOP $PID; sleep 6
+ioreg -r -c IOAccelerator -w0 | grep 'Device Utilization'; kill -CONT $PID
+
+# 3. The decisive artifact: sample the culprit DURING the episode —
+#    hot stacks name the exact code (SwiftUI AnimationDriver, ViewGraph,
+#    MLX eval, etc.).
+sample "<process name>" 5 -file /tmp/culprit_sample.txt
+```
+
+# Benchmarking rule derived from this
+
+Never trust step-time benchmarks from a machine with ambient GPU load
+(Xcode builds, an animating UI, another generation). Gate every measured
+run on a quiet window (e.g. device utilization < 15-25% sustained) and
+record utilization alongside the run to tag contaminated measurements.
+Correctness tests are fine under contention; timing tests are not.
+
+# Gotchas learned the hard way
+
+- `Renderer Utilization` does NOT discriminate UI vs compute while your own
+  MLX process runs — only cross-suspension does.
+- A per-step spread of 10x within one run (e.g. 16 s and 134 s steps) is
+  the signature of contention, not thermal throttling (which is smooth).
+- Per-process GPU attribution without sudo is limited; suspension +
+  `sample` beats trying to read per-process GPU counters.


### PR DESCRIPTION
## Quoi

Nouvelle couche « connaissance » du repo : `docs/knowledge/`, un bundle [OKF v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) (markdown + frontmatter YAML, `index.md`, `log.md`). Distinct des docs utilisateur (`docs/` = comment utiliser) : ici on capture **ce qui a été mesuré et décidé, et pourquoi** — versionné, reviewable en PR, lisible par humains et agents, pour ne plus jamais re-dériver une baseline ni re-débattre une décision tranchée.

Coût de la conformance OKF : un champ `type` par fichier — zéro lock-in (si OKF meurt, ça reste du markdown bien rangé ; s'il devient une lingua franca, on est déjà compatibles).

## Contenu initial (campagne perf de juillet 2026, PRs #112-#116)

- **Benchmarks** : baselines klein (13-15 s/step 9B bf16 1 MP, règle d'interprétation « au-delà = contention ») ; coûts de chargement chaud/froid.
- **Décisions** : verdicts quantization (qint8 = mémoire pas vitesse, transparent qualité sur 9B ; mxfp8 à éviter) ; compile-step neutre gardé opt-in (avec les pièges si jamais revisité).
- **Pièges** (7, tous vérifiés source) : erreurs de lecture différées avalées par MLX, `update()` sans vérification, `quantize()` qui saute les couches quantifiées, sources quanto mixtes bf16, `withWiredLimit` sync no-op, `Thread.isMainThread` interdit en async, Metal full-JIT.
- **Investigation** : résumé de l'enquête lenteur (le moteur était innocent — contention GPU de l'UI de l'app hôte).
- **Playbook** : diagnostic de contention GPU en 5 minutes (suspension croisée + sample).

README pointe sur le bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)