### PR TITLE
feat: opt-in RuntimeBeacon for external activity monitors (SiliconScope)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,25 @@ flux2 t2i "a cat" --model klein-4b --vae-variant small-decoder
 
 See [Small Decoder Benchmark](docs/examples/small-decoder/) for measured performance and visual comparison.
 
+## Activity Beacon (Opt-in)
+
+Heavy operations (generation, model loading, LoRA training, quantized export) can advertise themselves to external activity monitors such as [SiliconScope](https://github.com/kennss/SiliconScope). While the operation runs, a small JSON manifest lives at `~/Library/Application Support/ai-runtime-beacons/<pid>-<id>.json` and is deleted the moment it ends — errors included. Nothing is ever written unless you opt in:
+
+```swift
+// Swift package
+RuntimeBeacon.isEnabled = true
+```
+
+```bash
+# CLI: --beacon flag (t2i / i2i / inpaint / outpaint / train-lora / export-quantized / profile),
+# or the environment variable
+FLUX2_RUNTIME_BEACON=1 flux2 t2i "..."
+```
+
+The manifest schema is deliberately runtime-agnostic (`version`, `pid`, `runtime`, `displayName`, `task`, `model`, `phase`, `step`, `totalSteps`, timestamps) — the same convention as [ltx-video-swift-mlx](https://github.com/VincentGourbin/ltx-video-swift-mlx), so monitors only need one reader. Manifests left behind by a force-killed process are garbage-collected on the next beacon start via a pid liveness check.
+
+> **Note:** sandboxed apps write inside their container, invisible to external monitors — the beacon targets CLI tools and non-sandboxed apps.
+
 ## Documentation
 
 ### Guides

--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ RuntimeBeacon.isEnabled = true
 ```
 
 ```bash
-# CLI: --beacon flag (t2i / i2i / inpaint / outpaint / train-lora / export-quantized / profile),
-# or the environment variable
+# CLI: --beacon flag (t2i / i2i / inpaint / outpaint / train-lora / export-quantized /
+# profile / compare-encoders / evaluate-lora), or the environment variable
 FLUX2_RUNTIME_BEACON=1 flux2 t2i "..."
 ```
 

--- a/Sources/Flux2CLI/BeaconOptions.swift
+++ b/Sources/Flux2CLI/BeaconOptions.swift
@@ -1,0 +1,17 @@
+// BeaconOptions.swift — shared --beacon opt-in for CLI commands
+// Copyright 2026 Vincent Gourbin
+
+import ArgumentParser
+import Flux2Core
+
+/// Shared `--beacon` flag, pulled into commands via `@OptionGroup` so the
+/// flag, its help text, and its activation live in exactly one place.
+struct BeaconOptions: ParsableArguments {
+    @Flag(name: .long, help: "Advertise activity to external monitors (writes a transient manifest in ~/Library/Application Support/ai-runtime-beacons/)")
+    var beacon: Bool = false
+
+    /// Call at the top of the command's run().
+    func activate() {
+        RuntimeBeacon.isEnabled = beacon
+    }
+}

--- a/Sources/Flux2CLI/CompareEncoders.swift
+++ b/Sources/Flux2CLI/CompareEncoders.swift
@@ -52,8 +52,11 @@ struct CompareEncoders: AsyncParsableCommand {
     @Flag(name: .long, help: "Skip image generation (embeddings comparison only)")
     var embeddingsOnly: Bool = false
 
+    @OptionGroup var beaconOptions: BeaconOptions
+
     func run() async throws {
         let startTime = Date()
+        beaconOptions.activate()
 
         // Parse model variant
         guard model == "klein-4b" || model == "klein-9b" else {

--- a/Sources/Flux2CLI/EvaluateLoRA.swift
+++ b/Sources/Flux2CLI/EvaluateLoRA.swift
@@ -47,8 +47,11 @@ struct EvaluateLoRA: AsyncParsableCommand {
     @Option(name: .long, help: "HuggingFace token for gated models")
     var hfToken: String?
 
+    @OptionGroup var beaconOptions: BeaconOptions
+
     func run() async throws {
         let startTime = Date()
+        beaconOptions.activate()
 
         // Parse model
         guard let modelVariant = Flux2Model(rawValue: model) else {

--- a/Sources/Flux2CLI/ExportQuantizedCommand.swift
+++ b/Sources/Flux2CLI/ExportQuantizedCommand.swift
@@ -31,8 +31,12 @@ struct ExportQuantized: AsyncParsableCommand {
     @Flag(name: .long, help: "Regenerate from the source weights even when a checkpoint already exists (without this flag, an existing checkpoint is kept as-is and the command is a no-op).")
     var force: Bool = false
 
+    @Flag(name: .long, help: "Advertise activity to external monitors (writes a transient manifest in ~/Library/Application Support/ai-runtime-beacons/)")
+    var beacon: Bool = false
+
     func run() async throws {
         configureModelsDirectory(modelsDir)
+        RuntimeBeacon.isEnabled = beacon
 
         let modelChoice = try Flux2Model.parseCLI(fluxModel)
         let quant = try TransformerQuantization.parseCLI(transformerQuant)

--- a/Sources/Flux2CLI/ExportQuantizedCommand.swift
+++ b/Sources/Flux2CLI/ExportQuantizedCommand.swift
@@ -31,12 +31,11 @@ struct ExportQuantized: AsyncParsableCommand {
     @Flag(name: .long, help: "Regenerate from the source weights even when a checkpoint already exists (without this flag, an existing checkpoint is kept as-is and the command is a no-op).")
     var force: Bool = false
 
-    @Flag(name: .long, help: "Advertise activity to external monitors (writes a transient manifest in ~/Library/Application Support/ai-runtime-beacons/)")
-    var beacon: Bool = false
+    @OptionGroup var beaconOptions: BeaconOptions
 
     func run() async throws {
         configureModelsDirectory(modelsDir)
-        RuntimeBeacon.isEnabled = beacon
+        beaconOptions.activate()
 
         let modelChoice = try Flux2Model.parseCLI(fluxModel)
         let quant = try TransformerQuantization.parseCLI(transformerQuant)

--- a/Sources/Flux2CLI/Flux2CLI.swift
+++ b/Sources/Flux2CLI/Flux2CLI.swift
@@ -89,6 +89,9 @@ struct TextToImage: AsyncParsableCommand {
     @Flag(name: .long, help: "Enable performance profiling")
     var profile: Bool = false
 
+    @Flag(name: .long, help: "Advertise activity to external monitors (writes a transient manifest in ~/Library/Application Support/ai-runtime-beacons/)")
+    var beacon: Bool = false
+
     @Flag(name: .long, help: "Enhance prompt with more visual details before encoding")
     var upsamplePrompt: Bool = false
 
@@ -122,6 +125,8 @@ struct TextToImage: AsyncParsableCommand {
     func run() async throws {
         // Configure custom models directory
         configureModelsDirectory(modelsDir)
+
+        RuntimeBeacon.isEnabled = beacon
 
         // Configure logging verbosity
         if verbose {
@@ -415,6 +420,9 @@ struct ImageToImage: AsyncParsableCommand {
     @Flag(name: .long, help: "Show detailed performance profiling")
     var profile: Bool = false
 
+    @Flag(name: .long, help: "Advertise activity to external monitors (writes a transient manifest in ~/Library/Application Support/ai-runtime-beacons/)")
+    var beacon: Bool = false
+
     @Flag(name: .long, help: "Show detailed logs (model loading, config, VLM interpretation)")
     var verbose: Bool = false
 
@@ -453,6 +461,8 @@ struct ImageToImage: AsyncParsableCommand {
 
         // Configure custom models directory
         configureModelsDirectory(modelsDir)
+
+        RuntimeBeacon.isEnabled = beacon
 
         // Configure logging verbosity
         if verbose {

--- a/Sources/Flux2CLI/Flux2CLI.swift
+++ b/Sources/Flux2CLI/Flux2CLI.swift
@@ -89,8 +89,7 @@ struct TextToImage: AsyncParsableCommand {
     @Flag(name: .long, help: "Enable performance profiling")
     var profile: Bool = false
 
-    @Flag(name: .long, help: "Advertise activity to external monitors (writes a transient manifest in ~/Library/Application Support/ai-runtime-beacons/)")
-    var beacon: Bool = false
+    @OptionGroup var beaconOptions: BeaconOptions
 
     @Flag(name: .long, help: "Enhance prompt with more visual details before encoding")
     var upsamplePrompt: Bool = false
@@ -126,7 +125,7 @@ struct TextToImage: AsyncParsableCommand {
         // Configure custom models directory
         configureModelsDirectory(modelsDir)
 
-        RuntimeBeacon.isEnabled = beacon
+        beaconOptions.activate()
 
         // Configure logging verbosity
         if verbose {
@@ -420,8 +419,7 @@ struct ImageToImage: AsyncParsableCommand {
     @Flag(name: .long, help: "Show detailed performance profiling")
     var profile: Bool = false
 
-    @Flag(name: .long, help: "Advertise activity to external monitors (writes a transient manifest in ~/Library/Application Support/ai-runtime-beacons/)")
-    var beacon: Bool = false
+    @OptionGroup var beaconOptions: BeaconOptions
 
     @Flag(name: .long, help: "Show detailed logs (model loading, config, VLM interpretation)")
     var verbose: Bool = false
@@ -462,7 +460,7 @@ struct ImageToImage: AsyncParsableCommand {
         // Configure custom models directory
         configureModelsDirectory(modelsDir)
 
-        RuntimeBeacon.isEnabled = beacon
+        beaconOptions.activate()
 
         // Configure logging verbosity
         if verbose {

--- a/Sources/Flux2CLI/InpaintCommand.swift
+++ b/Sources/Flux2CLI/InpaintCommand.swift
@@ -123,8 +123,7 @@ struct Inpaint: AsyncParsableCommand {
     @Flag(name: .long, help: "Show detailed per-phase performance profiling (model loads, text encoding, VAE encodes, per-step timings).")
     var profile: Bool = false
 
-    @Flag(name: .long, help: "Advertise activity to external monitors (writes a transient manifest in ~/Library/Application Support/ai-runtime-beacons/)")
-    var beacon: Bool = false
+    @OptionGroup var beaconOptions: BeaconOptions
 
     @Option(name: .long, help: "Run the chain N times in the same process (same pipeline instance) to separate cold-start (first run: kernel compilation, cache warm-up) from steady-state. Default 1.")
     var repeatCount: Int = 1
@@ -146,7 +145,7 @@ struct Inpaint: AsyncParsableCommand {
         }
 
         configureModelsDirectory(modelsDir)
-        RuntimeBeacon.isEnabled = beacon
+        beaconOptions.activate()
 
         guard let imageCG = Self.loadCGImage(at: image) else {
             throw ValidationError("Could not decode image at \(image)")

--- a/Sources/Flux2CLI/InpaintCommand.swift
+++ b/Sources/Flux2CLI/InpaintCommand.swift
@@ -123,6 +123,9 @@ struct Inpaint: AsyncParsableCommand {
     @Flag(name: .long, help: "Show detailed per-phase performance profiling (model loads, text encoding, VAE encodes, per-step timings).")
     var profile: Bool = false
 
+    @Flag(name: .long, help: "Advertise activity to external monitors (writes a transient manifest in ~/Library/Application Support/ai-runtime-beacons/)")
+    var beacon: Bool = false
+
     @Option(name: .long, help: "Run the chain N times in the same process (same pipeline instance) to separate cold-start (first run: kernel compilation, cache warm-up) from steady-state. Default 1.")
     var repeatCount: Int = 1
 
@@ -143,6 +146,7 @@ struct Inpaint: AsyncParsableCommand {
         }
 
         configureModelsDirectory(modelsDir)
+        RuntimeBeacon.isEnabled = beacon
 
         guard let imageCG = Self.loadCGImage(at: image) else {
             throw ValidationError("Could not decode image at \(image)")

--- a/Sources/Flux2CLI/OutpaintCommand.swift
+++ b/Sources/Flux2CLI/OutpaintCommand.swift
@@ -63,12 +63,16 @@ struct Outpaint: AsyncParsableCommand {
     @Option(name: .long, help: "Cap on the total working pixel count. Defaults to 4 M; raise if you want larger canvases.")
     var maxPixels: Int = 4 * 1024 * 1024
 
+    @Flag(name: .long, help: "Advertise activity to external monitors (writes a transient manifest in ~/Library/Application Support/ai-runtime-beacons/)")
+    var beacon: Bool = false
+
     func run() async throws {
         @Sendable func logErr(_ msg: String) {
             FileHandle.standardError.write(Data((msg + "\n").utf8))
         }
 
         configureModelsDirectory(modelsDir)
+        RuntimeBeacon.isEnabled = beacon
 
         guard let imageCG = Self.loadCGImage(at: image) else {
             throw ValidationError("Could not decode image at \(image)")

--- a/Sources/Flux2CLI/OutpaintCommand.swift
+++ b/Sources/Flux2CLI/OutpaintCommand.swift
@@ -63,8 +63,7 @@ struct Outpaint: AsyncParsableCommand {
     @Option(name: .long, help: "Cap on the total working pixel count. Defaults to 4 M; raise if you want larger canvases.")
     var maxPixels: Int = 4 * 1024 * 1024
 
-    @Flag(name: .long, help: "Advertise activity to external monitors (writes a transient manifest in ~/Library/Application Support/ai-runtime-beacons/)")
-    var beacon: Bool = false
+    @OptionGroup var beaconOptions: BeaconOptions
 
     func run() async throws {
         @Sendable func logErr(_ msg: String) {
@@ -72,7 +71,7 @@ struct Outpaint: AsyncParsableCommand {
         }
 
         configureModelsDirectory(modelsDir)
-        RuntimeBeacon.isEnabled = beacon
+        beaconOptions.activate()
 
         guard let imageCG = Self.loadCGImage(at: image) else {
             throw ValidationError("Could not decode image at \(image)")

--- a/Sources/Flux2CLI/ProfileCommand.swift
+++ b/Sources/Flux2CLI/ProfileCommand.swift
@@ -94,8 +94,12 @@ struct ProfileRun: AsyncParsableCommand {
     @Flag(name: .long, help: "Disable Chrome Trace JSON export")
     var noChromeTrace: Bool = false
 
+    @Flag(name: .long, help: "Advertise activity to external monitors (writes a transient manifest in ~/Library/Application Support/ai-runtime-beacons/)")
+    var beacon: Bool = false
+
     func run() async throws {
         configureModelsDirectory(options.modelsDir)
+        RuntimeBeacon.isEnabled = beacon
 
         let modelVariant = try options.resolveModel()
         let quantConfig = try options.resolveQuantization()
@@ -194,8 +198,12 @@ struct ProfileBenchmark: AsyncParsableCommand {
     @Option(name: .long, help: "Output directory for results")
     var outputDir: String = "./benchmark_results"
 
+    @Flag(name: .long, help: "Advertise activity to external monitors (writes a transient manifest in ~/Library/Application Support/ai-runtime-beacons/)")
+    var beacon: Bool = false
+
     func run() async throws {
         configureModelsDirectory(options.modelsDir)
+        RuntimeBeacon.isEnabled = beacon
 
         let modelVariant = try options.resolveModel()
         let quantConfig = try options.resolveQuantization()
@@ -323,8 +331,12 @@ struct ProfileCompare: AsyncParsableCommand {
     @Option(name: .long, help: "Output directory")
     var outputDir: String = "./comparison_results"
 
+    @Flag(name: .long, help: "Advertise activity to external monitors (writes a transient manifest in ~/Library/Application Support/ai-runtime-beacons/)")
+    var beacon: Bool = false
+
     func run() async throws {
         configureModelsDirectory(modelsDir)
+        RuntimeBeacon.isEnabled = beacon
 
         let token = hfToken ?? ProcessInfo.processInfo.environment["HF_TOKEN"]
 

--- a/Sources/Flux2CLI/ProfileCommand.swift
+++ b/Sources/Flux2CLI/ProfileCommand.swift
@@ -94,12 +94,11 @@ struct ProfileRun: AsyncParsableCommand {
     @Flag(name: .long, help: "Disable Chrome Trace JSON export")
     var noChromeTrace: Bool = false
 
-    @Flag(name: .long, help: "Advertise activity to external monitors (writes a transient manifest in ~/Library/Application Support/ai-runtime-beacons/)")
-    var beacon: Bool = false
+    @OptionGroup var beaconOptions: BeaconOptions
 
     func run() async throws {
         configureModelsDirectory(options.modelsDir)
-        RuntimeBeacon.isEnabled = beacon
+        beaconOptions.activate()
 
         let modelVariant = try options.resolveModel()
         let quantConfig = try options.resolveQuantization()
@@ -198,12 +197,11 @@ struct ProfileBenchmark: AsyncParsableCommand {
     @Option(name: .long, help: "Output directory for results")
     var outputDir: String = "./benchmark_results"
 
-    @Flag(name: .long, help: "Advertise activity to external monitors (writes a transient manifest in ~/Library/Application Support/ai-runtime-beacons/)")
-    var beacon: Bool = false
+    @OptionGroup var beaconOptions: BeaconOptions
 
     func run() async throws {
         configureModelsDirectory(options.modelsDir)
-        RuntimeBeacon.isEnabled = beacon
+        beaconOptions.activate()
 
         let modelVariant = try options.resolveModel()
         let quantConfig = try options.resolveQuantization()
@@ -331,12 +329,11 @@ struct ProfileCompare: AsyncParsableCommand {
     @Option(name: .long, help: "Output directory")
     var outputDir: String = "./comparison_results"
 
-    @Flag(name: .long, help: "Advertise activity to external monitors (writes a transient manifest in ~/Library/Application Support/ai-runtime-beacons/)")
-    var beacon: Bool = false
+    @OptionGroup var beaconOptions: BeaconOptions
 
     func run() async throws {
         configureModelsDirectory(modelsDir)
-        RuntimeBeacon.isEnabled = beacon
+        beaconOptions.activate()
 
         let token = hfToken ?? ProcessInfo.processInfo.environment["HF_TOKEN"]
 

--- a/Sources/Flux2CLI/TrainLoRACommand.swift
+++ b/Sources/Flux2CLI/TrainLoRACommand.swift
@@ -210,6 +210,9 @@ struct TrainLoRA: AsyncParsableCommand {
     @Flag(name: .long, help: "Dry run - validate configuration without training")
     var dryRun: Bool = false
 
+    @Flag(name: .long, help: "Advertise activity to external monitors (writes a transient manifest in ~/Library/Application Support/ai-runtime-beacons/)")
+    var beacon: Bool = false
+
     @Option(name: .long, help: "Custom models directory (for sandboxed apps or custom storage)")
     var modelsDir: String?
 
@@ -218,6 +221,8 @@ struct TrainLoRA: AsyncParsableCommand {
     func run() async throws {
         // Configure custom models directory
         configureModelsDirectory(modelsDir)
+
+        RuntimeBeacon.isEnabled = beacon
 
         // Configure logging
         if verbose {

--- a/Sources/Flux2CLI/TrainLoRACommand.swift
+++ b/Sources/Flux2CLI/TrainLoRACommand.swift
@@ -210,8 +210,7 @@ struct TrainLoRA: AsyncParsableCommand {
     @Flag(name: .long, help: "Dry run - validate configuration without training")
     var dryRun: Bool = false
 
-    @Flag(name: .long, help: "Advertise activity to external monitors (writes a transient manifest in ~/Library/Application Support/ai-runtime-beacons/)")
-    var beacon: Bool = false
+    @OptionGroup var beaconOptions: BeaconOptions
 
     @Option(name: .long, help: "Custom models directory (for sandboxed apps or custom storage)")
     var modelsDir: String?
@@ -222,7 +221,7 @@ struct TrainLoRA: AsyncParsableCommand {
         // Configure custom models directory
         configureModelsDirectory(modelsDir)
 
-        RuntimeBeacon.isEnabled = beacon
+        beaconOptions.activate()
 
         // Configure logging
         if verbose {

--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
@@ -368,6 +368,9 @@ public class Flux2Pipeline: @unchecked Sendable {
     /// Load all required models
     /// - Parameter progressCallback: Optional callback for download progress
     public func loadModels(progressCallback: Flux2DownloadProgressCallback? = nil) async throws {
+        let beacon = RuntimeBeacon.begin(task: "load-models", model: model.rawValue)
+        defer { beacon?.end() }
+
         // Check memory before loading
         let memCheck = memoryManager.checkTextEncodingPhase(config: quantization)
         if !memCheck.isOk {
@@ -761,6 +764,9 @@ public class Flux2Pipeline: @unchecked Sendable {
             throw Flux2Error.invalidConfiguration(
                 "exportPrequantizedTransformer requires a quantized transformer configuration (current: bf16)")
         }
+
+        let beacon = RuntimeBeacon.begin(task: "export-quantized", model: model.rawValue)
+        defer { beacon?.end() }
 
         // Resolve the source directory up-front (same resolution as
         // loadTransformer) so the exists/force decision precedes any load.
@@ -1168,6 +1174,19 @@ public class Flux2Pipeline: @unchecked Sendable {
         onCheckpoint: Flux2CheckpointCallback?,
         onStep: Flux2StepHook? = nil
     ) async throws -> Flux2GenerationResult {
+        let beacon = RuntimeBeacon.begin(task: "generate", model: model.rawValue)
+        defer { beacon?.end() }
+        let userProgress = onProgress
+        let onProgress: Flux2ProgressCallback?
+        if let beacon {
+            onProgress = { step, totalSteps in
+                beacon.update(phase: "denoising", step: step, totalSteps: totalSteps)
+                userProgress?(step, totalSteps)
+            }
+        } else {
+            onProgress = userProgress
+        }
+
         // Validate dimensions
         let (validHeight, validWidth) = LatentUtils.validateDimensions(
             height: height,
@@ -1220,6 +1239,7 @@ public class Flux2Pipeline: @unchecked Sendable {
             Flux2Debug.log("Pre-computed embeddings shape: \(precomputed.shape)")
         } else {
             Flux2Debug.log("=== PHASE 1: Text Encoding ===")
+            beacon?.update(phase: "text-encoding")
 
             MemoryConfig.applyCacheLimit(bytes: phaseLimits.textEncoding)
 
@@ -2060,6 +2080,7 @@ public class Flux2Pipeline: @unchecked Sendable {
 
         // === PHASE 3: Decode to Image ===
         Flux2Debug.log("=== PHASE 3: VAE Decoding ===")
+        beacon?.update(phase: "vae-decode")
 
         // MEMORY OPTIMIZATION: Set cache limit for VAE decoding phase
         MemoryConfig.applyCacheLimit(bytes: phaseLimits.vaeDecoding)

--- a/Sources/Flux2Core/Training/Loop/SimpleLoRATrainer.swift
+++ b/Sources/Flux2Core/Training/Loop/SimpleLoRATrainer.swift
@@ -690,11 +690,13 @@ public final class SimpleLoRATrainer {
                     try await saveCheckpoint(step: step, transformer: transformer, optimizer: optimizer, isPauseCheckpoint: true)
                     print("   Checkpoint saved. You can safely quit or wait for resume.")
 
-                    // Now wait while paused
+                    // Now wait while paused — advertise the idle GPU to monitors
+                    beacon?.update(phase: "paused", step: step, totalSteps: config.maxSteps)
                     if !ctrl.waitWhilePaused() {
                         // Stop was requested while paused - keep the checkpoint
                         break
                     }
+                    beacon?.update(phase: "training", step: step, totalSteps: config.maxSteps)
 
                     // Resumed from pause - delete the pause checkpoint (only kept if stopped)
                     print("▶️  Resuming training, cleaning up pause checkpoint...")

--- a/Sources/Flux2Core/Training/Loop/SimpleLoRATrainer.swift
+++ b/Sources/Flux2Core/Training/Loop/SimpleLoRATrainer.swift
@@ -261,6 +261,9 @@ public final class SimpleLoRATrainer {
         shouldStop = false
         currentStep = startStep
 
+        let beacon = RuntimeBeacon.begin(task: "train", model: modelType.rawValue)
+        defer { beacon?.end() }
+
         // Create output directory if needed
         try FileManager.default.createDirectory(at: config.outputDir, withIntermediateDirectories: true)
 
@@ -665,6 +668,7 @@ public final class SimpleLoRATrainer {
             // Update current step FIRST (before stop/pause checks so checkpoint has correct step)
             currentStep = step
             trainingState?.currentStep = step
+            beacon?.update(phase: "training", step: step, totalSteps: config.maxSteps)
 
             // Check for stop request (from controller or internal flag)
             if shouldStop { break }

--- a/Sources/Flux2Core/Utils/RuntimeBeacon.swift
+++ b/Sources/Flux2Core/Utils/RuntimeBeacon.swift
@@ -64,8 +64,10 @@ public enum RuntimeBeacon {
         set { enabledState.withLock { $0 = newValue } }
     }
 
+    /// Live read (getenv, not ProcessInfo's launch snapshot) so tests can
+    /// neutralize an exported FLUX2_RUNTIME_BEACON=1 via unsetenv.
     private static var environmentEnabled: Bool {
-        ProcessInfo.processInfo.environment["FLUX2_RUNTIME_BEACON"] == "1"
+        getenv("FLUX2_RUNTIME_BEACON").map { String(cString: $0) == "1" } ?? false
     }
 
     /// Test hook: redirects all manifest writes away from the real shared directory.
@@ -156,23 +158,24 @@ public enum RuntimeBeacon {
             let id = UUID().uuidString.prefix(8)
             self.fileURL = directory.appendingPathComponent("\(pid)-\(id).json")
             let now = Date()
+            let manifest = Manifest(
+                version: RuntimeBeacon.schemaVersion,
+                pid: pid,
+                runtime: RuntimeBeacon.runtimeID,
+                displayName: RuntimeBeacon.runtimeDisplayName,
+                task: task,
+                model: model,
+                phase: nil,
+                step: nil,
+                totalSteps: nil,
+                startedAt: now,
+                updatedAt: now
+            )
             self.state = OSAllocatedUnfairLock(initialState: State(
-                manifest: Manifest(
-                    version: RuntimeBeacon.schemaVersion,
-                    pid: pid,
-                    runtime: RuntimeBeacon.runtimeID,
-                    displayName: RuntimeBeacon.runtimeDisplayName,
-                    task: task,
-                    model: model,
-                    phase: nil,
-                    step: nil,
-                    totalSteps: nil,
-                    startedAt: now,
-                    updatedAt: now
-                ),
+                manifest: manifest,
                 ended: false
             ))
-            write()
+            Self.write(manifest, to: fileURL)
         }
 
         deinit {
@@ -182,33 +185,32 @@ public enum RuntimeBeacon {
         /// Refresh the manifest with the operation's current phase/step.
         /// Safe to call from any thread; no-op after ``end()``.
         public func update(phase: String, step: Int? = nil, totalSteps: Int? = nil) {
-            let stillLive = state.withLock { s -> Bool in
-                guard !s.ended else { return false }
+            state.withLock { s in
+                guard !s.ended else { return }
                 s.manifest.phase = phase
                 s.manifest.step = step
                 s.manifest.totalSteps = totalSteps
                 s.manifest.updatedAt = Date()
-                return true
+                Self.write(s.manifest, to: fileURL)
             }
-            if stillLive { write() }
         }
 
         /// Delete the manifest. Idempotent; also runs from `deinit`.
         public func end() {
-            let shouldRemove = state.withLock { s -> Bool in
-                guard !s.ended else { return false }
+            state.withLock { s in
+                guard !s.ended else { return }
                 s.ended = true
-                return true
-            }
-            if shouldRemove {
                 try? FileManager.default.removeItem(at: fileURL)
             }
         }
 
         /// Atomic write so a monitor never reads a half-written manifest.
-        private func write() {
-            let manifest = state.withLock { $0.manifest }
-            guard let data = try? Self.encoder.encode(manifest) else { return }
+        /// The file I/O stays inside the state lock (a ~300-byte write, at
+        /// most once per multi-second step): concurrent updates can neither
+        /// land out of order nor resurrect the manifest after a racing
+        /// `end()` has deleted it.
+        private static func write(_ manifest: Manifest, to fileURL: URL) {
+            guard let data = try? encoder.encode(manifest) else { return }
             try? data.write(to: fileURL, options: .atomic)
         }
     }

--- a/Sources/Flux2Core/Utils/RuntimeBeacon.swift
+++ b/Sources/Flux2Core/Utils/RuntimeBeacon.swift
@@ -1,0 +1,215 @@
+// RuntimeBeacon.swift - Opt-in presence beacon for external activity monitors
+// Copyright 2026 Vincent Gourbin
+
+import Foundation
+import os
+
+/// Opt-in beacon advertising heavy GPU/memory activity (generation, training,
+/// model loading) to external monitors such as SiliconScope.
+///
+/// When enabled, each heavy operation writes a small JSON manifest to
+/// `~/Library/Application Support/ai-runtime-beacons/<pid>-<id>.json` for its
+/// duration and deletes it when the operation ends (including on error, via
+/// `defer` at every call site). Nothing is ever written unless the host
+/// explicitly opts in.
+///
+/// ## Enabling
+/// ```swift
+/// RuntimeBeacon.isEnabled = true   // from code
+/// ```
+/// or set the environment variable `FLUX2_RUNTIME_BEACON=1` (used by the CLI's
+/// `--beacon` flag as well).
+///
+/// ## Manifest schema (version 1)
+/// The format is deliberately runtime-agnostic — same convention as
+/// ltx-video-swift-mlx's RuntimeBeacon — so monitors only need one reader:
+/// ```json
+/// {
+///   "version": 1,
+///   "pid": 1234,
+///   "runtime": "flux-2-swift-mlx",
+///   "displayName": "FLUX.2",
+///   "task": "generate",
+///   "model": "klein-9b",
+///   "phase": "denoising",
+///   "step": 3,
+///   "totalSteps": 4,
+///   "startedAt": "2026-07-16T09:00:00Z",
+///   "updatedAt": "2026-07-16T09:00:42Z"
+/// }
+/// ```
+///
+/// ## Crash safety
+/// A `kill -9` can leave a manifest behind; both `begin(task:model:)` and
+/// well-behaved consumers treat a manifest whose `pid` is dead as garbage and
+/// delete it, so stale files never outlive the next beacon-enabled run.
+///
+/// - Note: Sandboxed apps write inside their container, where external
+///   monitors cannot see the manifest. The beacon is a no-op in practice
+///   there; it targets CLI tools and non-sandboxed apps.
+public enum RuntimeBeacon {
+    /// Manifest schema version.
+    public static let schemaVersion = 1
+
+    /// Identity written to every manifest produced by this package.
+    static let runtimeID = "flux-2-swift-mlx"
+    static let runtimeDisplayName = "FLUX.2"
+
+    private static let enabledState = OSAllocatedUnfairLock(initialState: false)
+
+    /// Global opt-in toggle. Defaults to `false`: no file is ever written
+    /// unless the host sets this to `true` or exports `FLUX2_RUNTIME_BEACON=1`.
+    public static var isEnabled: Bool {
+        get { enabledState.withLock { $0 } }
+        set { enabledState.withLock { $0 = newValue } }
+    }
+
+    private static var environmentEnabled: Bool {
+        ProcessInfo.processInfo.environment["FLUX2_RUNTIME_BEACON"] == "1"
+    }
+
+    /// Test hook: redirects all manifest writes away from the real shared directory.
+    private static let directoryOverrideState = OSAllocatedUnfairLock<URL?>(initialState: nil)
+    static var directoryOverride: URL? {
+        get { directoryOverrideState.withLock { $0 } }
+        set { directoryOverrideState.withLock { $0 = newValue } }
+    }
+
+    /// Directory holding the manifests of all live beacon sessions
+    /// (shared, runtime-agnostic location).
+    public static var directory: URL {
+        directoryOverride
+            ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+                .appendingPathComponent("ai-runtime-beacons", isDirectory: true)
+    }
+
+    /// Start a beacon session for one heavy operation. Returns `nil` when the
+    /// beacon is disabled (the default), so call sites stay one-liners:
+    /// ```swift
+    /// let beacon = RuntimeBeacon.begin(task: "generate", model: model.rawValue)
+    /// defer { beacon?.end() }
+    /// ```
+    /// Never throws and never blocks generation: every filesystem failure is
+    /// swallowed and simply disables the session.
+    public static func begin(task: String, model: String? = nil) -> Session? {
+        guard isEnabled || environmentEnabled else { return nil }
+        let dir = directory
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        removeStaleManifests(in: dir)
+        return Session(directory: dir, task: task, model: model)
+    }
+
+    /// Delete manifests whose owning process is dead (leftovers from crashes /
+    /// force-kills). `kill(pid, 0)` probes liveness without sending a signal.
+    private static func removeStaleManifests(in dir: URL) {
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: nil) else { return }
+        for url in entries where url.pathExtension == "json" {
+            guard let pidToken = url.lastPathComponent.split(separator: "-").first,
+                  let pid = pid_t(pidToken) else { continue }
+            if pid != ProcessInfo.processInfo.processIdentifier,
+               kill(pid, 0) == -1 && errno == ESRCH {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+    }
+
+    // MARK: - Session
+
+    /// One live manifest: created by ``RuntimeBeacon/begin(task:model:)``,
+    /// refreshed by ``update(phase:step:totalSteps:)``, deleted by ``end()``.
+    /// `deinit` also ends the session as a safety net, but call sites must
+    /// still `defer { beacon?.end() }` — actors can keep references alive
+    /// longer than the operation.
+    public final class Session: Sendable {
+        private struct Manifest: Encodable {
+            let version: Int
+            let pid: Int32
+            let runtime: String
+            let displayName: String
+            let task: String
+            let model: String?
+            var phase: String?
+            var step: Int?
+            var totalSteps: Int?
+            let startedAt: Date
+            var updatedAt: Date
+        }
+
+        private struct State {
+            var manifest: Manifest
+            var ended: Bool
+        }
+
+        private let fileURL: URL
+        private let state: OSAllocatedUnfairLock<State>
+
+        private static let encoder: JSONEncoder = {
+            let e = JSONEncoder()
+            e.dateEncodingStrategy = .iso8601
+            e.outputFormatting = [.sortedKeys]
+            return e
+        }()
+
+        fileprivate init(directory: URL, task: String, model: String?) {
+            let pid = ProcessInfo.processInfo.processIdentifier
+            let id = UUID().uuidString.prefix(8)
+            self.fileURL = directory.appendingPathComponent("\(pid)-\(id).json")
+            let now = Date()
+            self.state = OSAllocatedUnfairLock(initialState: State(
+                manifest: Manifest(
+                    version: RuntimeBeacon.schemaVersion,
+                    pid: pid,
+                    runtime: RuntimeBeacon.runtimeID,
+                    displayName: RuntimeBeacon.runtimeDisplayName,
+                    task: task,
+                    model: model,
+                    phase: nil,
+                    step: nil,
+                    totalSteps: nil,
+                    startedAt: now,
+                    updatedAt: now
+                ),
+                ended: false
+            ))
+            write()
+        }
+
+        deinit {
+            end()
+        }
+
+        /// Refresh the manifest with the operation's current phase/step.
+        /// Safe to call from any thread; no-op after ``end()``.
+        public func update(phase: String, step: Int? = nil, totalSteps: Int? = nil) {
+            let stillLive = state.withLock { s -> Bool in
+                guard !s.ended else { return false }
+                s.manifest.phase = phase
+                s.manifest.step = step
+                s.manifest.totalSteps = totalSteps
+                s.manifest.updatedAt = Date()
+                return true
+            }
+            if stillLive { write() }
+        }
+
+        /// Delete the manifest. Idempotent; also runs from `deinit`.
+        public func end() {
+            let shouldRemove = state.withLock { s -> Bool in
+                guard !s.ended else { return false }
+                s.ended = true
+                return true
+            }
+            if shouldRemove {
+                try? FileManager.default.removeItem(at: fileURL)
+            }
+        }
+
+        /// Atomic write so a monitor never reads a half-written manifest.
+        private func write() {
+            let manifest = state.withLock { $0.manifest }
+            guard let data = try? Self.encoder.encode(manifest) else { return }
+            try? data.write(to: fileURL, options: .atomic)
+        }
+    }
+}

--- a/Tests/Flux2CoreTests/RuntimeBeaconTests.swift
+++ b/Tests/Flux2CoreTests/RuntimeBeaconTests.swift
@@ -18,6 +18,9 @@ final class RuntimeBeaconTests: XCTestCase {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("beacon-tests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        // An exported FLUX2_RUNTIME_BEACON=1 would force-enable begin() and
+        // break the enabled:false assertions — neutralize it for the test.
+        unsetenv("FLUX2_RUNTIME_BEACON")
         RuntimeBeacon.directoryOverride = dir
         RuntimeBeacon.isEnabled = enabled
         defer {

--- a/Tests/Flux2CoreTests/RuntimeBeaconTests.swift
+++ b/Tests/Flux2CoreTests/RuntimeBeaconTests.swift
@@ -1,0 +1,108 @@
+// RuntimeBeaconTests.swift — Unit tests for the opt-in activity beacon
+// Copyright 2026 Vincent Gourbin
+
+import XCTest
+@testable import Flux2Core
+
+/// RuntimeBeacon.isEnabled and directoryOverride are global state, so every
+/// test runs inside `withSandbox`, which restores both afterwards. XCTest
+/// runs the methods of one class serially, which is all the isolation needed.
+final class RuntimeBeaconTests: XCTestCase {
+
+    /// Runs `body` with the beacon enabled and sandboxed into a fresh temp
+    /// directory, restoring global state afterwards.
+    private func withSandbox<T>(
+        enabled: Bool = true,
+        _ body: (URL) throws -> T
+    ) throws -> T {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("beacon-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        RuntimeBeacon.directoryOverride = dir
+        RuntimeBeacon.isEnabled = enabled
+        defer {
+            RuntimeBeacon.isEnabled = false
+            RuntimeBeacon.directoryOverride = nil
+            try? FileManager.default.removeItem(at: dir)
+        }
+        return try body(dir)
+    }
+
+    private func manifestFiles(in dir: URL) -> [URL] {
+        (try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil))?
+            .filter { $0.pathExtension == "json" } ?? []
+    }
+
+    func testDisabledByDefaultBeginReturnsNilAndWritesNothing() throws {
+        try withSandbox(enabled: false) { dir in
+            XCTAssertNil(RuntimeBeacon.begin(task: "generate"))
+            XCTAssertTrue(manifestFiles(in: dir).isEmpty)
+        }
+    }
+
+    func testSessionLifecycleManifestCreatedUpdatedThenDeletedOnEnd() throws {
+        try withSandbox { dir in
+            let session = try XCTUnwrap(RuntimeBeacon.begin(task: "generate", model: "klein-9b"))
+
+            let files = manifestFiles(in: dir)
+            XCTAssertEqual(files.count, 1)
+            let url = try XCTUnwrap(files.first)
+
+            var json = try XCTUnwrap(
+                try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any])
+            XCTAssertEqual(json["runtime"] as? String, "flux-2-swift-mlx")
+            XCTAssertEqual(json["displayName"] as? String, "FLUX.2")
+            XCTAssertEqual(json["task"] as? String, "generate")
+            XCTAssertEqual(json["model"] as? String, "klein-9b")
+            XCTAssertEqual(json["pid"] as? Int32, ProcessInfo.processInfo.processIdentifier)
+            XCTAssertEqual(json["version"] as? Int, RuntimeBeacon.schemaVersion)
+            XCTAssertNil(json["phase"])
+
+            session.update(phase: "denoising", step: 3, totalSteps: 4)
+            json = try XCTUnwrap(
+                try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any])
+            XCTAssertEqual(json["phase"] as? String, "denoising")
+            XCTAssertEqual(json["step"] as? Int, 3)
+            XCTAssertEqual(json["totalSteps"] as? Int, 4)
+
+            session.end()
+            XCTAssertTrue(manifestFiles(in: dir).isEmpty)
+
+            // end() is idempotent and update() after end() writes nothing back.
+            session.end()
+            session.update(phase: "vae-decode")
+            XCTAssertTrue(manifestFiles(in: dir).isEmpty)
+        }
+    }
+
+    func testDeinitRemovesTheManifestEvenWithoutAnExplicitEnd() throws {
+        try withSandbox { dir in
+            do {
+                let session = try XCTUnwrap(RuntimeBeacon.begin(task: "train"))
+                XCTAssertEqual(manifestFiles(in: dir).count, 1)
+                _ = session  // silence unused warning; deallocated at scope exit
+            }
+            XCTAssertTrue(manifestFiles(in: dir).isEmpty)
+        }
+    }
+
+    func testBeginRemovesStaleManifestsLeftByDeadProcessesKeepsLiveOnes() throws {
+        try withSandbox { dir in
+            // Fake leftover from a crashed process. PID 99999997 is outside
+            // macOS's PID range, so kill(pid, 0) fails with ESRCH.
+            let stale = dir.appendingPathComponent("99999997-deadbeef.json")
+            try Data("{}".utf8).write(to: stale)
+            // Manifest of a live foreign process (launchd, pid 1) must survive.
+            let live = dir.appendingPathComponent("1-cafebabe.json")
+            try Data("{}".utf8).write(to: live)
+
+            let session = try XCTUnwrap(RuntimeBeacon.begin(task: "generate"))
+            defer { session.end() }
+
+            let names = manifestFiles(in: dir).map(\.lastPathComponent)
+            XCTAssertFalse(names.contains("99999997-deadbeef.json"))
+            XCTAssertTrue(names.contains("1-cafebabe.json"))
+            XCTAssertEqual(names.count, 2)  // live foreign + our session
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ports the **RuntimeBeacon** convention introduced in [ltx-video-swift-mlx #34](https://github.com/VincentGourbin/ltx-video-swift-mlx/pull/34) so FLUX.2 activity is visible to external monitors like [SiliconScope](https://github.com/kennss/SiliconScope).

While a heavy operation runs, a small JSON manifest lives at `~/Library/Application Support/ai-runtime-beacons/<pid>-<id>.json` and is deleted the moment it ends — errors included (`defer` at every call site, `deinit` safety net). **Nothing is ever written unless you opt in.**

Same canvas as LTX (shared directory, schema version 1, pid-liveness GC), so SiliconScope's producer-agnostic `RuntimeBeaconReader` picks it up **without any change on its side**: unknown runtimes fall back to the generic beacon kind and display the manifest's `displayName` ("FLUX.2").

## Instrumented operations

| Call site | task | phases |
|---|---|---|
| `Flux2Pipeline.generateWithResult` (all t2i/i2i/chains funnel here) | `generate` | `text-encoding` → `denoising` (step/totalSteps via existing `onProgress`) → `vae-decode` |
| `Flux2Pipeline.loadModels` | `load-models` | — |
| `Flux2Pipeline.exportPrequantizedTransformer` | `export-quantized` | — |
| `SimpleLoRATrainer.train` | `train` | `training` (step/maxSteps) |

## Opt-in

- Swift: `RuntimeBeacon.isEnabled = true`
- Env: `FLUX2_RUNTIME_BEACON=1`
- CLI: `--beacon` on `t2i`, `i2i`, `inpaint`, `outpaint`, `train-lora`, `export-quantized`, `profile run|benchmark|compare`

## Testing

- `RuntimeBeaconTests` (4 tests, XCTest): disabled-by-default, lifecycle create/update/delete, `deinit` cleanup, stale-pid GC keeping live foreign manifests — all pass via `xcodebuild test`.
- `xcodebuild -scheme Flux2CLI -configuration Release` builds clean.
- **End-to-end**: real `flux2 t2i --beacon` run (klein-4b, 512², 4 steps) — manifest observed with `text-encoding` → `denoising 1-3/4` → `vae-decode`, deleted on exit; a concurrently live LTX-Video training beacon in the same directory was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)