### PR TITLE
feat(vlm): provider sélectionnable pour l'enrichissement — Gemma 4 E2B à côté de Qwen 3.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,9 @@ let package = Package(
         .library(name: "FluxTextEncoders", targets: ["FluxTextEncoders"]),
         .library(name: "Flux2Core", targets: ["Flux2Core"]),
         .library(name: "Flux2Chains", targets: ["Flux2Chains"]),
+        // Opt-in: link this to enrich prompts / score checkpoints with Gemma 4 E2B
+        // instead of the bundled Qwen3.5. Nothing else pulls it in.
+        .library(name: "FluxGemma4VLM", targets: ["FluxGemma4VLM"]),
         // CLI Tools
         .executable(name: "FluxEncodersCLI", targets: ["FluxEncodersCLI"]),
         .executable(name: "Flux2CLI", targets: ["Flux2CLI"]),
@@ -25,6 +28,11 @@ let package = Package(
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.3"),
         .package(url: "https://github.com/jpsim/Yams", from: "6.0.0"),
         .package(url: "https://github.com/VincentGourbin/swift-mlx-profiler", from: "1.4.0"),
+        // Optional VLM provider (target `FluxGemma4VLM` only): Gemma 4 E2B as an
+        // alternative to the bundled Qwen3.5 for prompt enrichment / scoring.
+        // Its mlx-swift range is 0.31.4..<0.32, compatible with the exact pin above;
+        // it brings mlx-swift-lm in, which is why it stays out of the base targets.
+        .package(url: "https://github.com/VincentGourbin/gemma-4-swift-mlx", from: "1.5.0"),
     ],
     targets: [
         // MARK: - Libraries
@@ -61,6 +69,14 @@ let package = Package(
                 .product(name: "MLXRandom", package: "mlx-swift"),
             ]
         ),
+        .target(
+            name: "FluxGemma4VLM",
+            dependencies: [
+                "FluxTextEncoders",  // FluxVLMProvider protocol + registry
+                .product(name: "Gemma4Swift", package: "gemma-4-swift-mlx"),
+                .product(name: "MLX", package: "mlx-swift"),
+            ]
+        ),
         // MARK: - CLI Tools
         .executableTarget(
             name: "FluxEncodersCLI",
@@ -74,6 +90,7 @@ let package = Package(
             dependencies: [
                 "Flux2Core",
                 "Flux2Chains",
+                "FluxGemma4VLM",  // --vlm-provider gemma4
                 .product(name: "MLX", package: "mlx-swift"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Yams", package: "Yams"),
@@ -88,6 +105,10 @@ let package = Package(
         .testTarget(
             name: "FluxTextEncodersTests",
             dependencies: ["FluxTextEncoders"]
+        ),
+        .testTarget(
+            name: "FluxGemma4VLMTests",
+            dependencies: ["FluxGemma4VLM", "FluxTextEncoders"]
         ),
         .testTarget(
             name: "Flux2CoreTests",

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ A native Swift implementation of [Flux.2](https://blackforestlabs.ai/) image gen
 - **Mistral Small 3.2 (24B)**: Text encoder for FLUX.2 dev/pro
 - **Qwen3 (4B/8B)**: Text encoder for FLUX.2 Klein
 - **Qwen3.5-4B VLM**: Native vision-language model for image analysis (~3GB, auto-downloaded)
+- **Gemma 4 E2B VLM (opt-in)**: Alternative provider for the same enrichment services, via [gemma-4-swift-mlx](https://github.com/VincentGourbin/gemma-4-swift-mlx) — link `FluxGemma4VLM` and call `FluxGemma4VLM.activate()` ([VLM API](docs/VLM-API.md#providers))
 - **FLUX.2 Image Description**: VLM-powered image analysis optimized for FLUX.2 regeneration
 - **Image Comparison**: Score two images on scene and style fidelity (0-10)
 - **Text Generation**: Streaming text generation with configurable parameters
@@ -267,7 +268,7 @@ The manifest schema is deliberately runtime-agnostic (`version`, `pid`, `runtime
 | [LoRA Guide](docs/LoRA.md) | Loading and using LoRA adapters |
 | [LoRA Training Guide](docs/examples/TRAINING_GUIDE.md) | Training parameters, DOP, gradient checkpointing, YAML config |
 | [LoRA Evaluation](docs/examples/evaluate-lora/) | Automated gap analysis and training parameter recommendations |
-| [VLM API](docs/VLM-API.md) | Qwen3.5 VLM — image analysis, comparison, LoRA training setup |
+| [VLM API](docs/VLM-API.md) | VLM providers (Qwen3.5 bundled, Gemma 4 E2B opt-in) — image analysis, comparison, prompt rewriting, LoRA training setup |
 | [Text Encoders](docs/TextEncoders.md) | FluxTextEncoders library API and CLI |
 | [Custom Model Integration](docs/CustomModelIntegration.md) | Integrating custom MLX-compatible models into the framework |
 | [Flux2App Guide](docs/Flux2App.md) | Demo macOS application |

--- a/Sources/Flux2CLI/Flux2CLI.swift
+++ b/Sources/Flux2CLI/Flux2CLI.swift
@@ -37,6 +37,7 @@ struct Flux2CLI: AsyncParsableCommand {
             CompareEncoders.self,
             TestVLGeneration.self,
             TestQwen35.self,
+            TestGemma4.self,
             EvaluateLoRA.self,
             TrainLoRA.self,
             TrainingControlCommand.self,

--- a/Sources/Flux2CLI/InpaintCommand.swift
+++ b/Sources/Flux2CLI/InpaintCommand.swift
@@ -89,17 +89,14 @@ struct Inpaint: AsyncParsableCommand {
     @Flag(name: .long, help: "Text-encoder-only prompt rewriting (Mistral/Klein-Qwen3). Does NOT look at the image. For image-aware rewriting that inherits the source's lighting/camera/materials, use --enrich-prompt-with-vlm instead.")
     var upsamplePrompt: Bool = false
 
-    @Flag(name: .long, help: "Image-aware prompt rewriting via the bundled Qwen3.5 VLM. The VLM looks at --image and rewrites --prompt into a 30-80 word BFL-style Flux 2 prompt that inherits the source's photographic identity (camera angle, lighting direction, materials, palette, depth of field). Strictly optional: if the VLM is not loaded, the chain falls back to --prompt verbatim with a warning. Note: this CLI does NOT auto-load the VLM; load it ahead of time via FluxEncodersCLI or the test-qwen35 command. When both --upsample-prompt and --enrich-prompt-with-vlm are set, the VLM wins.")
+    @Flag(name: .long, help: "Image-aware prompt rewriting via a VLM (--vlm-provider: bundled Qwen3.5 by default, or Gemma 4 E2B). The VLM looks at --image and rewrites --prompt into a 30-80 word BFL-style Flux 2 prompt that inherits the source's photographic identity (camera angle, lighting direction, materials, palette, depth of field). Strictly optional: if no VLM is loaded, the chain falls back to --prompt verbatim with a warning. Pass --qwen35-variant/--qwen35-path (or --gemma4-variant/--gemma4-path) to have this command load one in-process. When both --upsample-prompt and --enrich-prompt-with-vlm are set, the VLM wins.")
     var enrichPromptWithVLM: Bool = false
 
     @Option(name: .long, help: "Drives --enrich-prompt-with-vlm (ignored otherwise). 'replace' = swap object X for Y (default). 'remove' = clear object X, surface continues. 'modify' = keep object X but change colour/outfit/expression. 'change-scene' = keep subject exactly as-is, change the scene around it (use this when the mask preserves the subject — e.g. 'put the cat at the pool').")
     var intent: InpaintIntentArg = .replace
 
-    @Option(name: .long, help: "Qwen3.5 VLM variant to load in-process when --enrich-prompt-with-vlm is set: '8bit' (default, 5 GB, recommended) or '4bit' (3 GB, faster but lower quality). Auto-downloads if missing. Omit to skip loading — the chain will then fall back to --prompt verbatim and emit a warning.")
-    var qwen35Variant: String?
-
-    @Option(name: .long, help: "Override the local path to Qwen3.5 VLM weights (alternative to --qwen35-variant for sandboxed apps).")
-    var qwen35Path: String?
+    /// `--vlm-provider`, `--qwen35-variant|-path`, `--gemma4-variant|-path`.
+    @OptionGroup var vlmOptions: VLMProviderOptions
 
     @Option(name: .long, help: "Denoising steps for FLUX.2 (4 for distilled klein, 25-28 for base/dev).")
     var steps: Int = 4
@@ -159,37 +156,18 @@ struct Inpaint: AsyncParsableCommand {
 
         let modelChoice = try Flux2Model.parseCLI(fluxModel)
 
-        // Optional Qwen3.5 VLM load — only relevant when the user opts
-        // into --enrich-prompt-with-vlm. The chain itself doesn't
-        // auto-load; we do it here at the CLI level so a single
-        // invocation is enough to benchmark the VLM-enriched path.
+        // Optional VLM load — only relevant when the user opts into
+        // --enrich-prompt-with-vlm. The chain itself doesn't auto-load; we do
+        // it here at the CLI level so a single invocation is enough to
+        // benchmark the VLM-enriched path.
         if enrichPromptWithVLM {
             // Surface the VLM-built prompt via FluxDebug.info so the
             // user can audit what FLUX.2 actually receives.
             FluxDebug.isEnabled = true
-            if qwen35Variant == nil, qwen35Path == nil {
-                logErr("WARNING: --enrich-prompt-with-vlm is set but neither --qwen35-variant nor --qwen35-path was provided — the chain will fall back to --prompt verbatim.")
-            }
         }
-        if let qwen35Path {
-            logErr("Loading Qwen3.5 VLM from \(qwen35Path) ...")
-            try await FluxTextEncoders.shared.loadQwen35VLM(from: qwen35Path)
-            logErr("✓ Qwen3.5 VLM loaded")
-        } else if let variantStr = qwen35Variant {
-            let selectedVariant: Qwen35Variant
-            switch variantStr.lowercased() {
-            case "4bit": selectedVariant = .qwen35_4B_4bit
-            case "8bit": selectedVariant = .qwen35_4B_8bit
-            default: throw ValidationError("Unsupported --qwen35-variant '\(variantStr)' (use '8bit' or '4bit')")
-            }
-            logErr("Downloading/loading Qwen3.5 VLM (\(selectedVariant.displayName)) ...")
-            let downloader = TextEncoderModelDownloader()
-            let path = try await downloader.downloadQwen35(variant: selectedVariant) { progress, message in
-                logErr("  [\(Int(progress * 100))%] \(message)")
-            }
-            try await FluxTextEncoders.shared.loadQwen35VLM(from: path.path)
-            logErr("✓ Qwen3.5 VLM loaded")
-        }
+        try await vlmOptions.loadIfRequested(
+            enrichmentRequested: enrichPromptWithVLM, logErr: logErr
+        )
 
         guard let textQuantization = MistralQuantization(rawValue: textQuant) else {
             throw ValidationError("Invalid text quantization: \(textQuant). Use bf16, 8bit, 6bit, or 4bit")

--- a/Sources/Flux2CLI/OutpaintCommand.swift
+++ b/Sources/Flux2CLI/OutpaintCommand.swift
@@ -16,6 +16,7 @@ import ImageIO
 import UniformTypeIdentifiers
 import Flux2Core
 import Flux2Chains
+import FluxTextEncoders  // FluxDebug
 
 struct Outpaint: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
@@ -56,8 +57,14 @@ struct Outpaint: AsyncParsableCommand {
     @Flag(name: .long, help: "Text-encoder-only prompt rewriting (Mistral/Klein-Qwen3). Does NOT look at the image. For image-aware rewriting that continues the source's lighting/materials into the new strips, use --enrich-prompt-with-vlm instead.")
     var upsamplePrompt: Bool = false
 
-    @Flag(name: .long, help: "Image-aware prompt rewriting via the bundled Qwen3.5 VLM. The VLM looks at --image and the requested extension sides, then assembles a 30-80 word BFL-style Flux 2 prompt that continues the kept region's materials, perspective, lighting and palette into the new strips. Strictly optional: if the VLM is not loaded, the chain falls back to --prompt verbatim with a warning. Load the VLM ahead of time via FluxEncodersCLI or the test-qwen35 command. When both --upsample-prompt and --enrich-prompt-with-vlm are set, the VLM wins.")
+    @Flag(name: .long, help: "Image-aware prompt rewriting via a VLM (--vlm-provider: bundled Qwen3.5 by default, or Gemma 4 E2B). The VLM looks at --image and the requested extension sides, then assembles a 30-80 word BFL-style Flux 2 prompt that continues the kept region's materials, perspective, lighting and palette into the new strips. Strictly optional: if no VLM is loaded, the chain falls back to --prompt verbatim with a warning. Pass --qwen35-variant/--qwen35-path (or --gemma4-variant/--gemma4-path) to have this command load one in-process. When both --upsample-prompt and --enrich-prompt-with-vlm are set, the VLM wins.")
     var enrichPromptWithVLM: Bool = false
+
+    /// `--vlm-provider`, `--qwen35-variant|-path`, `--gemma4-variant|-path`.
+    /// Until this existed, `--enrich-prompt-with-vlm` on this command was inert
+    /// unless something else in the process had already loaded a VLM.
+    @OptionGroup var vlmOptions: VLMProviderOptions
+
     @Option(name: .long, help: "Width of the soft transition band, in pixels of the keep region. Default 32.")
     var transitionPixels: Int = 32
     @Option(name: .long, help: "Cap on the total working pixel count. Defaults to 4 M; raise if you want larger canvases.")
@@ -81,6 +88,15 @@ struct Outpaint: AsyncParsableCommand {
         logErr("Prompt: \(prompt)")
 
         let modelChoice = try Flux2Model.parseCLI(fluxModel)
+
+        if enrichPromptWithVLM {
+            // Surface the VLM-built prompt so the user can audit what FLUX.2
+            // actually receives.
+            FluxDebug.isEnabled = true
+        }
+        try await vlmOptions.loadIfRequested(
+            enrichmentRequested: enrichPromptWithVLM, logErr: logErr
+        )
 
         let pipeline = Flux2Pipeline(
             model: modelChoice,

--- a/Sources/Flux2CLI/TestGemma4.swift
+++ b/Sources/Flux2CLI/TestGemma4.swift
@@ -1,0 +1,124 @@
+// TestGemma4.swift — `flux2 test-gemma4` (Gemma 4 E2B as the VLM provider)
+// Copyright 2025 Vincent Gourbin
+//
+// The `test-qwen35` counterpart for the opt-in Gemma 4 provider. Same three
+// modes (text-only, single-image analysis, two-image FLUX.2 comparison) so the
+// two providers can be compared on the exact same prompts — which is the whole
+// point of routing them through `FluxVLMProvider`.
+
+import Foundation
+import ArgumentParser
+import CoreGraphics
+import ImageIO
+import FluxTextEncoders
+import FluxGemma4VLM
+
+struct TestGemma4: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "test-gemma4",
+        abstract: "Test Gemma 4 E2B as the VLM provider: analyze images, compare two images, or generate text"
+    )
+
+    @Argument(help: "Text prompt")
+    var prompt: String
+
+    @Option(name: .shortAndLong, help: "Image path to analyze (omit for text-only)")
+    var image: String?
+
+    @Option(name: .long, help: "Second image path (for --compare)")
+    var image2: String?
+
+    @Flag(name: .long, help: "Compare two images with the framework's FLUX.2 scene/style rubric (requires --image and --image2)")
+    var compare: Bool = false
+
+    @Option(name: .long, help: "Variant: 6bit (default), 4bit, 8bit, bf16")
+    var variant: String = "6bit"
+
+    @Option(name: .long, help: "Local path to Gemma 4 weights (directory with config.json + safetensors + tokenizer.json). Takes precedence over --variant.")
+    var modelPath: String?
+
+    @Option(name: .long, help: "Custom Gemma weights cache directory (layout: {org}/{model})")
+    var modelsDir: String?
+
+    @Option(name: .long, help: "Maximum tokens to generate")
+    var maxTokens: Int = 512
+
+    @Flag(name: .long, help: "Ask for a reasoning pass before the answer (slower, needs a larger --max-tokens)")
+    var think: Bool = false
+
+    @Option(name: .long, help: "Temperature (0 = greedy, the framework default)")
+    var temperature: Float = 0
+
+    @Option(name: .long, help: "System prompt")
+    var systemPrompt: String?
+
+    @Flag(name: .long, help: "Use the framework's FLUX.2 image-description system prompt (what describeImageForFlux sends)")
+    var fluxDescribe: Bool = false
+
+    func run() async throws {
+        let startTime = Date()
+
+        guard let selectedVariant = Gemma4VLMProvider.Variant.fromCLIName(variant) else {
+            throw ValidationError("Unsupported --variant '\(variant)' (use '4bit', '6bit', '8bit' or 'bf16')")
+        }
+
+        if let modelsDir {
+            FluxGemma4VLM.setModelsDirectory(URL(fileURLWithPath: modelsDir))
+        }
+
+        print("=== Gemma 4 VLM Test ===")
+        print("Prompt: \"\(prompt)\"")
+        print("Mode: \(compare ? "comparison" : (image == nil ? "text-only" : "image analysis"))")
+        print()
+
+        print("Loading \(selectedVariant.displayName)...")
+        let provider = try await FluxGemma4VLM.activate(
+            variant: selectedVariant,
+            modelPath: modelPath.map { URL(fileURLWithPath: $0) },
+            progress: { print($0); fflush(stdout) }
+        )
+        print("Model loaded.\n")
+
+        if compare {
+            guard let img1 = image, let img2 = image2 else {
+                throw ValidationError("--compare requires both --image and --image2")
+            }
+            let ref = try Self.loadImage(img1)
+            let gen = try Self.loadImage(img2)
+            print("--- FLUX.2 Image Comparison ---")
+            let comparison = try await provider.compareImagesForFlux(reference: ref, generated: gen)
+            print("Scene: \(comparison.sceneScore)/100 — \(comparison.sceneReason)")
+            print("Style: \(comparison.styleScore)/100 — \(comparison.styleReason)")
+            print("\nRaw: \(comparison.rawResponse)")
+        } else {
+            let effectiveSystemPrompt: String? = fluxDescribe
+                ? FluxTextEncoders.fluxImageDescriptionSystemPrompt
+                : systemPrompt
+            let images: [CGImage] = try image.map { [try Self.loadImage($0)] } ?? []
+            if let first = images.first {
+                print("Image loaded: \(first.width)x\(first.height)")
+            }
+            print("--- Generation ---")
+            let text = try await provider.generateText(
+                images: images,
+                prompt: prompt,
+                systemPrompt: effectiveSystemPrompt,
+                enableThinking: think,
+                maxTokens: maxTokens,
+                temperature: temperature
+            )
+            print(text)
+        }
+
+        print("\nTotal time: \(String(format: "%.1f", Date().timeIntervalSince(startTime)))s")
+        await FluxGemma4VLM.deactivate()
+    }
+
+    private static func loadImage(_ path: String) throws -> CGImage {
+        guard let source = CGImageSourceCreateWithURL(URL(fileURLWithPath: path) as CFURL, nil),
+              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            throw ValidationError("Failed to load image: \(path)")
+        }
+        return image
+    }
+}

--- a/Sources/Flux2CLI/VLMProviderOptions.swift
+++ b/Sources/Flux2CLI/VLMProviderOptions.swift
@@ -1,0 +1,104 @@
+// VLMProviderOptions.swift — Shared CLI surface for choosing + loading the VLM
+// Copyright 2025 Vincent Gourbin
+//
+// The image-aware prompt rewriters (`inpaint --enrich-prompt-with-vlm`,
+// `outpaint --enrich-prompt-with-vlm`) need a VLM resident in-process; the
+// chains never auto-load one, on purpose (they must stay usable with no VLM at
+// all, falling back to the caller's prompt). This option group is the one place
+// that decides which provider runs and gets it loaded, so both commands offer
+// the same flags and the same defaults.
+//
+// Backwards compatible: `--qwen35-variant` / `--qwen35-path` keep their exact
+// previous meaning, and the default provider is still the bundled Qwen3.5.
+
+import Foundation
+import ArgumentParser
+import FluxTextEncoders
+import FluxGemma4VLM
+
+/// Which VLM serves the framework's image-aware enrichment.
+enum VLMProviderArg: String, ExpressibleByArgument, CaseIterable {
+    /// Bundled Qwen3.5 4B (default — what every previous release used).
+    case qwen35
+    /// Gemma 4 E2B through the opt-in `FluxGemma4VLM` target.
+    case gemma4
+}
+
+struct VLMProviderOptions: ParsableArguments {
+
+    @Option(name: .long, help: "Which VLM serves --enrich-prompt-with-vlm: 'qwen35' (default, bundled Qwen3.5 4B) or 'gemma4' (Gemma 4 E2B-it). Both answer the same system prompts; Gemma is smaller and faster, Qwen3.5 is the historical default.")
+    var vlmProvider: VLMProviderArg = .qwen35
+
+    @Option(name: .long, help: "Qwen3.5 VLM variant to load in-process when --enrich-prompt-with-vlm is set: '8bit' (5 GB, recommended) or '4bit' (3 GB, faster but lower quality). Auto-downloads if missing. Omit (and omit --qwen35-path) to skip loading — the chain then falls back to --prompt verbatim with a warning.")
+    var qwen35Variant: String?
+
+    @Option(name: .long, help: "Override the local path to Qwen3.5 VLM weights (alternative to --qwen35-variant for sandboxed apps).")
+    var qwen35Path: String?
+
+    @Option(name: .long, help: "Gemma 4 E2B-it variant when --vlm-provider gemma4: '6bit' (default, ~4.2 GB), '4bit' (~3.6 GB), '8bit' (~5.2 GB) or 'bf16' (~10 GB). Auto-downloads if missing.")
+    var gemma4Variant: String?
+
+    @Option(name: .long, help: "Override the local path to Gemma 4 weights (directory with config.json + safetensors + tokenizer.json). Takes precedence over --gemma4-variant.")
+    var gemma4Path: String?
+
+    /// Load the selected provider and register it as `FluxVLM.active`.
+    ///
+    /// - Returns: `true` when a VLM is resident afterwards, `false` when the
+    ///   caller asked for enrichment but gave no weights (the chain will then
+    ///   fall back to the verbatim prompt — the commands warn about it).
+    @discardableResult
+    func loadIfRequested(
+        enrichmentRequested: Bool,
+        logErr: @escaping @Sendable (String) -> Void
+    ) async throws -> Bool {
+        switch vlmProvider {
+        case .qwen35:
+            if let qwen35Path {
+                logErr("Loading Qwen3.5 VLM from \(qwen35Path) ...")
+                try await FluxTextEncoders.shared.loadQwen35VLM(from: qwen35Path)
+                logErr("✓ Qwen3.5 VLM loaded")
+                return true
+            }
+            guard let variantStr = qwen35Variant else {
+                if enrichmentRequested {
+                    logErr("WARNING: --enrich-prompt-with-vlm is set but neither --qwen35-variant nor --qwen35-path was provided — the chain will fall back to --prompt verbatim.")
+                }
+                return false
+            }
+            let selectedVariant: Qwen35Variant
+            switch variantStr.lowercased() {
+            case "4bit": selectedVariant = .qwen35_4B_4bit
+            case "8bit": selectedVariant = .qwen35_4B_8bit
+            default: throw ValidationError("Unsupported --qwen35-variant '\(variantStr)' (use '8bit' or '4bit')")
+            }
+            logErr("Downloading/loading Qwen3.5 VLM (\(selectedVariant.displayName)) ...")
+            let downloader = TextEncoderModelDownloader()
+            let path = try await downloader.downloadQwen35(variant: selectedVariant) { progress, message in
+                logErr("  [\(Int(progress * 100))%] \(message)")
+            }
+            try await FluxTextEncoders.shared.loadQwen35VLM(from: path.path)
+            logErr("✓ Qwen3.5 VLM loaded")
+            return true
+
+        case .gemma4:
+            let variant: Gemma4VLMProvider.Variant
+            if let gemma4Variant {
+                guard let parsed = Gemma4VLMProvider.Variant.fromCLIName(gemma4Variant) else {
+                    throw ValidationError("Unsupported --gemma4-variant '\(gemma4Variant)' (use '4bit', '6bit', '8bit' or 'bf16')")
+                }
+                variant = parsed
+            } else {
+                variant = .e2b6bit
+            }
+            let path = gemma4Path.map { URL(fileURLWithPath: $0) }
+            logErr("Loading \(variant.displayName)\(path == nil ? "" : " from \(path!.path)") ...")
+            try await FluxGemma4VLM.activate(
+                variant: variant,
+                modelPath: path,
+                progress: { message in logErr("  \(message)") }
+            )
+            logErr("✓ \(FluxVLM.active.displayName) loaded and registered as the active VLM")
+            return true
+        }
+    }
+}

--- a/Sources/Flux2CLI/VLMProviderOptions.swift
+++ b/Sources/Flux2CLI/VLMProviderOptions.swift
@@ -41,6 +41,22 @@ struct VLMProviderOptions: ParsableArguments {
     @Option(name: .long, help: "Override the local path to Gemma 4 weights (directory with config.json + safetensors + tokenizer.json). Takes precedence over --gemma4-variant.")
     var gemma4Path: String?
 
+    /// Parse `--qwen35-variant`. Returns `nil` for an unknown spelling.
+    private static func qwenVariant(named name: String) -> Qwen35Variant? {
+        switch name.lowercased() {
+        case "4bit": return .qwen35_4B_4bit
+        case "8bit": return .qwen35_4B_8bit
+        default: return nil
+        }
+    }
+
+    /// Provider for an explicitly requested Qwen variant. `nil` (an unknown
+    /// spelling, which `loadIfRequested` rejects right after, or no variant at
+    /// all) falls back to `Qwen35VLMProvider.shared` through the registry.
+    private static func qwenProvider(forVariant name: String) -> Qwen35VLMProvider? {
+        qwenVariant(named: name).map { Qwen35VLMProvider(variant: $0) }
+    }
+
     /// Load the selected provider and register it as `FluxVLM.active`.
     ///
     /// - Returns: `true` when a VLM is resident afterwards, `false` when the
@@ -53,6 +69,12 @@ struct VLMProviderOptions: ParsableArguments {
     ) async throws -> Bool {
         switch vlmProvider {
         case .qwen35:
+            // Make the flag authoritative rather than relying on whatever the
+            // process last registered: `--vlm-provider qwen35` must put the
+            // bundled Qwen3.5 in the seat, with the variant the user asked for
+            // (so a later `ensureLoaded()` fetches that one, not the default).
+            FluxVLM.register(qwen35Variant.flatMap(Self.qwenProvider(forVariant:)))
+
             if let qwen35Path {
                 logErr("Loading Qwen3.5 VLM from \(qwen35Path) ...")
                 try await FluxTextEncoders.shared.loadQwen35VLM(from: qwen35Path)
@@ -65,11 +87,8 @@ struct VLMProviderOptions: ParsableArguments {
                 }
                 return false
             }
-            let selectedVariant: Qwen35Variant
-            switch variantStr.lowercased() {
-            case "4bit": selectedVariant = .qwen35_4B_4bit
-            case "8bit": selectedVariant = .qwen35_4B_8bit
-            default: throw ValidationError("Unsupported --qwen35-variant '\(variantStr)' (use '8bit' or '4bit')")
+            guard let selectedVariant = Self.qwenVariant(named: variantStr) else {
+                throw ValidationError("Unsupported --qwen35-variant '\(variantStr)' (use '8bit' or '4bit')")
             }
             logErr("Downloading/loading Qwen3.5 VLM (\(selectedVariant.displayName)) ...")
             let downloader = TextEncoderModelDownloader()

--- a/Sources/Flux2Chains/Flux2MaskedInpaintingChain.swift
+++ b/Sources/Flux2Chains/Flux2MaskedInpaintingChain.swift
@@ -167,9 +167,10 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
     /// configuration.
     ///
     /// Cost: one extra VLM forward pass (~few seconds on M-series). The
-    /// caller is responsible for the VLM lifecycle — load it via
-    /// ``FluxTextEncoders/shared/loadQwen35VLM(from:)`` before
-    /// ``run()`` and unload when done. Default `false`.
+    /// caller is responsible for the VLM lifecycle — load ``FluxVLM/active``
+    /// (bundled Qwen3.5 via `FluxTextEncoders.shared.loadQwen35VLM(from:)`,
+    /// or Gemma 4 E2B via `FluxGemma4VLM.activate(...)`) before ``run()``
+    /// and unload when done. Default `false`.
     public let enrichPromptWithVLM: Bool
 
     /// Drives ``Flux2VLMPromptBuilder`` when ``enrichPromptWithVLM`` is
@@ -487,8 +488,8 @@ public struct Flux2MaskedInpaintingChain: Flux2Chain {
         guard enrichPromptWithVLM else {
             return (prompt, upsamplePrompt)
         }
-        guard FluxTextEncoders.shared.isQwen35VLMLoaded else {
-            FluxDebug.error("[Flux2MaskedInpaintingChain] enrichPromptWithVLM=true but Qwen3.5 VLM is not loaded. Falling back to caller's prompt. Load the VLM via FluxTextEncoders.shared.loadQwen35VLM(from:) before run() to enable image-aware prompt enrichment.")
+        guard FluxVLM.active.isLoaded else {
+            FluxDebug.error("[Flux2MaskedInpaintingChain] enrichPromptWithVLM=true but \(FluxVLM.active.displayName) is not loaded. Falling back to caller's prompt. Load a VLM before run() (FluxTextEncoders.shared.loadQwen35VLM(from:) for the bundled Qwen3.5, or FluxGemma4VLM.activate(...) for Gemma 4 E2B) to enable image-aware prompt enrichment.")
             return (prompt, upsamplePrompt)
         }
         if upsamplePrompt {

--- a/Sources/Flux2Chains/Flux2OutpaintingChain.swift
+++ b/Sources/Flux2Chains/Flux2OutpaintingChain.swift
@@ -82,9 +82,10 @@ public struct Flux2OutpaintingChain: Flux2Chain {
     /// **Collision with ``upsamplePrompt``:** when both are `true`, the
     /// VLM wins. A warning is logged.
     ///
-    /// The caller owns the VLM lifecycle (load via
-    /// ``FluxTextEncoders/shared/loadQwen35VLM(from:)`` before
-    /// ``run()``, unload when done). Default `false`.
+    /// The caller owns the VLM lifecycle: load ``FluxVLM/active`` before
+    /// ``run()`` (bundled Qwen3.5 via
+    /// `FluxTextEncoders.shared.loadQwen35VLM(from:)`, or Gemma 4 E2B via
+    /// `FluxGemma4VLM.activate(...)`), unload when done. Default `false`.
     public let enrichPromptWithVLM: Bool
     public let onProgress: Flux2ProgressCallback?
 
@@ -283,8 +284,8 @@ public struct Flux2OutpaintingChain: Flux2Chain {
         guard enrichPromptWithVLM else {
             return (prompt, upsamplePrompt)
         }
-        guard FluxTextEncoders.shared.isQwen35VLMLoaded else {
-            FluxDebug.error("[Flux2OutpaintingChain] enrichPromptWithVLM=true but Qwen3.5 VLM is not loaded. Falling back to caller's prompt. Load the VLM via FluxTextEncoders.shared.loadQwen35VLM(from:) before run() to enable image-aware prompt enrichment.")
+        guard FluxVLM.active.isLoaded else {
+            FluxDebug.error("[Flux2OutpaintingChain] enrichPromptWithVLM=true but \(FluxVLM.active.displayName) is not loaded. Falling back to caller's prompt. Load a VLM before run() (FluxTextEncoders.shared.loadQwen35VLM(from:) for the bundled Qwen3.5, or FluxGemma4VLM.activate(...) for Gemma 4 E2B) to enable image-aware prompt enrichment.")
             return (prompt, upsamplePrompt)
         }
         if upsamplePrompt {

--- a/Sources/Flux2Chains/Flux2VLMPromptBuilder.swift
+++ b/Sources/Flux2Chains/Flux2VLMPromptBuilder.swift
@@ -11,21 +11,26 @@
 // words structured Subject + Action + Style + Context, with photographic
 // vocabulary (focal length, lighting direction, depth of field).
 //
-// This builder asks the bundled Qwen3.5 VLM to *look at the source* and
-// assemble such a prompt automatically, with an operation-specific system
-// prompt so the produced text matches the actual intent (replace / remove
-// / modify / outpaint). The chains call this as a strictly opt-in
-// preprocessor — when the VLM isn't loaded the call returns `nil` so the
-// caller can fall back to the user's verbatim prompt.
+// This builder asks the active VLM to *look at the source* and assemble
+// such a prompt automatically, with an operation-specific system prompt so
+// the produced text matches the actual intent (replace / remove / modify /
+// outpaint). The chains call this as a strictly opt-in preprocessor — when
+// no VLM is loaded the call returns `nil` so the caller can fall back to
+// the user's verbatim prompt.
+//
+// Which VLM runs is `FluxVLM.active`: the bundled Qwen3.5 by default, or
+// Gemma 4 E2B when the process registered it (see the `FluxGemma4VLM`
+// target). The system prompts below are provider-agnostic — they describe
+// the task, not the model.
 
 import Foundation
 import CoreGraphics
 import FluxTextEncoders
 
-/// Build FLUX.2-style prompts from a source image using the bundled
-/// Qwen3.5 VLM. Returns `nil` whenever the VLM is not currently loaded
-/// (callers must treat this as a graceful fallback signal — never as an
-/// error).
+/// Build FLUX.2-style prompts from a source image using ``FluxVLM/active``
+/// (bundled Qwen3.5 unless another provider was registered). Returns `nil`
+/// whenever the VLM is not currently loaded (callers must treat this as a
+/// graceful fallback signal — never as an error).
 public enum Flux2VLMPromptBuilder {
 
     // MARK: - System prompts (public so tests can introspect them)
@@ -184,7 +189,7 @@ public enum Flux2VLMPromptBuilder {
         userInstruction: String,
         intent: Flux2InpaintIntent
     ) async throws -> String? {
-        guard FluxTextEncoders.shared.isQwen35VLMLoaded else { return nil }
+        guard FluxVLM.active.isLoaded else { return nil }
 
         let systemPrompt: String
         switch intent {
@@ -195,9 +200,6 @@ public enum Flux2VLMPromptBuilder {
         }
         let userMessage = userMessage(forInpaint: intent, instruction: userInstruction)
 
-        // The VLM forward is synchronous and takes ~3 s on M-series. Run
-        // it on a detached task so other work on the cooperative pool
-        // (UI updates, concurrent chains) isn't starved while we wait.
         let raw = try await runVLM(image: source, prompt: userMessage, systemPrompt: systemPrompt)
         return cleanFinalPrompt(raw)
     }
@@ -220,7 +222,7 @@ public enum Flux2VLMPromptBuilder {
         userInstruction: String,
         sides: Set<OutpaintSide>
     ) async throws -> String? {
-        guard FluxTextEncoders.shared.isQwen35VLMLoaded else { return nil }
+        guard FluxVLM.active.isLoaded else { return nil }
         guard !sides.isEmpty else { return nil }
 
         let userMessage = userMessage(forOutpaintSides: sides, instruction: userInstruction)
@@ -229,24 +231,21 @@ public enum Flux2VLMPromptBuilder {
         return cleanFinalPrompt(raw)
     }
 
-    /// Run the Qwen3.5 VLM forward on a detached, user-initiated task
-    /// so the ~3 s sync call doesn't block the cooperative thread pool.
-    /// CGImage / String are Sendable in the SDK we target.
+    /// Run one forward on the active provider. Each provider keeps the heavy
+    /// work off the cooperative pool itself (the Qwen3.5 forward is sync and
+    /// takes ~3 s, so it runs detached; Gemma streams from a ModelContainer
+    /// actor), so this stays a plain await.
     private static func runVLM(
         image: CGImage,
         prompt: String,
         systemPrompt: String
     ) async throws -> String {
-        try await Task.detached(priority: .userInitiated) {
-            try FluxTextEncoders.shared.analyzeImageWithQwen35(
-                image: image,
-                prompt: prompt,
-                systemPrompt: systemPrompt,
-                enableThinking: false,
-                maxTokens: 220,
-                temperature: 0
-            ).text
-        }.value
+        try await FluxVLM.active.analyzeImage(
+            image: image,
+            prompt: prompt,
+            systemPrompt: systemPrompt,
+            maxTokens: 220
+        )
     }
 
     // MARK: - User message assembly (exposed for tests)

--- a/Sources/Flux2Core/Training/LoRAEvaluator.swift
+++ b/Sources/Flux2Core/Training/LoRAEvaluator.swift
@@ -152,31 +152,30 @@ public class LoRAEvaluator {
         onProgress?("[1/5] Analyzing reference image with VLM...")
         onProgress?("  LoRA context: \"\(context.name)\" — \(context.description)")
 
-        // Load VLM if not already loaded
-        if !FluxTextEncoders.shared.isQwen35VLMLoaded {
-            onProgress?("  Loading Qwen3.5 VLM...")
-            let downloader = TextEncoderModelDownloader()
-            let vlmPath = try await downloader.downloadQwen35(variant: .qwen35_4B_4bit)
-            try await FluxTextEncoders.shared.loadQwen35VLM(from: vlmPath.path)
+        // Load whichever VLM is active (bundled Qwen3.5 by default, Gemma 4
+        // E2B when the process registered it) if it isn't resident yet.
+        let vlm = FluxVLM.active
+        if !vlm.isLoaded {
+            onProgress?("  Loading \(vlm.displayName)...")
+            try await vlm.ensureLoaded()
         }
 
         // Describe the image with LoRA context for focused description
-        let descResult = try FluxTextEncoders.shared.describeImageForFlux(
+        let description = try await vlm.describeImageForFlux(
             image: referenceImage,
             context: "This image is a training reference for a LoRA called \"\(context.name)\". Training goal: \(context.description). Describe the image focusing on what makes this subject unique and what the model needs to learn."
         )
-        let description = descResult.text
         onProgress?("  Description: \"\(description.prefix(80))...\"")
 
         // === Step 2: LLM analyzes LoRA context for trigger word and DOP ===
         onProgress?("[2/5] Analyzing LoRA training context...")
 
-        let analysisResult = try analyzeLoRAContext(context: context)
+        let analysisResult = try await analyzeLoRAContext(context: context)
         onProgress?("  Trigger word: \(analysisResult.triggerWord)")
         onProgress?("  DOP: \(analysisResult.dopRecommended ? "yes (\(analysisResult.dopClass ?? "object"))" : "no")")
 
         // Unload VLM to free memory for generation
-        FluxTextEncoders.shared.unloadQwen35VLM()
+        await vlm.unload()
         Memory.clearCache()
 
         // === Step 3: Generate baseline image with base model ===
@@ -211,10 +210,8 @@ public class LoRAEvaluator {
         onProgress?("[4/5] Comparing reference vs baseline...")
 
         // Reload VLM
-        if !FluxTextEncoders.shared.isQwen35VLMLoaded {
-            let downloader = TextEncoderModelDownloader()
-            let vlmPath = try await downloader.downloadQwen35(variant: .qwen35_4B_4bit)
-            try await FluxTextEncoders.shared.loadQwen35VLM(from: vlmPath.path)
+        if !vlm.isLoaded {
+            try await vlm.ensureLoaded()
         }
 
         // Contextual comparison — focused on what the LoRA needs to learn
@@ -244,26 +241,22 @@ public class LoRAEvaluator {
         {"scene_score": N, "scene_reason": "what the LoRA needs to learn", "style_score": N, "style_reason": "what differs in style"}
         """
 
-        guard let vlm = FluxTextEncoders.shared.qwen35VLMForEvaluation else {
-            throw Flux2Error.modelNotLoaded("Qwen3.5 VLM not loaded")
+        guard vlm.isLoaded else {
+            throw Flux2Error.modelNotLoaded("\(vlm.displayName) not loaded")
         }
 
-        let compResult = try vlm.generateMultiImage(
-            images: [referenceImage, baselineImage],
-            prompt: "Compare these two images for LoRA training evaluation.",
+        let comparison = try await vlm.compareImagesForFlux(
+            reference: referenceImage,
+            generated: baselineImage,
             systemPrompt: comparisonSystemPrompt,
-            enableThinking: false,
-            maxTokens: 300,
-            temperature: 0
+            prompt: "Compare these two images for LoRA training evaluation."
         )
-
-        let comparison = FluxTextEncoders.shared.parseComparisonForEvaluation(compResult.text)
 
         onProgress?("  Scene: \(comparison.sceneScore)/100 — \(comparison.sceneReason)")
         onProgress?("  Style: \(comparison.styleScore)/100 — \(comparison.styleReason)")
 
         // Unload VLM
-        FluxTextEncoders.shared.unloadQwen35VLM()
+        await vlm.unload()
 
         // === Step 5: Generate recommendation ===
         onProgress?("[5/5] Generating training recommendation...")
@@ -302,8 +295,9 @@ public class LoRAEvaluator {
         let dopClass: String?
     }
 
-    /// Use LLM to analyze the LoRA context and suggest trigger word + DOP settings
-    private func analyzeLoRAContext(context: LoRAContext) throws -> ContextAnalysis {
+    /// Use the active VLM's text path to analyze the LoRA context and suggest
+    /// trigger word + DOP settings
+    private func analyzeLoRAContext(context: LoRAContext) async throws -> ContextAnalysis {
         let analysisPrompt = """
         TASK: Analyze this LoRA training description and provide recommendations.
 
@@ -321,15 +315,13 @@ public class LoRAEvaluator {
         {"trigger_word": "xyz_name", "dop_recommended": true, "dop_class": "cat"}
         """
 
-        let result = try FluxTextEncoders.shared.generateWithQwen35(
+        let text = try await FluxVLM.active.generate(
             prompt: analysisPrompt,
             systemPrompt: "You are a LoRA training configuration assistant. Output only valid JSON.",
-            maxTokens: 100,
-            temperature: 0
+            maxTokens: 100
         )
 
         // Parse JSON from response
-        let text = result.text
         if let start = text.firstIndex(of: "{"), let end = text.lastIndex(of: "}") {
             let jsonStr = String(text[start...end])
             struct Analysis: Decodable {

--- a/Sources/Flux2Core/Training/LoRATrainingSetup.swift
+++ b/Sources/Flux2Core/Training/LoRATrainingSetup.swift
@@ -44,33 +44,32 @@ public class LoRATrainingSetup_API {
     public func describeReferenceForValidation(
         image: CGImage,
         triggerWord: String
-    ) throws -> String {
-        guard FluxTextEncoders.shared.isQwen35VLMLoaded else {
-            throw Flux2Error.modelNotLoaded("Qwen3.5 VLM not loaded")
+    ) async throws -> String {
+        let vlm = FluxVLM.active
+        guard vlm.isLoaded else {
+            throw Flux2Error.modelNotLoaded("\(vlm.displayName) not loaded")
         }
 
-        let result = try FluxTextEncoders.shared.analyzeImageWithQwen35(
+        let caption = try await vlm.analyzeImage(
             image: image,
             prompt: "Describe this person's physical appearance for image generation. Focus on: face shape, hair color and style, glasses, clothing, pose, and lighting. Be concise (one paragraph).",
-            enableThinking: false,
-            maxTokens: 200,
-            temperature: 0
+            maxTokens: 200
         )
 
         // Prepend trigger word
-        return "\(triggerWord), \(result.text)"
+        return "\(triggerWord), \(caption)"
     }
 
     /// Describe a reference image from file path
     public func describeReferenceForValidation(
         path: String,
         triggerWord: String
-    ) throws -> String {
+    ) async throws -> String {
         guard let source = CGImageSourceCreateWithURL(URL(fileURLWithPath: path) as CFURL, nil),
               let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
             throw Flux2Error.invalidConfiguration("Failed to load image: \(path)")
         }
-        return try describeReferenceForValidation(image: image, triggerWord: triggerWord)
+        return try await describeReferenceForValidation(image: image, triggerWord: triggerWord)
     }
 
     /// Create a complete training setup with VLM evaluation
@@ -118,20 +117,19 @@ public class LoRATrainingSetup_API {
 
         // Step 2: Generate validation prompt from reference
         onProgress?("Generating validation prompt from reference...")
-        if !FluxTextEncoders.shared.isQwen35VLMLoaded {
-            let downloader = TextEncoderModelDownloader()
-            let vlmPath = try await downloader.downloadQwen35(variant: .qwen35_4B_4bit)
-            try await FluxTextEncoders.shared.loadQwen35VLM(from: vlmPath.path)
+        let vlm = FluxVLM.active
+        if !vlm.isLoaded {
+            try await vlm.ensureLoaded()
         }
 
-        let validationPrompt = try describeReferenceForValidation(
+        let validationPrompt = try await describeReferenceForValidation(
             image: refImage,
             triggerWord: triggerWord
         )
         onProgress?("Validation prompt: \"\(validationPrompt.prefix(80))...\"")
 
         // Unload VLM
-        FluxTextEncoders.shared.unloadQwen35VLM()
+        await vlm.unload()
 
         return LoRATrainingSetup(
             referenceImage: refImage,

--- a/Sources/Flux2Core/Training/Loop/SimpleLoRATrainer.swift
+++ b/Sources/Flux2Core/Training/Loop/SimpleLoRATrainer.swift
@@ -2088,12 +2088,11 @@ public final class SimpleLoRATrainer {
                 return nil
             }
 
-            // Load VLM
-            let downloader = TextEncoderModelDownloader()
-            let vlmPath = try await downloader.downloadQwen35(variant: .qwen35_4B_4bit)
-            try await FluxTextEncoders.shared.loadQwen35VLM(from: vlmPath.path)
-
-            guard let vlm = FluxTextEncoders.shared.qwen35VLMForEvaluation else {
+            // Load whichever VLM is active (bundled Qwen3.5 by default,
+            // Gemma 4 E2B when the process registered it)
+            let vlm = FluxVLM.active
+            try await vlm.ensureLoaded()
+            guard vlm.isLoaded else {
                 print("    Warning: VLM not available, skipping scoring")
                 return nil
             }
@@ -2126,7 +2125,7 @@ public final class SimpleLoRATrainer {
                 }
 
                 // Compare reference vs generated using VLM (0-100 scale)
-                let result = try vlm.generateMultiImage(
+                let result = try await vlm.generateText(
                     images: [refCG, valCG],
                     prompt: "Compare these two images for LoRA training evaluation.",
                     systemPrompt: Self.vlmTrainingScoringPrompt,
@@ -2136,9 +2135,9 @@ public final class SimpleLoRATrainer {
                 )
 
                 Flux2Debug.log("[VLM] ref=\(refImage.lastPathComponent) val=\(imageName)")
-                Flux2Debug.log("[VLM] response: \(result.text.prefix(200))")
+                Flux2Debug.log("[VLM] response: \(result.prefix(200))")
 
-                let (sceneScore, styleScore, sceneReason, styleReason) = parseVLMScores(result.text)
+                let (sceneScore, styleScore, sceneReason, styleReason) = parseVLMScores(result)
 
                 // Compare vs baseline if enabled
                 var baselineScene: Int? = nil
@@ -2150,7 +2149,7 @@ public final class SimpleLoRATrainer {
                     if FileManager.default.fileExists(atPath: baselinePath.path),
                        let blSource = CGImageSourceCreateWithURL(baselinePath as CFURL, nil),
                        let blCG = CGImageSourceCreateImageAtIndex(blSource, 0, nil) {
-                        let blResult = try vlm.generateMultiImage(
+                        let blResult = try await vlm.generateText(
                             images: [refCG, blCG],
                             prompt: "Compare these two images for LoRA training evaluation.",
                             systemPrompt: Self.vlmTrainingScoringPrompt,
@@ -2158,8 +2157,8 @@ public final class SimpleLoRATrainer {
                             maxTokens: 300,
                             temperature: 0
                         )
-                        Flux2Debug.log("[VLM] baseline response: \(blResult.text.prefix(200))")
-                        let (blScene, blStyle, _, _) = parseVLMScores(blResult.text)
+                        Flux2Debug.log("[VLM] baseline response: \(blResult.prefix(200))")
+                        let (blScene, blStyle, _, _) = parseVLMScores(blResult)
                         baselineScene = blScene
                         baselineStyle = blStyle
                     }
@@ -2178,7 +2177,7 @@ public final class SimpleLoRATrainer {
             }
 
             // Unload VLM and clear memory
-            FluxTextEncoders.shared.unloadQwen35VLM()
+            await vlm.unload()
             eval([])
             try await Task.sleep(nanoseconds: 500_000_000)
             MLX.Memory.clearCache()
@@ -2214,7 +2213,7 @@ public final class SimpleLoRATrainer {
         } catch {
             print("    Warning: VLM scoring failed: \(error.localizedDescription)")
             // Ensure VLM is unloaded even on error
-            FluxTextEncoders.shared.unloadQwen35VLM()
+            await FluxVLM.active.unload()
             MLX.Memory.clearCache()
             return nil
         }

--- a/Sources/FluxGemma4VLM/FluxGemma4VLM.swift
+++ b/Sources/FluxGemma4VLM/FluxGemma4VLM.swift
@@ -1,0 +1,84 @@
+// FluxGemma4VLM.swift — Entry point for the opt-in Gemma 4 VLM provider
+// Copyright 2025 Vincent Gourbin
+
+import Foundation
+import FluxTextEncoders
+import Gemma4Swift
+
+/// Opt-in namespace: activates Gemma 4 E2B as the VLM behind the framework's
+/// enrichment functions (BFL prompt rewriting in the inpainting/outpainting
+/// chains, `describeImageForFlux`, LoRA scene/style scoring, training captions).
+///
+/// Nothing here runs unless you call it. Until then — and after
+/// ``deactivate()`` — ``FluxVLM/active`` is the bundled Qwen3.5.
+public enum FluxGemma4VLM {
+
+    /// Register Gemma 4 as the active provider and load its weights.
+    ///
+    /// - Parameters:
+    ///   - variant: Quantisation of Gemma 4 E2B-it. Default `.e2b6bit` (~4.2 GB).
+    ///   - modelPath: Load from this directory instead of downloading (what a
+    ///     sandboxed app passes; the directory needs `config.json`,
+    ///     `*.safetensors` and `tokenizer.json`).
+    ///   - hfToken: HuggingFace token, for gated or private repos.
+    ///   - progress: Load/download progress lines, delivered off the main actor.
+    /// - Returns: The registered provider, in case you want to unload it later.
+    @discardableResult
+    public static func activate(
+        variant: Gemma4VLMProvider.Variant = .e2b6bit,
+        modelPath: URL? = nil,
+        hfToken: String? = nil,
+        progress: (@Sendable (String) -> Void)? = nil
+    ) async throws -> Gemma4VLMProvider {
+        let provider = Gemma4VLMProvider(
+            variant: variant, modelPath: modelPath, hfToken: hfToken, progress: progress
+        )
+        try await provider.ensureLoaded()
+        FluxVLM.register(provider)
+        return provider
+    }
+
+    /// Register Gemma 4 as the active provider **without** loading it. The
+    /// framework loads it on first use through `ensureLoaded()` — which is what
+    /// the training paths (LoRA evaluation, VLM-guided checkpoint selection)
+    /// expect, since they load and unload the VLM around each generation phase.
+    @discardableResult
+    public static func register(
+        variant: Gemma4VLMProvider.Variant = .e2b6bit,
+        modelPath: URL? = nil,
+        hfToken: String? = nil,
+        progress: (@Sendable (String) -> Void)? = nil
+    ) -> Gemma4VLMProvider {
+        let provider = Gemma4VLMProvider(
+            variant: variant, modelPath: modelPath, hfToken: hfToken, progress: progress
+        )
+        FluxVLM.register(provider)
+        return provider
+    }
+
+    /// Unload Gemma (if it is the active provider) and hand the seat back to
+    /// the bundled Qwen3.5.
+    public static func deactivate() async {
+        let active = FluxVLM.active
+        FluxVLM.register(nil)
+        if let gemma = active as? Gemma4VLMProvider {
+            await gemma.unload()
+        }
+    }
+
+    /// Point the Gemma weights cache somewhere else — e.g. the app's shared
+    /// models directory. The layout inside is `{org}/{model}`, the same
+    /// HuggingFace owner namespace the other model directories use, so
+    /// `mlx-community/gemma-4-e2b-it-6bit` lands next to the FLUX checkpoints.
+    ///
+    /// Set this before the first `activate`/`ensureLoaded`.
+    public static func setModelsDirectory(_ directory: URL?) {
+        Gemma4ModelCache.customModelsDirectory = directory
+    }
+
+    /// Whether `variant`'s weights are already on disk (custom cache, or the
+    /// default HuggingFace one).
+    public static func isDownloaded(_ variant: Gemma4VLMProvider.Variant) -> Bool {
+        Gemma4ModelCache.isDownloaded(variant.model)
+    }
+}

--- a/Sources/FluxGemma4VLM/Gemma4VLMProvider.swift
+++ b/Sources/FluxGemma4VLM/Gemma4VLMProvider.swift
@@ -1,0 +1,281 @@
+// Gemma4VLMProvider.swift — Gemma 4 E2B as a FluxVLMProvider
+// Copyright 2025 Vincent Gourbin
+//
+// Why this target exists separately:
+// Gemma4Swift brings `mlx-swift-lm` (MLXLLM/MLXLMCommon) into the package
+// graph. The base libraries — FluxTextEncoders, Flux2Core, Flux2Chains — must
+// stay free of it, so this provider lives in its own opt-in target. Link
+// `FluxGemma4VLM` and call `FluxGemma4VLM.activate(...)`; link nothing and the
+// framework keeps running on the bundled Qwen3.5, byte for byte.
+//
+// What it does: implements the four `FluxVLMProvider` members on top of
+// `Gemma4Pipeline` (the same stack ltx-video-swift-mlx uses for its LTX-2.5
+// prompt enhancer). The system prompts and the response parsing are NOT here —
+// they are shared in FluxTextEncoders, so Gemma answers the exact same
+// questions Qwen3.5 does.
+
+import CoreGraphics
+import Foundation
+import FluxTextEncoders
+import Gemma4Swift
+import MLX
+
+/// Gemma 4 E2B (2.3B effective, text+vision) serving the framework's VLM
+/// enrichment functions.
+///
+/// ```swift
+/// // Auto-download into the Gemma cache and take over from Qwen3.5:
+/// try await FluxGemma4VLM.activate(variant: .e2b6bit)
+///
+/// // Sandboxed app with its own weights directory:
+/// try await FluxGemma4VLM.activate(modelPath: URL(fileURLWithPath: "…/gemma-4-e2b-it-6bit"))
+/// ```
+public final class Gemma4VLMProvider: FluxVLMProvider, @unchecked Sendable {
+
+    // MARK: - Variants
+
+    /// The E2B family only: it is the smallest Gemma 4 that carries a vision
+    /// tower, which keeps it in the same memory class as the Qwen3.5 4B it
+    /// replaces. Larger families (E4B, 31B, 26B-A4B) work through
+    /// ``Gemma4VLMProvider/init(model:modelPath:hfToken:)`` if you have the RAM.
+    public enum Variant: String, CaseIterable, Sendable, Codable {
+        case e2b4bit
+        case e2b6bit
+        case e2b8bit
+        case e2bBf16
+
+        /// CLI/YAML spelling (`4bit`, `6bit`, `8bit`, `bf16`).
+        public var cliName: String {
+            switch self {
+            case .e2b4bit: return "4bit"
+            case .e2b6bit: return "6bit"
+            case .e2b8bit: return "8bit"
+            case .e2bBf16: return "bf16"
+            }
+        }
+
+        public static func fromCLIName(_ name: String) -> Variant? {
+            Variant.allCases.first { $0.cliName == name.lowercased() }
+        }
+
+        public var model: Gemma4Pipeline.Model {
+            switch self {
+            case .e2b4bit: return .e2b4bit
+            case .e2b6bit: return .e2b6bit
+            case .e2b8bit: return .e2b8bit
+            case .e2bBf16: return .e2bBf16
+            }
+        }
+
+        public var displayName: String { model.displayName }
+        public var estimatedSizeGB: Float { model.estimatedSizeGB }
+    }
+
+    // MARK: - Configuration
+
+    /// Model this provider loads when it has to fetch weights itself.
+    public let model: Gemma4Pipeline.Model
+
+    /// When set, `ensureLoaded()` loads from this directory instead of
+    /// downloading — the path sandboxed apps need.
+    public let modelPath: URL?
+
+    private let hfToken: String?
+    private let progress: (@Sendable (String) -> Void)?
+
+    private let lock = NSLock()
+    private var pipeline: Gemma4Pipeline?
+
+    /// Default: Gemma 4 E2B-it 6-bit (~4.2 GB) — the closest match in size and
+    /// latency to the 4-bit Qwen3.5 the enrichment paths have always used, with
+    /// noticeably steadier instruction following than 4-bit on the
+    /// "output ONLY the prompt" rules the BFL rewriters depend on.
+    public init(
+        variant: Variant = .e2b6bit,
+        modelPath: URL? = nil,
+        hfToken: String? = nil,
+        progress: (@Sendable (String) -> Void)? = nil
+    ) {
+        self.model = variant.model
+        self.modelPath = modelPath
+        self.hfToken = hfToken
+        self.progress = progress
+    }
+
+    /// Escape hatch for a non-E2B family (E4B, 31B, 26B-A4B). Vision-capable
+    /// families only — a text-only model cannot serve the image paths.
+    public init(
+        model: Gemma4Pipeline.Model,
+        modelPath: URL? = nil,
+        hfToken: String? = nil,
+        progress: (@Sendable (String) -> Void)? = nil
+    ) {
+        self.model = model
+        self.modelPath = modelPath
+        self.hfToken = hfToken
+        self.progress = progress
+    }
+
+    // MARK: - FluxVLMProvider
+
+    public var displayName: String { model.displayName }
+
+    public var isLoaded: Bool {
+        lock.withLock { pipeline != nil }
+    }
+
+    public func ensureLoaded() async throws {
+        guard !isLoaded else { return }
+
+        let created = await Gemma4Pipeline()
+        if let modelPath {
+            progress?("Loading \(model.displayName) from \(modelPath.path)…")
+            // `resolvingSymlinksInPath` matters for HuggingFace snapshot
+            // layouts, whose files are symlinks into `blobs/`.
+            try await created.load(from: modelPath.resolvingSymlinksInPath(), multimodal: true)
+        } else {
+            progress?("Loading \(model.displayName) (downloading if needed, ~\(String(format: "%.1f", model.estimatedSizeGB)) GB)…")
+            let sink = progress
+            try await created.load(
+                model,
+                multimodal: true,
+                downloadIfNeeded: true,
+                hfToken: hfToken,
+                progress: { p in
+                    guard !p.currentFile.isEmpty else { return }
+                    sink?("  \(p.currentFile)")
+                }
+            )
+        }
+
+        lock.withLock { pipeline = created }
+        progress?("\(model.displayName) ready")
+    }
+
+    public func unload() async {
+        let taken = lock.withLock { () -> Gemma4Pipeline? in
+            let current = pipeline
+            pipeline = nil
+            return current
+        }
+        guard let taken else { return }
+        await taken.unload()
+        Memory.clearCache()
+    }
+
+    public func generateText(
+        images: [CGImage],
+        prompt: String,
+        systemPrompt: String?,
+        enableThinking: Bool,
+        maxTokens: Int,
+        temperature: Float
+    ) async throws -> String {
+        guard let current = lock.withLock({ pipeline }) else {
+            throw Gemma4VLMProviderError.notLoaded
+        }
+
+        // Thinking is off unless asked: the enrichment paths parse the answer
+        // (a one-line prompt, a JSON object), and a reasoning channel both
+        // eats the token budget and has to be stripped back out.
+        let templateVariables: [String: any Sendable]? =
+            enableThinking ? ["enable_thinking": true] : nil
+
+        let stream: AsyncThrowingStream<String, Error>
+        if images.isEmpty {
+            // A nil system prompt would make ChatSession fall back to its own
+            // French default instructions; keep the framework's paths English.
+            stream = try await current.chatStream(
+                prompt: prompt,
+                systemPrompt: systemPrompt ?? Self.defaultSystemPrompt,
+                temperature: temperature,
+                maxTokens: maxTokens,
+                templateVariables: templateVariables
+            )
+        } else {
+            nonisolated(unsafe) let pixels = try Self.batchedPixelValues(images)
+            // `Gemma4Processor.multimodalChatIds` prepends exactly one
+            // `<|image|>` marker to the user turn; images 2..N need their own,
+            // and the pipeline refuses a marker/batch mismatch rather than
+            // scattering random embeddings.
+            let extraMarkers = String(
+                repeating: Gemma4Processor.imageToken + "\n",
+                count: images.count - 1
+            )
+            stream = try await current.chatStreamMultimodal(
+                prompt: extraMarkers + prompt,
+                pixelValues: pixels,
+                systemPrompt: systemPrompt,
+                temperature: temperature,
+                maxTokens: maxTokens,
+                templateVariables: templateVariables
+            )
+        }
+
+        var text = ""
+        for try await chunk in stream { text += chunk }
+        return Self.cleanGeneratedText(text)
+    }
+
+    /// Neutral instructions for the text-only path when the caller gives none.
+    public static let defaultSystemPrompt = "You are a helpful assistant."
+
+    // MARK: - Image batching
+
+    /// Pack N images into one `[N, 3, H, W]` batch.
+    ///
+    /// `Gemma4ImageProcessor` sizes each image to its own aspect-ratio-preserving
+    /// box, so a comparison of a 1024×1024 reference against a 512×768 render
+    /// yields two differently shaped tensors. They are zero-padded to the batch
+    /// maximum, top-left aligned — the same thing `gemma4-cli describe` does for
+    /// its multi-image mode.
+    internal static func batchedPixelValues(_ images: [CGImage]) throws -> MLXArray {
+        precondition(!images.isEmpty, "batchedPixelValues requires at least one image")
+        let processed = try images.map { try Gemma4ImageProcessor.processImage($0) }
+        if processed.count == 1 { return processed[0] }
+
+        let maxH = processed.map { $0.dim(2) }.max()!
+        let maxW = processed.map { $0.dim(3) }.max()!
+        let padded = processed.map { pv -> MLXArray in
+            let h = pv.dim(2), w = pv.dim(3)
+            if h == maxH && w == maxW { return pv }
+            let canvas = MLXArray.zeros([1, 3, maxH, maxW], dtype: pv.dtype)
+            canvas[0..., 0..., 0 ..< h, 0 ..< w] = pv
+            return canvas
+        }
+        return concatenated(padded, axis: 0)
+    }
+
+    // MARK: - Output cleanup
+
+    /// Strip Gemma's reasoning channel and control tokens.
+    ///
+    /// With thinking on, the answer is preceded by
+    /// `<|channel>thought … <channel|>`; the stream forwards it verbatim and the
+    /// caller is expected to cut it. Keeping only what follows the LAST
+    /// `<channel|>` is what the ltx enhancer does, and it also degrades
+    /// correctly when thinking is off (no marker, nothing removed).
+    internal static func cleanGeneratedText(_ raw: String) -> String {
+        var text = raw
+        if let close = text.range(of: "<channel|>", options: .backwards) {
+            text = String(text[close.upperBound...])
+        }
+        for token in ["<|channel>thought", "<|think|>", "<end_of_turn>", "<start_of_turn>", "<eos>"] {
+            text = text.replacingOccurrences(of: token, with: "")
+        }
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+// MARK: - Errors
+
+public enum Gemma4VLMProviderError: LocalizedError {
+    case notLoaded
+
+    public var errorDescription: String? {
+        switch self {
+        case .notLoaded:
+            return "Gemma 4 VLM not loaded — call ensureLoaded() (or FluxGemma4VLM.activate) first."
+        }
+    }
+}

--- a/Sources/FluxTextEncoders/FluxTextEncoders.swift
+++ b/Sources/FluxTextEncoders/FluxTextEncoders.swift
@@ -484,6 +484,33 @@ public final class FluxTextEncoders: @unchecked Sendable {
         )
     }
 
+    /// Generate text with Qwen3.5 VLM from an arbitrary number of images.
+    ///
+    /// The N-image entry point the facade was missing: callers needing a
+    /// comparison used to reach for `qwen35VLMForEvaluation` and call
+    /// `generateMultiImage` on the model itself. `images: []` is the text-only
+    /// case, so ``Qwen35VLMProvider`` can serve every enrichment shape through
+    /// this one call.
+    public func generateWithQwen35(
+        images: [CGImage],
+        prompt: String,
+        systemPrompt: String? = nil,
+        enableThinking: Bool = true,
+        maxTokens: Int = 512,
+        temperature: Float = 0.7,
+        onToken: ((String) -> Bool)? = nil
+    ) throws -> GenerationResult {
+        guard let vlm = qwen35VLM else {
+            throw FluxEncoderError.invalidInput("Qwen3.5 VLM not loaded")
+        }
+        return try vlm.generateMultiImage(
+            images: images, prompt: prompt, systemPrompt: systemPrompt,
+            enableThinking: enableThinking,
+            maxTokens: maxTokens, temperature: temperature,
+            onToken: onToken
+        )
+    }
+
     // MARK: - FLUX.2 Image Description Service
 
     /// System prompt for describing images in FLUX.2-compatible style

--- a/Sources/FluxTextEncoders/VLM/FluxVLMProvider.swift
+++ b/Sources/FluxTextEncoders/VLM/FluxVLMProvider.swift
@@ -1,0 +1,186 @@
+// FluxVLMProvider.swift — Provider abstraction for the VLM enrichment services
+// Copyright 2025 Vincent Gourbin
+//
+// Why this exists:
+// Every image-aware convenience in this framework — the BFL prompt rewriter of
+// the inpainting/outpainting chains, `describeImageForFlux`, the 0-100
+// scene/style scoring used by the LoRA evaluator and by VLM-guided checkpoint
+// selection, the training captioner — used to call the bundled Qwen3.5 VLM
+// directly. That hardcoding meant a second VLM could not serve those functions
+// without duplicating each call site.
+//
+// `FluxVLMProvider` is the one primitive all of them actually need: N images
+// (0, 1 or 2) + a user prompt + a system prompt -> text. The system prompts and
+// the response parsing stay HERE, shared, so a provider only has to know how to
+// run a forward. `FluxVLM.active` selects which one runs; it defaults to the
+// bundled Qwen3.5, so nothing changes for callers that never register anything.
+//
+// Adding a provider therefore means implementing four members, not re-deriving
+// the prompt engineering. See `FluxGemma4VLM` (Gemma 4 E2B) for the second one.
+
+import Foundation
+import CoreGraphics
+
+/// A VLM able to serve the framework's enrichment functions (prompt rewriting,
+/// FLUX.2 image description, scene/style scoring, training captions).
+///
+/// Concurrency: implementations are shared, long-lived objects reached from any
+/// task, hence `Sendable`. `ensureLoaded()`/`unload()` must be serialised by the
+/// caller (the framework always does load → use → unload in sequence), exactly
+/// like `FluxTextEncoders` itself.
+public protocol FluxVLMProvider: AnyObject, Sendable {
+
+    /// Short identifier used in logs and CLI output (e.g. `"qwen3.5-4b-4bit"`).
+    var displayName: String { get }
+
+    /// Whether weights are currently resident.
+    var isLoaded: Bool { get }
+
+    /// Download (if needed) and load this provider's weights. A no-op when
+    /// `isLoaded` is already true. Callers that manage weights themselves
+    /// (sandboxed apps loading from an explicit path) can implement this as a
+    /// no-op and load ahead of time.
+    func ensureLoaded() async throws
+
+    /// Free the weights. Must be safe to call when nothing is loaded.
+    func unload() async
+
+    /// The single generation primitive.
+    ///
+    /// - Parameters:
+    ///   - images: 0 images = text-only, 1 = image analysis, 2+ = comparison.
+    ///     Providers must present them to the model in the given order.
+    ///   - prompt: The user turn.
+    ///   - systemPrompt: Instructions turn; `nil` uses the provider's default.
+    ///   - enableThinking: Ask for a reasoning pass before the answer. The
+    ///     framework's enrichment paths all pass `false` — they parse the
+    ///     output. Providers must strip any reasoning channel from the result
+    ///     either way, so the returned string is always the answer alone.
+    ///   - maxTokens: Generation budget.
+    ///   - temperature: `0` = greedy, which every framework path uses.
+    /// - Returns: The answer text, control tokens and reasoning channel removed.
+    func generateText(
+        images: [CGImage],
+        prompt: String,
+        systemPrompt: String?,
+        enableThinking: Bool,
+        maxTokens: Int,
+        temperature: Float
+    ) async throws -> String
+}
+
+// MARK: - Shared enrichment services
+
+extension FluxVLMProvider {
+
+    /// Describe an image so FLUX.2 can recreate it (scene + style), using the
+    /// shared system prompt in
+    /// ``FluxTextEncoders/fluxImageDescriptionSystemPrompt``.
+    public func describeImageForFlux(
+        image: CGImage,
+        context: String? = nil,
+        maxTokens: Int = 300
+    ) async throws -> String {
+        try await generateText(
+            images: [image],
+            prompt: context ?? "Describe this image.",
+            systemPrompt: FluxTextEncoders.fluxImageDescriptionSystemPrompt,
+            enableThinking: false,
+            maxTokens: maxTokens,
+            temperature: 0
+        )
+    }
+
+    /// Score a generated image against a reference on scene and style (0-100).
+    ///
+    /// - Parameter systemPrompt: Defaults to the framework's comparison rubric;
+    ///   callers with training context (LoRA name/goal) pass their own, which is
+    ///   why this is a parameter rather than a constant.
+    public func compareImagesForFlux(
+        reference: CGImage,
+        generated: CGImage,
+        systemPrompt: String? = nil,
+        prompt: String = "Compare these two images.",
+        maxTokens: Int = 300
+    ) async throws -> FluxTextEncoders.FluxImageComparison {
+        let text = try await generateText(
+            images: [reference, generated],
+            prompt: prompt,
+            systemPrompt: systemPrompt ?? FluxTextEncoders.fluxImageComparisonSystemPrompt,
+            enableThinking: false,
+            maxTokens: maxTokens,
+            temperature: 0
+        )
+        return FluxTextEncoders.shared.parseComparisonForEvaluation(text)
+    }
+
+    /// Free-form single-image analysis (the prompt rewriters use this).
+    public func analyzeImage(
+        image: CGImage,
+        prompt: String,
+        systemPrompt: String? = nil,
+        maxTokens: Int = 220
+    ) async throws -> String {
+        try await generateText(
+            images: [image],
+            prompt: prompt,
+            systemPrompt: systemPrompt,
+            enableThinking: false,
+            maxTokens: maxTokens,
+            temperature: 0
+        )
+    }
+
+    /// Text-only generation (LoRA context analysis uses this).
+    public func generate(
+        prompt: String,
+        systemPrompt: String? = nil,
+        maxTokens: Int = 256
+    ) async throws -> String {
+        try await generateText(
+            images: [],
+            prompt: prompt,
+            systemPrompt: systemPrompt,
+            enableThinking: false,
+            maxTokens: maxTokens,
+            temperature: 0
+        )
+    }
+}
+
+// MARK: - Registry
+
+/// Selects which ``FluxVLMProvider`` the framework's enrichment functions run
+/// on.
+///
+/// The default is the bundled Qwen3.5 (``Qwen35VLMProvider/shared``), so a
+/// process that registers nothing behaves exactly as before this abstraction
+/// existed. Register once at startup — the framework reads `active` on every
+/// enrichment call and never writes it.
+///
+/// ```swift
+/// import FluxGemma4VLM
+/// try await FluxGemma4VLM.activate(variant: .e2b6bit)   // registers + loads
+/// ```
+public enum FluxVLM {
+
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var registered: (any FluxVLMProvider)?
+
+    /// The provider serving enrichment calls: whatever was registered, else the
+    /// bundled Qwen3.5.
+    public static var active: any FluxVLMProvider {
+        lock.withLock { registered ?? Qwen35VLMProvider.shared }
+    }
+
+    /// Whether a provider other than the bundled Qwen3.5 is in charge.
+    public static var hasCustomProvider: Bool {
+        lock.withLock { registered != nil }
+    }
+
+    /// Install `provider` as the active one. Pass `nil` to fall back to the
+    /// bundled Qwen3.5. Does not load or unload anything.
+    public static func register(_ provider: (any FluxVLMProvider)?) {
+        lock.withLock { registered = provider }
+    }
+}

--- a/Sources/FluxTextEncoders/VLM/Qwen35VLMProvider.swift
+++ b/Sources/FluxTextEncoders/VLM/Qwen35VLMProvider.swift
@@ -1,0 +1,77 @@
+// Qwen35VLMProvider.swift — The bundled Qwen3.5 VLM as a FluxVLMProvider
+// Copyright 2025 Vincent Gourbin
+//
+// This is the default provider, and it changes nothing about how Qwen3.5 runs:
+// it forwards to the same `FluxTextEncoders.shared` entry points the enrichment
+// functions called directly before the abstraction existed (same weights, same
+// download path, same `Qwen35VLM.generateMultiImage` forward). Its only job is
+// to present them behind `FluxVLMProvider` so a second VLM can take the same
+// seat.
+
+import Foundation
+import CoreGraphics
+import MLX
+
+/// The bundled Qwen3.5 4B VLM, exposed as a provider.
+///
+/// `ensureLoaded()` downloads the configured variant through
+/// `TextEncoderModelDownloader` and loads it into `FluxTextEncoders.shared`,
+/// which is exactly what the training/evaluation paths did inline.
+public final class Qwen35VLMProvider: FluxVLMProvider {
+
+    /// Process-wide default instance (4-bit, matching what training and the
+    /// chains have always downloaded).
+    public static let shared = Qwen35VLMProvider()
+
+    /// Variant `ensureLoaded()` fetches. Register a custom instance to change
+    /// it: `FluxVLM.register(Qwen35VLMProvider(variant: .qwen35_4B_8bit))`.
+    public let variant: Qwen35Variant
+
+    private let hfToken: String?
+
+    public init(variant: Qwen35Variant = .qwen35_4B_4bit, hfToken: String? = nil) {
+        self.variant = variant
+        self.hfToken = hfToken
+    }
+
+    public var displayName: String { "Qwen3.5 4B (\(variant.shortName))" }
+
+    public var isLoaded: Bool { FluxTextEncoders.shared.isQwen35VLMLoaded }
+
+    public func ensureLoaded() async throws {
+        guard !isLoaded else { return }
+        let downloader = TextEncoderModelDownloader(hfToken: hfToken)
+        let path = try await downloader.downloadQwen35(variant: variant)
+        try await FluxTextEncoders.shared.loadQwen35VLM(from: path.path)
+    }
+
+    public func unload() async {
+        FluxTextEncoders.shared.unloadQwen35VLM()
+    }
+
+    public func generateText(
+        images: [CGImage],
+        prompt: String,
+        systemPrompt: String?,
+        enableThinking: Bool,
+        maxTokens: Int,
+        temperature: Float
+    ) async throws -> String {
+        guard isLoaded else {
+            throw FluxEncoderError.invalidInput("Qwen3.5 VLM not loaded")
+        }
+        // The forward is synchronous and takes seconds on M-series. Run it off
+        // the cooperative pool so UI updates and concurrent chains aren't
+        // starved while we wait (same reasoning as Flux2VLMPromptBuilder).
+        return try await Task.detached(priority: .userInitiated) {
+            try FluxTextEncoders.shared.generateWithQwen35(
+                images: images,
+                prompt: prompt,
+                systemPrompt: systemPrompt,
+                enableThinking: enableThinking,
+                maxTokens: maxTokens,
+                temperature: temperature
+            ).text
+        }.value
+    }
+}

--- a/Tests/FluxGemma4VLMTests/Gemma4VLMProviderTests.swift
+++ b/Tests/FluxGemma4VLMTests/Gemma4VLMProviderTests.swift
@@ -1,0 +1,178 @@
+// Gemma4VLMProviderTests.swift — Gemma 4 provider: pure-Swift surface + gated load
+// Copyright 2025 Vincent Gourbin
+//
+// Everything here except the last suite runs without weights:
+// - variant ↔ CLI spelling ↔ Gemma4Swift model mapping (what --gemma4-variant
+//   resolves to, and the 6-bit default);
+// - the multi-image batching, which is the one piece of real logic this target
+//   adds: two differently-sized images must come out as one [2, 3, H, W] batch,
+//   zero-padded top-left, or `chatStreamMultimodal` would reject the
+//   marker/batch mismatch (or worse, scatter the wrong embeddings);
+// - the reasoning-channel stripping.
+//
+// The load test is gated on FLUX2_GEMMA4_DIR (a local Gemma 4 weights
+// directory), like ltx's Gemma4EnhancerProbeTests: loading is the whole test.
+
+import XCTest
+import CoreGraphics
+import MLX
+import FluxTextEncoders
+@testable import FluxGemma4VLM
+
+final class Gemma4VariantTests: XCTestCase {
+
+    func testDefaultVariantIsSixBitE2B() {
+        let provider = Gemma4VLMProvider()
+        XCTAssertEqual(provider.model, .e2b6bit)
+        XCTAssertTrue(provider.displayName.contains("E2B"))
+        XCTAssertNil(provider.modelPath)
+    }
+
+    func testCLINamesRoundTrip() {
+        for variant in Gemma4VLMProvider.Variant.allCases {
+            XCTAssertEqual(Gemma4VLMProvider.Variant.fromCLIName(variant.cliName), variant)
+        }
+        XCTAssertEqual(Gemma4VLMProvider.Variant.fromCLIName("6bit"), .e2b6bit)
+        XCTAssertEqual(Gemma4VLMProvider.Variant.fromCLIName("BF16"), .e2bBf16, "Parsing must be case-insensitive.")
+        XCTAssertNil(Gemma4VLMProvider.Variant.fromCLIName("3bit"))
+    }
+
+    func testVariantsMapToE2BRepos() {
+        XCTAssertEqual(Gemma4VLMProvider.Variant.e2b4bit.model.rawValue, "mlx-community/gemma-4-e2b-it-4bit")
+        XCTAssertEqual(Gemma4VLMProvider.Variant.e2b6bit.model.rawValue, "mlx-community/gemma-4-e2b-it-6bit")
+        XCTAssertEqual(Gemma4VLMProvider.Variant.e2b8bit.model.rawValue, "mlx-community/gemma-4-e2b-it-8bit")
+        XCTAssertEqual(Gemma4VLMProvider.Variant.e2bBf16.model.rawValue, "mlx-community/gemma-4-e2b-it-bf16")
+    }
+
+    func testProviderIsUnloadedBeforeEnsureLoaded() {
+        XCTAssertFalse(Gemma4VLMProvider().isLoaded)
+    }
+
+    func testRegisterDoesNotLoad() {
+        let provider = FluxGemma4VLM.register(variant: .e2b4bit)
+        XCTAssertTrue(FluxVLM.active === provider, "register() must take the seat immediately…")
+        XCTAssertFalse(provider.isLoaded, "…but must not touch the weights: training loads/unloads around each phase.")
+        FluxVLM.register(nil)
+        XCTAssertTrue(FluxVLM.active === Qwen35VLMProvider.shared)
+    }
+}
+
+final class Gemma4ImageBatchingTests: XCTestCase {
+
+    func testSingleImagePassesThroughUnbatched() throws {
+        let batch = try Gemma4VLMProvider.batchedPixelValues([Self.image(width: 96, height: 96)])
+        XCTAssertEqual(batch.dim(0), 1)
+        XCTAssertEqual(batch.dim(1), 3, "Channel-first [N, 3, H, W] is what the vision tower expects.")
+    }
+
+    func testTwoDifferentlySizedImagesArePaddedIntoOneBatch() throws {
+        // A 1024² reference scored against a 512×768 render is the real case:
+        // the processor sizes each to its own aspect-ratio box, so the shapes
+        // differ before batching.
+        let batch = try Gemma4VLMProvider.batchedPixelValues([
+            Self.image(width: 480, height: 480),
+            Self.image(width: 240, height: 480),
+        ])
+        XCTAssertEqual(batch.dim(0), 2, "Both images must land on the batch axis — one marker each.")
+        XCTAssertEqual(batch.dim(1), 3)
+        XCTAssertGreaterThan(batch.dim(2), 0)
+        XCTAssertGreaterThan(batch.dim(3), 0)
+    }
+
+    func testPaddingIsZeroAndTopLeftAligned() throws {
+        let wide = Self.image(width: 480, height: 240)
+        let tall = Self.image(width: 240, height: 480)
+        let batch = try Gemma4VLMProvider.batchedPixelValues([wide, tall])
+        let h = batch.dim(2), w = batch.dim(3)
+
+        // Each source is smaller than the union box in exactly one axis, so the
+        // far corner of at least one slot must be padding.
+        let cornerA = batch[0, 0, h - 1, w - 1].item(Float.self)
+        let cornerB = batch[1, 0, h - 1, w - 1].item(Float.self)
+        XCTAssertTrue(cornerA == 0 || cornerB == 0, "Padding must be zeros, not garbage.")
+
+        // Top-left is real image content — a solid mid-blue fill, so non-zero.
+        XCTAssertGreaterThan(batch[0, 2, 0, 0].item(Float.self), 0,
+                             "Images must be top-left aligned inside the padded canvas.")
+    }
+
+    private static func image(width: Int, height: Int) -> CGImage {
+        let ctx = CGContext(
+            data: nil, width: width, height: height,
+            bitsPerComponent: 8, bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        ctx.setFillColor(CGColor(red: 0.25, green: 0.5, blue: 0.75, alpha: 1))
+        ctx.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        return ctx.makeImage()!
+    }
+}
+
+final class Gemma4OutputCleanupTests: XCTestCase {
+
+    func testKeepsOnlyTheAnswerAfterTheThoughtChannel() {
+        let raw = "<|channel>thought The user wants a duck. Asphalt is grey.<channel|>A mallard duck stands on weathered grey asphalt."
+        XCTAssertEqual(
+            Gemma4VLMProvider.cleanGeneratedText(raw),
+            "A mallard duck stands on weathered grey asphalt."
+        )
+    }
+
+    func testStripsControlTokensAndTrims() {
+        let raw = "  A mallard duck on asphalt.<end_of_turn>\n<eos>  "
+        XCTAssertEqual(Gemma4VLMProvider.cleanGeneratedText(raw), "A mallard duck on asphalt.")
+    }
+
+    func testLeavesPlainAnswersUntouched() {
+        let raw = "A mallard duck stands on weathered grey asphalt, 50mm, soft side light."
+        XCTAssertEqual(Gemma4VLMProvider.cleanGeneratedText(raw), raw)
+    }
+
+    func testKeepsTextAfterTheLastChannelMarker() {
+        // Two reasoning segments: only what follows the final close marker is the answer.
+        let raw = "<|channel>thought a<channel|>draft<|channel>thought b<channel|>final answer"
+        XCTAssertEqual(Gemma4VLMProvider.cleanGeneratedText(raw), "final answer")
+    }
+}
+
+/// Loading is the whole test — same shape as ltx's enhancer probe.
+///
+/// ```
+/// FLUX2_GEMMA4_DIR=~/Pictures/FluxforgeStudio/Models/mlx-community/gemma-4-e2b-it-6bit \
+///   xcodebuild test -scheme Flux2Swift-Package -destination 'platform=macOS' \
+///     -skipPackagePluginValidation -only-testing:FluxGemma4VLMTests
+/// ```
+final class Gemma4LoadProbeTests: XCTestCase {
+
+    func testLoadDescribeUnload() async throws {
+        guard let dir = ProcessInfo.processInfo.environment["FLUX2_GEMMA4_DIR"] else {
+            throw XCTSkip("Set FLUX2_GEMMA4_DIR to a local Gemma 4 weights directory to run this.")
+        }
+        let provider = Gemma4VLMProvider(modelPath: URL(fileURLWithPath: dir))
+        try await provider.ensureLoaded()
+        XCTAssertTrue(provider.isLoaded)
+
+        let text = try await provider.analyzeImage(
+            image: Self.image(),
+            prompt: "What colour dominates this image? Answer in one word.",
+            maxTokens: 16
+        )
+        XCTAssertFalse(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+        await provider.unload()
+        XCTAssertFalse(provider.isLoaded)
+    }
+
+    private static func image() -> CGImage {
+        let ctx = CGContext(
+            data: nil, width: 224, height: 224,
+            bitsPerComponent: 8, bytesPerRow: 224 * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        ctx.setFillColor(CGColor(red: 0.1, green: 0.2, blue: 0.9, alpha: 1))
+        ctx.fill(CGRect(x: 0, y: 0, width: 224, height: 224))
+        return ctx.makeImage()!
+    }
+}

--- a/Tests/FluxTextEncodersTests/FluxVLMProviderTests.swift
+++ b/Tests/FluxTextEncodersTests/FluxVLMProviderTests.swift
@@ -1,0 +1,146 @@
+// FluxVLMProviderTests.swift — Provider registry contract
+// Copyright 2025 Vincent Gourbin
+//
+// No weights are involved: what matters here is the contract every enrichment
+// call site depends on — `FluxVLM.active` is the bundled Qwen3.5 unless someone
+// registered something else, and registering never loads or unloads anything.
+
+import XCTest
+import CoreGraphics
+@testable import FluxTextEncoders
+
+/// Records what it was asked, answers a canned string. Stands in for a real
+/// provider so the registry and the shared helpers can be tested without a VLM.
+private final class StubVLMProvider: FluxVLMProvider, @unchecked Sendable {
+    let displayName = "stub-vlm"
+    var isLoaded: Bool = true
+    var ensureLoadedCalls = 0
+    var unloadCalls = 0
+    var lastImageCount: Int?
+    var lastSystemPrompt: String?
+    var lastMaxTokens: Int?
+    var lastTemperature: Float?
+    var answer: String
+
+    init(answer: String = "stub answer") { self.answer = answer }
+
+    func ensureLoaded() async throws { ensureLoadedCalls += 1 }
+    func unload() async { unloadCalls += 1 }
+
+    func generateText(
+        images: [CGImage],
+        prompt: String,
+        systemPrompt: String?,
+        enableThinking: Bool,
+        maxTokens: Int,
+        temperature: Float
+    ) async throws -> String {
+        lastImageCount = images.count
+        lastSystemPrompt = systemPrompt
+        lastMaxTokens = maxTokens
+        lastTemperature = temperature
+        return answer
+    }
+}
+
+final class FluxVLMProviderTests: XCTestCase {
+
+    override func tearDown() {
+        // Global state: never leak a stub into another test.
+        FluxVLM.register(nil)
+        super.tearDown()
+    }
+
+    // MARK: - Registry
+
+    func testDefaultProviderIsBundledQwen35() {
+        XCTAssertFalse(FluxVLM.hasCustomProvider)
+        XCTAssertTrue(FluxVLM.active === Qwen35VLMProvider.shared,
+                      "With nothing registered, enrichment must keep running on the bundled Qwen3.5.")
+        XCTAssertTrue(FluxVLM.active.displayName.contains("Qwen3.5"))
+    }
+
+    func testRegisteredProviderTakesOver() {
+        let stub = StubVLMProvider()
+        FluxVLM.register(stub)
+        XCTAssertTrue(FluxVLM.hasCustomProvider)
+        XCTAssertTrue(FluxVLM.active === stub)
+    }
+
+    func testRegisteringNilRestoresQwen35() {
+        FluxVLM.register(StubVLMProvider())
+        FluxVLM.register(nil)
+        XCTAssertFalse(FluxVLM.hasCustomProvider)
+        XCTAssertTrue(FluxVLM.active === Qwen35VLMProvider.shared)
+    }
+
+    func testQwen35ProviderReportsUnloadedInTestEnvironment() {
+        // The singleton is never loaded in tests; the enrichment paths rely on
+        // this being observable rather than throwing.
+        XCTAssertFalse(Qwen35VLMProvider.shared.isLoaded)
+    }
+
+    func testQwen35ProviderVariantIsFourBitByDefault() {
+        XCTAssertEqual(Qwen35VLMProvider.shared.variant, .qwen35_4B_4bit,
+                       "Training and the chains have always downloaded the 4-bit variant.")
+        XCTAssertEqual(Qwen35VLMProvider(variant: .qwen35_4B_8bit).variant, .qwen35_4B_8bit)
+    }
+
+    // MARK: - Shared helpers route through the active provider
+
+    func testDescribeImageForFluxUsesSharedSystemPrompt() async throws {
+        let stub = StubVLMProvider(answer: "a duck on asphalt, soft side light")
+        let text = try await stub.describeImageForFlux(image: Self.solidImage(), context: "focus on the face")
+        XCTAssertEqual(text, "a duck on asphalt, soft side light")
+        XCTAssertEqual(stub.lastImageCount, 1)
+        XCTAssertEqual(stub.lastSystemPrompt, FluxTextEncoders.fluxImageDescriptionSystemPrompt)
+        XCTAssertEqual(stub.lastTemperature, 0, "Enrichment must stay greedy/deterministic.")
+    }
+
+    func testCompareImagesForFluxSendsTwoImagesAndParsesScores() async throws {
+        let stub = StubVLMProvider(answer: """
+        {"scene_score": 72, "scene_reason": "same subject, different pose", "style_score": 41, "style_reason": "flat vector vs 3D"}
+        """)
+        let comparison = try await stub.compareImagesForFlux(
+            reference: Self.solidImage(), generated: Self.solidImage()
+        )
+        XCTAssertEqual(stub.lastImageCount, 2)
+        XCTAssertEqual(stub.lastSystemPrompt, FluxTextEncoders.fluxImageComparisonSystemPrompt)
+        XCTAssertEqual(comparison.sceneScore, 72)
+        XCTAssertEqual(comparison.styleScore, 41)
+        XCTAssertEqual(comparison.sceneReason, "same subject, different pose")
+    }
+
+    func testCompareImagesForFluxHonoursCustomSystemPrompt() async throws {
+        // The LoRA evaluator passes a training-context rubric; it must not be
+        // silently replaced by the generic one.
+        let stub = StubVLMProvider(answer: "{\"scene_score\": 5, \"style_score\": 5}")
+        _ = try await stub.compareImagesForFlux(
+            reference: Self.solidImage(), generated: Self.solidImage(),
+            systemPrompt: "CUSTOM RUBRIC"
+        )
+        XCTAssertEqual(stub.lastSystemPrompt, "CUSTOM RUBRIC")
+    }
+
+    func testTextOnlyHelperSendsNoImages() async throws {
+        let stub = StubVLMProvider(answer: "{\"trigger_word\": \"sks\"}")
+        let out = try await stub.generate(prompt: "analyse", systemPrompt: "JSON only", maxTokens: 100)
+        XCTAssertEqual(out, "{\"trigger_word\": \"sks\"}")
+        XCTAssertEqual(stub.lastImageCount, 0)
+        XCTAssertEqual(stub.lastMaxTokens, 100)
+    }
+
+    // MARK: - Helpers
+
+    private static func solidImage(width: Int = 16, height: Int = 16) -> CGImage {
+        let ctx = CGContext(
+            data: nil, width: width, height: height,
+            bitsPerComponent: 8, bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        ctx.setFillColor(CGColor(red: 0.2, green: 0.4, blue: 0.8, alpha: 1))
+        ctx.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        return ctx.makeImage()!
+    }
+}

--- a/docs/INPAINTING_GUIDE.md
+++ b/docs/INPAINTING_GUIDE.md
@@ -20,8 +20,8 @@ of impact:
 1. **Prompt describes the WHOLE scene, not the edit.** 30–80 words, BFL
    structure (Subject + Action + Style + Context). `"a duck"` gives a floating,
    unshaded duck; a full scene description gives correct scale + cast shadow.
-   Best: load the Qwen3.5 VLM and set `enrichPromptWithVLM: true` + the right
-   `intent`.
+   Best: load a VLM (bundled Qwen3.5, or Gemma 4 E2B via `FluxGemma4VLM`) and
+   set `enrichPromptWithVLM: true` + the right `intent`.
 2. **Soft mask edges.** Gaussian-blur the mask edge ≈ `image_width / 30`
    (the diffusers example uses `blur_factor=12` at 1024 px — same ballpark).
    Hard masks produce visible seams.
@@ -45,8 +45,8 @@ of impact:
    pixels come straight from the user's original.
 6. **If you use `enrichPromptWithVLM`, actually load the VLM.** The chain
    *silently falls back* to the verbatim prompt when
-   `FluxTextEncoders.shared.isQwen35VLMLoaded == false` (a `FluxDebug` warning
-   is logged, nothing throws). Easy to miss in an app.
+   `FluxVLM.active.isLoaded == false` (a `FluxDebug` warning is logged, nothing
+   throws). Easy to miss in an app.
 7. **Seed everything** while iterating, so you can attribute changes to your
    changes.
 
@@ -152,7 +152,9 @@ Hand-writing a 50-word scene-aware prompt for every user edit is unrealistic.
 The framework bundles an image-aware prompt builder:
 
 ```swift
-try await FluxTextEncoders.shared.loadQwen35VLM(from: vlmPath)  // caller owns lifecycle
+// Caller owns the VLM lifecycle. Either provider serves the rewriter:
+try await FluxTextEncoders.shared.loadQwen35VLM(from: vlmPath)  // bundled Qwen3.5
+// or: try await FluxGemma4VLM.activate(variant: .e2b6bit)      // Gemma 4 E2B
 
 let chain = Flux2MaskedInpaintingChain(
     pipeline: pipeline,

--- a/docs/VLM-API.md
+++ b/docs/VLM-API.md
@@ -1,4 +1,17 @@
-# Qwen3.5 VLM API Reference
+# VLM API Reference
+
+The framework's image-aware services — FLUX.2 image description, 0-100
+scene/style scoring, BFL prompt rewriting for the inpainting/outpainting
+chains, training captions — run on a **VLM provider**. Two are available:
+
+| Provider | Weights | Target to link | Notes |
+|---|---|---|---|
+| **Qwen3.5 4B** (default) | ~3 GB 4-bit / ~5 GB 8-bit | `FluxTextEncoders` (bundled) | Historical default; nothing to opt into |
+| **Gemma 4 E2B-it** | ~3.6 GB 4-bit / **~4.2 GB 6-bit** / ~5.2 GB 8-bit / ~10 GB bf16 | `FluxGemma4VLM` (opt-in) | Runs on [gemma-4-swift-mlx](https://github.com/VincentGourbin/gemma-4-swift-mlx); brings `mlx-swift-lm` into the graph, hence the separate target |
+
+Both answer the *same* system prompts and are parsed by the same code — see
+[Providers](#providers). The sections below document the Qwen3.5-specific
+entry points, which remain unchanged.
 
 Native Qwen3.5-4B Vision-Language Model running locally on Apple Silicon. Auto-downloaded (~3GB 4-bit, ~5GB 8-bit) on first use.
 
@@ -219,10 +232,10 @@ Generate a validation prompt from a reference photo. Useful when setting up trai
 ```swift
 let setupAPI = LoRATrainingSetup_API()
 
-// Load VLM first
-try await FluxTextEncoders.shared.loadQwen35VLM(from: vlmPath)
+// Load whichever provider is active first
+try await FluxVLM.active.ensureLoaded()
 
-let prompt = try setupAPI.describeReferenceForValidation(
+let prompt = try await setupAPI.describeReferenceForValidation(
     image: refImage,
     triggerWord: "VinZ"
 )
@@ -246,6 +259,86 @@ Step  50: 72/100 (scene: 70, style: 74)  ← improving
 Step  75: 71/100 (scene: 68, style: 73)  ← plateau
 Step 100: 73/100 (scene: 72, style: 74)  ← best checkpoint saved
 ```
+
+## Providers
+
+### Choosing one
+
+`FluxVLM.active` is what every enrichment call uses. With nothing registered it
+is the bundled Qwen3.5, so an app that never touches this API keeps its previous
+behaviour exactly.
+
+```swift
+import FluxTextEncoders
+import FluxGemma4VLM   // opt-in target
+
+// Load Gemma 4 E2B-it 6-bit (downloads on first use) and take over from Qwen3.5
+try await FluxGemma4VLM.activate(variant: .e2b6bit)
+
+// …every enrichment call now runs on Gemma:
+let text = try await FluxVLM.active.describeImageForFlux(image: photo)
+let scores = try await FluxVLM.active.compareImagesForFlux(reference: ref, generated: gen)
+
+// Hand the seat back (and free the weights)
+await FluxGemma4VLM.deactivate()
+```
+
+Sandboxed apps that manage their own weights directory pass a path instead of a
+variant, and can point the Gemma cache at their shared models folder (the layout
+inside is `{org}/{model}`, the same HuggingFace owner namespace the FLUX
+checkpoints use):
+
+```swift
+FluxGemma4VLM.setModelsDirectory(URL(fileURLWithPath: "…/FluxforgeStudio/Models"))
+try await FluxGemma4VLM.activate(
+    modelPath: URL(fileURLWithPath: "…/Models/mlx-community/gemma-4-e2b-it-6bit")
+)
+```
+
+For the training paths (LoRA evaluation, VLM-guided checkpoint selection), which
+load and unload the VLM around each generation phase, register without loading:
+
+```swift
+FluxGemma4VLM.register(variant: .e2b6bit)   // loaded on first use via ensureLoaded()
+```
+
+### The provider protocol
+
+```swift
+public protocol FluxVLMProvider: AnyObject, Sendable {
+    var displayName: String { get }
+    var isLoaded: Bool { get }
+    func ensureLoaded() async throws
+    func unload() async
+    func generateText(
+        images: [CGImage],          // 0 = text-only, 1 = analysis, 2 = comparison
+        prompt: String,
+        systemPrompt: String?,
+        enableThinking: Bool,
+        maxTokens: Int,
+        temperature: Float
+    ) async throws -> String
+}
+```
+
+That is the whole contract. The system prompts, the JSON score parsing, the
+FLUX.2 description rubric and the BFL rewriting rules live in
+`FluxTextEncoders` as protocol extensions (`describeImageForFlux`,
+`compareImagesForFlux`, `analyzeImage`, `generate`), so a new provider inherits
+all of them and only has to know how to run a forward.
+
+Registering a third VLM is therefore:
+
+```swift
+final class MyVLMProvider: FluxVLMProvider { /* four members */ }
+FluxVLM.register(MyVLMProvider())
+```
+
+### What the chains do when nothing is loaded
+
+Unchanged and load-bearing: `enrichPromptWithVLM: true` with no VLM resident
+logs a warning and falls back to the caller's verbatim prompt. The chains never
+auto-load a VLM, whichever provider is active.
 
 ## Thinking Mode
 
@@ -291,6 +384,26 @@ flux2 evaluate-lora --image ref.png \
 # Model variant selection
 flux2 test-qwen35 "Hello" --variant 8bit  # higher quality (5GB)
 flux2 test-qwen35 "Hello" --variant 4bit  # faster, less memory (3GB)
+```
+
+### Gemma 4 provider
+
+```bash
+# Same three modes as test-qwen35, on Gemma 4 E2B-it (6-bit by default)
+flux2 test-gemma4 "What do you see?" --image photo.png
+flux2 test-gemma4 "Describe" --image photo.png --flux-describe
+flux2 test-gemma4 "Compare" --image ref.png --image2 gen.png --compare
+
+# Variant / local weights / custom cache
+flux2 test-gemma4 "Hello" --variant 4bit
+flux2 test-gemma4 "Hello" --model-path ~/Models/mlx-community/gemma-4-e2b-it-6bit
+flux2 test-gemma4 "Hello" --models-dir ~/Pictures/FluxforgeStudio/Models
+
+# Image-aware prompt rewriting on either provider
+flux2 inpaint  -i in.jpg -m mask.png -p "replace the cat with a duck" -o out.png \
+  --enrich-prompt-with-vlm --vlm-provider gemma4 --gemma4-variant 6bit
+flux2 outpaint -i in.jpg --right 384 -p "…" -o out.png \
+  --enrich-prompt-with-vlm --vlm-provider qwen35 --qwen35-variant 8bit
 ```
 
 ## Performance

--- a/docs/knowledge/decisions/vlm-provider-abstraction.md
+++ b/docs/knowledge/decisions/vlm-provider-abstraction.md
@@ -1,0 +1,86 @@
+---
+type: Decision
+title: "VLM enrichment runs behind a provider protocol; Qwen3.5 stays the default"
+description: Why the image-aware services were abstracted behind FluxVLMProvider, why Gemma 4 lives in its own target, and the constraints each provider path must respect.
+tags: [vlm, qwen35, gemma4, architecture, prompt-enrichment]
+timestamp: 2026-08-24T00:00:00Z
+---
+
+Decision (2026-08-24, PR: `feature/gemma4-vlm-provider`): the framework's
+image-aware services — BFL prompt rewriting for the inpainting/outpainting
+chains, `describeImageForFlux`, the 0-100 scene/style scoring used by the LoRA
+evaluator and by VLM-guided checkpoint selection, the training captioner — run
+on **`FluxVLM.active`**, a `FluxVLMProvider`. Two providers ship: the bundled
+Qwen3.5 4B (**default, unchanged**) and Gemma 4 E2B-it (opt-in).
+
+# Why abstract at all
+
+Before this, every call site named Qwen3.5 directly. That was a real trap, not
+just duplication: Qwen3.5 was *also* the image-guided prompt rewriter of the
+inpainting/outpainting chains, so any migration that replaced the captioning
+loops with another VLM and dropped Qwen would have degraded prompt enrichment
+**silently** — the chains fall back to the verbatim prompt with only a
+`FluxDebug` warning. One seat, one protocol, and the fallback stays visible.
+
+# Shape of the abstraction
+
+One primitive: `generateText(images: [CGImage], prompt:, systemPrompt:,
+enableThinking:, maxTokens:, temperature:)`. `images` is `0` (text-only), `1`
+(analysis) or `2` (comparison) — those are the only shapes the framework uses.
+
+Everything else — the FLUX.2 description rubric, the comparison rubric, the JSON
+score parsing, the five intent-specific BFL system prompts — stays in
+`FluxTextEncoders` as protocol extensions. A provider knows how to run a
+forward; it never re-derives prompt engineering. Adding a third VLM is four
+members.
+
+# Why Gemma 4 lives in its own target (`FluxGemma4VLM`)
+
+`Gemma4Swift` depends on `mlx-swift-lm` (MLXLLM/MLXLMCommon). Putting it in
+`FluxTextEncoders` would have pushed that graph into `Flux2Core`,
+`Flux2Chains`, the CLI and the app — for a feature most processes never use.
+The provider protocol therefore lives in `FluxTextEncoders` (no new
+dependency); the Gemma implementation lives in an opt-in library target that
+consumers link deliberately. Version compatibility checked: gemma-4-swift-mlx
+1.5.0 accepts mlx-swift `0.31.4..<0.32`, so the framework's `exact: "0.31.6"`
+pin holds; resolution brings mlx-swift-lm 3.31.4.
+
+# Why E2B 6-bit is the Gemma default
+
+~4.2 GB, the same memory class as the 4-bit Qwen3.5 the enrichment paths have
+always downloaded, and E2B is the smallest Gemma 4 family carrying a vision
+tower. 4-bit (~3.6 GB) and 8-bit (~5.2 GB) and bf16 (~10 GB, what the ltx
+enhancer uses for parity with the reference service) are selectable.
+
+# Constraints the Gemma path must respect
+
+* **One `<|image|>` marker per image.** `Gemma4Processor.multimodalChatIds`
+  prepends exactly one marker; images 2..N need their own in the user prompt.
+  `chatStreamMultimodal` rejects a marker/batch mismatch — which is the good
+  outcome, because `maskedScatter` indexes its source modulo size and would
+  otherwise scatter unrelated embeddings with no error at all.
+* **Batch padding is required.** `Gemma4ImageProcessor` sizes each image to its
+  own aspect-ratio box, so a 1024² reference and a 512×768 render come out with
+  different shapes; they are zero-padded top-left to the batch maximum before
+  `concatenated(axis: 0)`.
+* **Thinking off, temperature 0.** The enrichment paths parse the answer (a
+  one-line prompt, a JSON object). Reasoning eats the token budget and then has
+  to be stripped; `cleanGeneratedText` keeps only what follows the last
+  `<channel|>` for the cases where it is deliberately enabled.
+* **A `nil` system prompt on the text-only path** would make Gemma's
+  `ChatSession` inject its own French default instructions — the provider
+  substitutes a neutral English one instead.
+* `Gemma4Pipeline` is `@MainActor`, unlike this framework's off-main loading
+  policy. The weight loading and the generation still run off the main actor
+  (nonisolated `loadModelContainer`, `ModelContainer` actor), but the pipeline
+  handle itself must be created and called with `await`.
+
+# What did not change
+
+* Default provider, default weights, and the byte-for-byte Qwen3.5 forward
+  (`generateMultiImage`).
+* The load-bearing contract that the chains **never auto-load** a VLM and fall
+  back to the caller's prompt when none is resident.
+* The existing Qwen-specific public API (`loadQwen35VLM`,
+  `analyzeImageWithQwen35`, `describeImageForFlux`, `compareImagesForFlux`, …),
+  so Fluxforge Studio keeps compiling untouched.

--- a/docs/knowledge/index.md
+++ b/docs/knowledge/index.md
@@ -21,6 +21,7 @@ record what was measured and decided so it is never re-derived or re-litigated.
 
 * [Quantization verdicts for inference](decisions/quantization-verdicts.md) - qint8/mxfp8/int4 speed and quality, measured; quantization buys memory, not step time
 * [MLX.compile on the denoising forward: neutral, kept opt-in](decisions/compile-step-neutral.md) - why compiling the step wins nothing here, and the traps if it is ever revisited
+* [VLM enrichment behind a provider protocol](decisions/vlm-provider-abstraction.md) - one seat for the image-aware services, Qwen3.5 still the default, Gemma 4 E2B opt-in in its own target, and the constraints of each path
 
 # Pitfalls
 

--- a/docs/knowledge/log.md
+++ b/docs/knowledge/log.md
@@ -1,5 +1,13 @@
 # Directory Update Log
 
+## 2026-08-24
+
+* **Added**: [VLM enrichment behind a provider protocol](/docs/knowledge/decisions/vlm-provider-abstraction.md)
+  — the image-aware services (prompt rewriting, FLUX.2 description, LoRA
+  scene/style scoring, training captions) now run on `FluxVLM.active`; Gemma 4
+  E2B joins the bundled Qwen3.5 as a selectable provider, with the
+  marker/batch/thinking constraints of the Gemma path recorded.
+
 ## 2026-07-15
 
 * **Creation**: Bootstrapped the knowledge bundle from the July 2026


### PR DESCRIPTION
## Pourquoi

Tous les services image-aware du framework nommaient **Qwen 3.5 en dur** :
réécriture de prompt BFL des chaînes inpaint/outpaint (`Flux2VLMPromptBuilder`),
`describeImageForFlux`, scoring scène/style 0-100 de `LoRAEvaluator` et de la
sélection de checkpoint (`SimpleLoRATrainer`), captioning de
`LoRATrainingSetup`.

C'était un garde-fou fragile : Qwen 3.5 étant *aussi* le réécrivain guidé par
l'image des chaînes, une migration partielle vers un autre VLM aurait dégradé
l'enrichissement **en silence** — les chaînes se replient sur le prompt verbatim
avec un simple warning `FluxDebug`.

## Ce que fait la PR

Un seul siège : **`FluxVLM.active`**, un `FluxVLMProvider`.

| | |
|---|---|
| `FluxVLMProvider` (dans `FluxTextEncoders`, **aucune dépendance nouvelle**) | Une primitive : `generateText(images:prompt:systemPrompt:enableThinking:maxTokens:temperature:)` — 0 image = texte, 1 = analyse, 2 = comparaison |
| `Qwen35VLMProvider` | **Provider par défaut**, forward inchangé (`generateMultiImage`), mêmes poids, même téléchargement |
| `FluxGemma4VLM` (nouvelle cible **opt-in**) | Gemma 4 E2B via [gemma-4-swift-mlx](https://github.com/VincentGourbin/gemma-4-swift-mlx) 1.5.0 |

Les system prompts, la rubrique FLUX.2, les cinq system prompts d'intention BFL
et le parsing JSON des scores restent **partagés**, en extensions de protocole :
un provider sait faire un forward, il ne re-dérive pas le prompt engineering.
Ajouter un troisième VLM = quatre membres.

```swift
import FluxGemma4VLM
try await FluxGemma4VLM.activate(variant: .e2b6bit)   // Gemma prend le siège
…
await FluxGemma4VLM.deactivate()                      // retour à Qwen 3.5
```

### Pourquoi une cible séparée

`Gemma4Swift` entraîne `mlx-swift-lm` (MLXLLM/MLXLMCommon). Le mettre dans
`FluxTextEncoders` l'aurait poussé dans `Flux2Core`, `Flux2Chains`, la CLI et
l'app — pour une fonction que la plupart des process n'utilisent pas. Le
protocole vit dans `FluxTextEncoders`, l'implémentation Gemma dans une cible que
le consommateur linke délibérément.

Compatibilité vérifiée : gemma-4-swift-mlx 1.5.0 accepte mlx-swift
`0.31.4..<0.32` → le pin `exact: "0.31.6"` tient ; la résolution ramène
mlx-swift-lm 3.31.4.

### Variante par défaut : E2B-it 6-bit (~4,2 Go)

Même classe mémoire que le Qwen 3.5 4-bit que les chemins d'enrichissement
téléchargent depuis toujours, et E2B est la plus petite famille Gemma 4 portant
une tour vision. 4-bit / 8-bit / bf16 sélectionnables.

### CLI

```bash
flux2 test-gemma4 "Describe" --image photo.png --flux-describe
flux2 test-gemma4 "Compare" --image ref.png --image2 gen.png --compare

flux2 inpaint  … --enrich-prompt-with-vlm --vlm-provider gemma4 --gemma4-variant 6bit
flux2 outpaint … --enrich-prompt-with-vlm --vlm-provider qwen35 --qwen35-variant 8bit
```

Groupe d'options partagé (`--vlm-provider`, `--qwen35-variant|-path`,
`--gemma4-variant|-path`). **Effet de bord bienvenu** :
`outpaint --enrich-prompt-with-vlm` charge enfin un VLM in-process — le flag
était inerte à moins qu'un autre composant du process en ait déjà chargé un.

## Contraintes du chemin Gemma (vérifiées, documentées)

- **Un marqueur `<|image|>` par image.** `multimodalChatIds` n'en préfixe qu'un ;
  les images 2..N ont besoin du leur. `chatStreamMultimodal` refuse un
  désaccord marqueurs/batch — heureusement, car `maskedScatter` indexe sa source
  modulo sa taille et recopierait sinon des embeddings sans lever d'erreur.
- **Padding obligatoire** : chaque image est dimensionnée dans sa propre boîte
  aspect-ratio, donc une référence 1024² et un rendu 512×768 n'ont pas la même
  forme ; zéro-padding top-left avant `concatenated(axis: 0)`.
- **Thinking off, température 0** : les chemins d'enrichissement parsent la
  sortie. `cleanGeneratedText` ne garde que ce qui suit le dernier `<channel|>`.
- **System prompt neutre explicite** sur le chemin texte : `nil` ferait injecter
  à `ChatSession` ses instructions par défaut… en français.
- `Gemma4Pipeline` est `@MainActor` : le chargement des poids et la génération
  restent hors main actor (`loadModelContainer` nonisolated, `ModelContainer`
  acteur), mais le handle se crée et s'appelle avec `await`.

## Inchangé

- Provider par défaut, poids par défaut, forward Qwen 3.5 identique.
- Contrat porteur : les chaînes ne chargent **jamais** de VLM et se replient sur
  le prompt de l'appelant quand aucun n'est résident.
- Toute l'API publique Qwen 3.5 (`loadQwen35VLM`, `analyzeImageWithQwen35`,
  `describeImageForFlux`, `compareImagesForFlux`, …) — Fluxforge Studio compile
  tel quel.

## Note de comportement

`LoRAEvaluator.analyzeLoRAContext` passait implicitement `enableThinking: true`
avec 100 tokens de budget pour une sortie JSON : le raisonnement mangeait le
budget et le parse retombait sur les valeurs par défaut (`"sks"`, DOP off). Le
chemin provider force `enableThinking: false`, comme partout ailleurs.

## Tests

`xcodebuild test -scheme Flux2Swift-Package` → **619 tests, 0 échec**
(65 Chains + 387 Core + 154 TextEncoders + 13 Gemma4VLM dont 1 *skipped*, gated
sur `FLUX2_GEMMA4_DIR`).

Nouveaux : registre de providers et helpers partagés (via un stub, sans poids),
mapping des variantes ↔ repos HF, batching multi-image (shapes + padding zéro +
alignement top-left), nettoyage du canal de raisonnement, sonde de chargement
gated.

Non exécuté : run end-to-end avec de vrais poids Gemma (aucun checkpoint
Gemma 4 présent sur la machine — `flux2 test-gemma4` le téléchargera).

## Docs

- [`docs/VLM-API.md`](docs/VLM-API.md) : retitré, tableau des providers, section
  « Providers » (choix, protocole, app sandboxée, chemin training), CLI Gemma.
- [`docs/INPAINTING_GUIDE.md`](docs/INPAINTING_GUIDE.md), `README.md` : mentions
  agnostiques du provider.
- [`docs/knowledge/decisions/vlm-provider-abstraction.md`](docs/knowledge/decisions/vlm-provider-abstraction.md)
  : la décision, ses raisons et les pièges du chemin Gemma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
