### PR TITLE
feat(loading): per-component path overrides (ask #2)

### DIFF
--- a/Sources/Flux2App/Views/ContentView.swift
+++ b/Sources/Flux2App/Views/ContentView.swift
@@ -2333,12 +2333,13 @@ struct TransformerSection: View {
 
                     Spacer()
 
-                    if isDownloaded, ModelRegistry.pathOverride(for: .transformer(variant)) != nil {
-                        // An overridden location may be the only copy; the
-                        // framework refuses to delete it, so don't offer to.
+                    if isDownloaded, Flux2ModelDownloader.isRelocated(.transformer(variant)) {
+                        // A path override, or weights symlinked in place, may
+                        // be the only copy; the framework refuses to delete
+                        // either, so don't offer to.
                         Image(systemName: "externaldrive")
                             .foregroundStyle(.secondary)
-                            .help("Loaded from a custom location — manage it there")
+                            .help("Relocated to another disk — manage it there")
                     } else if isDownloaded {
                         Button(action: {
                             transformerToDelete = variant
@@ -2401,10 +2402,10 @@ struct VAESection: View {
 
                 Spacer()
 
-                if modelManager.isVAEDownloaded, ModelRegistry.pathOverride(for: .vae(.standard)) != nil {
+                if modelManager.isVAEDownloaded, Flux2ModelDownloader.isRelocated(.vae(.standard)) {
                     Image(systemName: "externaldrive")
                         .foregroundStyle(.secondary)
-                        .help("Loaded from a custom location — manage it there")
+                        .help("Relocated to another disk — manage it there")
                 } else if modelManager.isVAEDownloaded {
                     Button(action: { showDeleteAlert = true }) {
                         Image(systemName: "trash")

--- a/Sources/Flux2App/Views/ContentView.swift
+++ b/Sources/Flux2App/Views/ContentView.swift
@@ -2206,6 +2206,7 @@ struct DiffusionModelsSection: View {
     @EnvironmentObject var modelManager: ModelManager
     @State private var transformerToDelete: ModelRegistry.TransformerVariant?
     @State private var showDeleteAlert = false
+    @State private var deleteError: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -2268,7 +2269,7 @@ struct DiffusionModelsSection: View {
                 do {
                     try modelManager.deleteTransformer(variant)
                 } catch {
-                    modelManager.errorMessage = error.localizedDescription
+                    deleteError = error.localizedDescription
                 }
             }
         } message: { variant in
@@ -2276,15 +2277,12 @@ struct DiffusionModelsSection: View {
             Text("Are you sure you want to delete \(info.name)? This cannot be undone.")
         }
         .alert(
-            "Model Error",
-            isPresented: Binding(
-                get: { modelManager.errorMessage != nil },
-                set: { if !$0 { modelManager.errorMessage = nil } }
-            )
+            "Could Not Delete",
+            isPresented: Binding(get: { deleteError != nil }, set: { if !$0 { deleteError = nil } })
         ) {
             Button("OK", role: .cancel) { }
         } message: {
-            Text(modelManager.errorMessage ?? "")
+            Text(deleteError ?? "")
         }
     }
 }
@@ -2331,7 +2329,13 @@ struct TransformerSection: View {
 
                     Spacer()
 
-                    if isDownloaded {
+                    if isDownloaded, ModelRegistry.pathOverride(for: .transformer(variant)) != nil {
+                        // An overridden location may be the only copy; the
+                        // framework refuses to delete it, so don't offer to.
+                        Image(systemName: "externaldrive")
+                            .foregroundStyle(.secondary)
+                            .help("Loaded from a custom location — manage it there")
+                    } else if isDownloaded {
                         Button(action: {
                             transformerToDelete = variant
                             showDeleteAlert = true
@@ -2362,6 +2366,7 @@ struct TransformerSection: View {
 struct VAESection: View {
     @EnvironmentObject var modelManager: ModelManager
     @State private var showDeleteAlert = false
+    @State private var deleteError: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -2392,7 +2397,11 @@ struct VAESection: View {
 
                 Spacer()
 
-                if modelManager.isVAEDownloaded {
+                if modelManager.isVAEDownloaded, ModelRegistry.pathOverride(for: .vae(.standard)) != nil {
+                    Image(systemName: "externaldrive")
+                        .foregroundStyle(.secondary)
+                        .help("Loaded from a custom location — manage it there")
+                } else if modelManager.isVAEDownloaded {
                     Button(action: { showDeleteAlert = true }) {
                         Image(systemName: "trash")
                             .foregroundStyle(.red)
@@ -2419,11 +2428,19 @@ struct VAESection: View {
                 do {
                     try modelManager.deleteVAE()
                 } catch {
-                    modelManager.errorMessage = error.localizedDescription
+                    deleteError = error.localizedDescription
                 }
             }
         } message: {
             Text("Are you sure you want to delete the VAE? This cannot be undone.")
+        }
+        .alert(
+            "Could Not Delete",
+            isPresented: Binding(get: { deleteError != nil }, set: { if !$0 { deleteError = nil } })
+        ) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(deleteError ?? "")
         }
     }
 }

--- a/Sources/Flux2App/Views/ContentView.swift
+++ b/Sources/Flux2App/Views/ContentView.swift
@@ -2265,11 +2265,26 @@ struct DiffusionModelsSection: View {
         .alert("Delete Transformer", isPresented: $showDeleteAlert, presenting: transformerToDelete) { variant in
             Button("Cancel", role: .cancel) { }
             Button("Delete", role: .destructive) {
-                try? modelManager.deleteTransformer(variant)
+                do {
+                    try modelManager.deleteTransformer(variant)
+                } catch {
+                    modelManager.errorMessage = error.localizedDescription
+                }
             }
         } message: { variant in
             let info = modelManager.transformerDisplayInfo(variant)
             Text("Are you sure you want to delete \(info.name)? This cannot be undone.")
+        }
+        .alert(
+            "Model Error",
+            isPresented: Binding(
+                get: { modelManager.errorMessage != nil },
+                set: { if !$0 { modelManager.errorMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(modelManager.errorMessage ?? "")
         }
     }
 }
@@ -2401,7 +2416,11 @@ struct VAESection: View {
         .alert("Delete VAE", isPresented: $showDeleteAlert) {
             Button("Cancel", role: .cancel) { }
             Button("Delete", role: .destructive) {
-                try? modelManager.deleteVAE()
+                do {
+                    try modelManager.deleteVAE()
+                } catch {
+                    modelManager.errorMessage = error.localizedDescription
+                }
             }
         } message: {
             Text("Are you sure you want to delete the VAE? This cannot be undone.")

--- a/Sources/Flux2App/Views/ContentView.swift
+++ b/Sources/Flux2App/Views/ContentView.swift
@@ -2269,7 +2269,11 @@ struct DiffusionModelsSection: View {
                 do {
                     try modelManager.deleteTransformer(variant)
                 } catch {
-                    deleteError = error.localizedDescription
+                    // Presenting a second alert while the first is still
+                    // dismissing can be dropped by SwiftUI; hand it to the
+                    // next runloop so the message actually shows.
+                    let message = error.localizedDescription
+                    Task { @MainActor in deleteError = message }
                 }
             }
         } message: { variant in
@@ -2428,7 +2432,11 @@ struct VAESection: View {
                 do {
                     try modelManager.deleteVAE()
                 } catch {
-                    deleteError = error.localizedDescription
+                    // Presenting a second alert while the first is still
+                    // dismissing can be dropped by SwiftUI; hand it to the
+                    // next runloop so the message actually shows.
+                    let message = error.localizedDescription
+                    Task { @MainActor in deleteError = message }
                 }
             }
         } message: {

--- a/Sources/Flux2Core/Configuration/ModelRegistry.swift
+++ b/Sources/Flux2Core/Configuration/ModelRegistry.swift
@@ -447,8 +447,58 @@ public enum ModelRegistry {
         return cacheDir.appendingPathComponent("models", isDirectory: true)
     }
 
-    /// Get the local path for a model component
+    // MARK: Per-component path overrides
+
+    /// Set (or clear, with `nil`) an explicit location for a single component,
+    /// e.g. one relocated wholesale to an external disk while the rest of the
+    /// catalog stays under `customModelsDirectory`. An override is authoritative:
+    /// `localPath(for:)` returns it, and `Flux2ModelDownloader` checks only that
+    /// location — never the default cache-search tiers — for that component.
+    ///
+    /// Only `.transformer` and `.vae` are supported: `.textEncoder` loading goes
+    /// through `TextEncoderModelDownloader` (FluxTextEncoders), which does not
+    /// consult this registry, so accepting an override there would be silently
+    /// inert. It throws instead.
+    ///
+    /// Overrides are deliberately not exposed as a mutable dictionary: each call
+    /// is one atomic update under a lock, so concurrent writers to different
+    /// components can't lose each other's entries.
+    public static func setPathOverride(_ url: URL?, for component: ModelComponent) throws {
+        if case .textEncoder = component {
+            throw Flux2DownloadError.pathOverrideUnsupported(component.displayName)
+        }
+        pathOverridesLock.lock()
+        defer { pathOverridesLock.unlock() }
+        _pathOverrides[component] = url
+    }
+
+    /// The explicit location set via `setPathOverride(_:for:)`, if any.
+    public static func pathOverride(for component: ModelComponent) -> URL? {
+        pathOverridesLock.lock()
+        defer { pathOverridesLock.unlock() }
+        return _pathOverrides[component]
+    }
+
+    /// Remove every override (mainly for tests and app reset flows).
+    public static func clearPathOverrides() {
+        pathOverridesLock.lock()
+        defer { pathOverridesLock.unlock() }
+        _pathOverrides.removeAll()
+    }
+
+    private static let pathOverridesLock = NSLock()
+    nonisolated(unsafe) private static var _pathOverrides: [ModelComponent: URL] = [:]
+
+    /// Get the local path for a model component: its override if one is set,
+    /// otherwise the computed default under `modelsDirectory`.
     public static func localPath(for component: ModelComponent) -> URL {
+        pathOverride(for: component) ?? defaultLocalPath(for: component)
+    }
+
+    /// The computed default location under `modelsDirectory`, ignoring any
+    /// override. Pure: reads no override state, so a caller that has already
+    /// taken an override snapshot can use it without a second read.
+    public static func defaultLocalPath(for component: ModelComponent) -> URL {
         switch component {
         case .transformer(let variant):
             let modelName: String
@@ -489,17 +539,14 @@ public enum ModelRegistry {
         }
     }
 
-    /// Check if a model component is downloaded
-    /// Note: This delegates to Flux2ModelDownloader which checks multiple cache locations
+    /// Check if a model component is downloaded *and complete*.
+    ///
+    /// Delegates entirely to `Flux2ModelDownloader` so this and
+    /// `Flux2ModelDownloader.isDownloaded` can never disagree: an existing but
+    /// empty/partial directory (or one whose weights are broken symlinks) is
+    /// not "downloaded" here either.
     public static func isDownloaded(_ component: ModelComponent) -> Bool {
-        // First check our local path
-        let path = localPath(for: component)
-        if FileManager.default.fileExists(atPath: path.path) {
-            return true
-        }
-
-        // Also check HuggingFace cache via Flux2ModelDownloader
-        return Flux2ModelDownloader.isDownloaded(component)
+        Flux2ModelDownloader.isDownloaded(component)
     }
 
     // MARK: - Configuration Files

--- a/Sources/Flux2Core/Configuration/ModelRegistry.swift
+++ b/Sources/Flux2Core/Configuration/ModelRegistry.swift
@@ -449,34 +449,79 @@ public enum ModelRegistry {
 
     // MARK: Per-component path overrides
 
+    /// The components whose location can be overridden individually.
+    ///
+    /// `.textEncoder` is deliberately absent: Mistral/Qwen3 loading goes through
+    /// `TextEncoderModelDownloader` (FluxTextEncoders), which has its own
+    /// `customModelsDirectory` and never consults this registry, so an override
+    /// there could only ever be silently inert. Making it unrepresentable beats
+    /// rejecting it at runtime. Spelled like `ModelComponent` so call sites read
+    /// the same (`.vae(.standard)`, `.transformer(.klein9B_bf16)`).
+    public enum OverridableComponent: Hashable, Sendable {
+        case transformer(TransformerVariant)
+        case vae(VAEVariant)
+
+        public init?(_ component: ModelComponent) {
+            switch component {
+            case .transformer(let v): self = .transformer(v)
+            case .vae(let v): self = .vae(v)
+            case .textEncoder: return nil
+            }
+        }
+
+        public var component: ModelComponent {
+            switch self {
+            case .transformer(let v): return .transformer(v)
+            case .vae(let v): return .vae(v)
+            }
+        }
+    }
+
     /// Set (or clear, with `nil`) an explicit location for a single component,
     /// e.g. one relocated wholesale to an external disk while the rest of the
-    /// catalog stays under `customModelsDirectory`. An override is authoritative:
-    /// `localPath(for:)` returns it, and `Flux2ModelDownloader` checks only that
-    /// location — never the default cache-search tiers — for that component.
+    /// catalog stays under `customModelsDirectory`.
     ///
-    /// Only `.transformer` and `.vae` are supported: `.textEncoder` loading goes
-    /// through `TextEncoderModelDownloader` (FluxTextEncoders), which does not
-    /// consult this registry, so accepting an override there would be silently
-    /// inert. It throws instead.
+    /// An override is authoritative for `Flux2ModelDownloader`: it checks only
+    /// that directory for the component — never the default cache-search tiers
+    /// — and `download()` writes there. `localPath(for:)` is unaffected (it
+    /// stays the pure catalog layout); use `resolvedPath(for:)` for
+    /// "override if set, else layout".
     ///
-    /// Overrides are deliberately not exposed as a mutable dictionary: each call
-    /// is one atomic update under a lock, so concurrent writers to different
+    /// The URL must be a file URL (throws `invalidPathOverride` otherwise) and
+    /// is stored standardized as a directory URL. Under App Sandbox the
+    /// directory must lie inside an active security-scoped resource: metadata
+    /// calls succeed outside a scope but directory listing does not, which
+    /// `download()` reports as `destinationUnreadable` rather than "not
+    /// downloaded".
+    ///
+    /// Overrides are not exposed as a mutable dictionary: each call is one
+    /// atomic update under a lock, so concurrent writers to different
     /// components can't lose each other's entries.
-    public static func setPathOverride(_ url: URL?, for component: ModelComponent) throws {
-        if case .textEncoder = component {
-            throw Flux2DownloadError.pathOverrideUnsupported(component.displayName)
+    public static func setPathOverride(_ url: URL?, for component: OverridableComponent) throws {
+        var stored: URL?
+        if let url {
+            guard url.isFileURL else {
+                throw Flux2DownloadError.invalidPathOverride(url)
+            }
+            stored = URL(fileURLWithPath: url.path, isDirectory: true).standardizedFileURL
         }
         pathOverridesLock.lock()
         defer { pathOverridesLock.unlock() }
-        _pathOverrides[component] = url
+        _pathOverrides[component] = stored
     }
 
     /// The explicit location set via `setPathOverride(_:for:)`, if any.
-    public static func pathOverride(for component: ModelComponent) -> URL? {
+    public static func pathOverride(for component: OverridableComponent) -> URL? {
         pathOverridesLock.lock()
         defer { pathOverridesLock.unlock() }
         return _pathOverrides[component]
+    }
+
+    /// Same, keyed by `ModelComponent`; always `nil` for `.textEncoder`.
+    /// (Distinct label: both enums spell their cases identically, so a shared
+    /// `for:` overload would make `.vae(.standard)` ambiguous at call sites.)
+    public static func pathOverride(forComponent component: ModelComponent) -> URL? {
+        OverridableComponent(component).flatMap { pathOverride(for: $0) }
     }
 
     /// Remove every override (mainly for tests and app reset flows).
@@ -487,18 +532,20 @@ public enum ModelRegistry {
     }
 
     private static let pathOverridesLock = NSLock()
-    nonisolated(unsafe) private static var _pathOverrides: [ModelComponent: URL] = [:]
+    nonisolated(unsafe) private static var _pathOverrides: [OverridableComponent: URL] = [:]
 
-    /// Get the local path for a model component: its override if one is set,
-    /// otherwise the computed default under `modelsDirectory`.
-    public static func localPath(for component: ModelComponent) -> URL {
-        pathOverride(for: component) ?? defaultLocalPath(for: component)
+    /// Where the component is actually looked up: its override if one is set,
+    /// otherwise `localPath(for:)`.
+    public static func resolvedPath(for component: ModelComponent) -> URL {
+        pathOverride(forComponent: component) ?? localPath(for: component)
     }
 
-    /// The computed default location under `modelsDirectory`, ignoring any
-    /// override. Pure: reads no override state, so a caller that has already
-    /// taken an override snapshot can use it without a second read.
-    public static func defaultLocalPath(for component: ModelComponent) -> URL {
+    /// The catalog layout location of a component under `modelsDirectory`.
+    ///
+    /// Pure and override-agnostic on purpose: consumers use it to derive
+    /// paths *relative to* `modelsDirectory` (their own relocation bookkeeping
+    /// depends on it staying under that root). See `resolvedPath(for:)`.
+    public static func localPath(for component: ModelComponent) -> URL {
         switch component {
         case .transformer(let variant):
             let modelName: String

--- a/Sources/Flux2Core/Configuration/ModelRegistry.swift
+++ b/Sources/Flux2Core/Configuration/ModelRegistry.swift
@@ -468,13 +468,6 @@ public enum ModelRegistry {
             case .textEncoder: return nil
             }
         }
-
-        public var component: ModelComponent {
-            switch self {
-            case .transformer(let v): return .transformer(v)
-            case .vae(let v): return .vae(v)
-            }
-        }
     }
 
     /// Set (or clear, with `nil`) an explicit location for a single component,
@@ -488,7 +481,9 @@ public enum ModelRegistry {
     /// "override if set, else layout".
     ///
     /// The URL must be a file URL (throws `invalidPathOverride` otherwise) and
-    /// is stored standardized as a directory URL. Under App Sandbox the
+    /// is stored as a lexically standardized directory URL (`.` / `..`
+    /// removed; symlinks such as `/private` are *not* resolved, so the stored
+    /// URL compares equal to what the caller passed). Under App Sandbox the
     /// directory must lie inside an active security-scoped resource: metadata
     /// calls succeed outside a scope but directory listing does not, which
     /// `download()` reports as `destinationUnreadable` rather than "not
@@ -503,7 +498,7 @@ public enum ModelRegistry {
             guard url.isFileURL else {
                 throw Flux2DownloadError.invalidPathOverride(url)
             }
-            stored = URL(fileURLWithPath: url.path, isDirectory: true).standardizedFileURL
+            stored = URL(fileURLWithPath: url.path, isDirectory: true).standardized
         }
         pathOverridesLock.lock()
         defer { pathOverridesLock.unlock() }

--- a/Sources/Flux2Core/Loading/KleinTextEncoder.swift
+++ b/Sources/Flux2Core/Loading/KleinTextEncoder.swift
@@ -102,6 +102,12 @@ public class KleinTextEncoder: @unchecked Sendable {
 
         for candidate in candidates {
             if TextEncoderModelDownloader.isQwen3ModelDownloaded(variant: candidate) {
+                if candidate != candidates.first {
+                    // Visible at the default log level: the preferred variant
+                    // may be present but unreachable (relocated, disk unplugged).
+                    Flux2Debug.warning(
+                        "Qwen3 \(candidates[0].rawValue) not available (missing, or relocated to a disk that isn't connected) — using \(candidate.rawValue) instead")
+                }
                 return candidate
             }
         }

--- a/Sources/Flux2Core/Loading/ModelDownloader.swift
+++ b/Sources/Flux2Core/Loading/ModelDownloader.swift
@@ -2,6 +2,7 @@
 // Copyright 2025 Vincent Gourbin
 
 import Foundation
+import FluxTextEncoders
 
 /// Progress callback for download updates
 public typealias Flux2DownloadProgressCallback = @Sendable (Double, String) -> Void
@@ -60,66 +61,78 @@ public class Flux2ModelDownloader: @unchecked Sendable {
     public static func unavailableReason(for component: ModelRegistry.ModelComponent) -> String? {
         let location = location(for: component)
         guard findModelPath(for: component, at: location) == nil else { return nil }
-        let dir = location.url
-        let where_ = location.isOverride ? "Its path override (\(dir.path))" : "Its directory (\(dir.path))"
 
-        if isDirectoryUnreadable(dir) {
-            return "\(where_) exists but can't be listed — under App Sandbox it must lie inside an active security-scoped resource."
-        }
-        if isOnUnmountedVolume(dir) {
-            return "\(where_) is on a disk that isn't connected — connect it and retry."
-        }
-        let unreachable = unreachableWeights(at: dir)
-        if !unreachable.isEmpty {
-            return "\(where_) has weight files that are symlinks to a disk that isn't connected (\(unreachable.prefix(3).joined(separator: ", "))) — connect it and retry."
-        }
-        let relocated = symlinkedWeights(at: dir)
-        if !relocated.isEmpty {
-            let missing = verifyModel(at: dir).missing.prefix(3).joined(separator: ", ")
-            return "\(where_) holds relocated weights (symlinks) but is incomplete (\(missing)) — restore the missing files at the relocation target; re-downloading here would replace the links with local copies."
+        // Same classification `download()` throws on, so the explanation a user
+        // reads and the error a caller catches can never name different causes.
+        if let problem = destinationProblem(component, at: location.url) {
+            return problem.errorDescription
         }
         if location.isOverride {
-            return "\(where_) holds no complete model — restore the files there or clear the override."
+            return "\(component.displayName)'s path override (\(location.url.path)) holds no complete model — restore the files there or clear the override."
         }
         return nil
     }
 
-    /// The directory exists (`stat` works) but can't be listed — under App
-    /// Sandbox that is a missing security scope, not an empty model.
+    /// Everything that makes a destination directory unusable, resolved in one
+    /// place and in one precedence order.
+    ///
+    /// `download()` throws this before touching the network; `unavailableReason`
+    /// renders it. Keeping both on one helper is what stops a fifth check (or a
+    /// reordering) from landing in only one of them.
+    static func destinationProblem(
+        _ component: ModelRegistry.ModelComponent, at directory: URL
+    ) -> Flux2DownloadError? {
+        let name = component.displayName
+
+        // Under App Sandbox, `stat` works everywhere but listing a directory
+        // outside an active security scope fails with EPERM; verifyModel
+        // swallows that into "no weights", which must not become a download.
+        if isDirectoryUnreadable(directory) {
+            return .destinationUnreadable(name, directory)
+        }
+        // An unmounted volume: `createDirectory(withIntermediateDirectories:)`
+        // would rebuild the missing tree on the boot volume and download into
+        // it. Applies to a catalog root on removable storage as much as to an
+        // override, and precedes the weight checks — an absent directory has
+        // no weights to inspect.
+        if isOnUnmountedVolume(directory) {
+            return .destinationVolumeUnavailable(name, directory)
+        }
+        // Relocated weights: writing here replaces the links with local copies
+        // and orphans the external payload. Dangling ones mean the disk is
+        // gone; live ones mean the series is incomplete at the target.
+        let links = SafetensorsDirectory.symlinkedWeights(at: directory)
+        guard !links.isEmpty else { return nil }
+        let unreachable = SafetensorsDirectory.unreachableWeights(at: directory)
+        if !unreachable.isEmpty {
+            return .weightsUnreachable(name, directory, unreachable)
+        }
+        return .weightsRelocated(name, directory, missing: verifyModel(at: directory).missing)
+    }
+
+    /// The path exists (`stat` works) but can't be listed as a directory —
+    /// under App Sandbox a missing security scope, otherwise a plain file
+    /// sitting where the model directory belongs.
     static func isDirectoryUnreadable(_ directory: URL) -> Bool {
         let fm = FileManager.default
-        return fm.fileExists(atPath: directory.path)
-            && (try? fm.contentsOfDirectory(atPath: directory.path)) == nil
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: directory.path, isDirectory: &isDir), isDir.boolValue else {
+            return false
+        }
+        return (try? fm.contentsOfDirectory(atPath: directory.path)) == nil
     }
 
-    /// Every `.safetensors` entry in `directory` that is a symlink, live or
-    /// dangling: the model was relocated, and `download()` must not write
-    /// into it (it would replace the links with local copies).
+    /// `.safetensors` entries that are symlinks, live or dangling: the model
+    /// was relocated, and `download()` must not write into it.
     public static func symlinkedWeights(at directory: URL) -> [String] {
-        let fm = FileManager.default
-        let contents = (try? fm.contentsOfDirectory(atPath: directory.path)) ?? []
-        return contents.filter { name in
-            guard name.hasSuffix(".safetensors"), !name.hasPrefix("._") else { return false }
-            let attrs = try? fm.attributesOfItem(atPath: directory.appendingPathComponent(name).path)
-            return (attrs?[.type] as? FileAttributeType) == .typeSymbolicLink
-        }.sorted()
+        SafetensorsDirectory.symlinkedWeights(at: directory)
     }
 
-    /// `.safetensors` entries in `directory` that exist as symlinks but whose
-    /// target can't be reached — a model relocated to an external disk that is
-    /// currently unplugged. Such a model is neither loadable nor safely
-    /// re-downloadable: writing over the dangling links would silently undo
-    /// the relocation.
+    /// Symlinked `.safetensors` entries whose target can't be reached — a model
+    /// relocated to an external disk that is currently unplugged. Neither
+    /// loadable nor safely re-downloadable.
     public static func unreachableWeights(at directory: URL) -> [String] {
-        let fm = FileManager.default
-        let contents = (try? fm.contentsOfDirectory(atPath: directory.path)) ?? []
-        return contents.filter { name in
-            guard name.hasSuffix(".safetensors"), !name.hasPrefix("._") else { return false }
-            let path = directory.appendingPathComponent(name).path
-            guard let attrs = try? fm.attributesOfItem(atPath: path),
-                  (attrs[.type] as? FileAttributeType) == .typeSymbolicLink else { return false }
-            return !fm.fileExists(atPath: path)
-        }.sorted()
+        SafetensorsDirectory.unreachableWeights(at: directory)
     }
 
     /// The legacy `huggingface_hub`-style cache searched as a last resort
@@ -245,73 +258,10 @@ public class Flux2ModelDownloader: @unchecked Sendable {
     /// whatever the stem (`model-…`, `diffusion_pytorch_model-…`), and the
     /// whole `1…M` series must be reachable.
     public static func verifyModel(at path: URL) -> (complete: Bool, missing: [String]) {
-        let fm = FileManager.default
-        let contents = (try? fm.contentsOfDirectory(atPath: path.path)) ?? []
-        let safetensorsFiles = contents.filter {
-            $0.hasSuffix(".safetensors") && !$0.hasPrefix("._")
-                && fm.fileExists(atPath: path.appendingPathComponent($0).path)
-        }
-
-        // Single file model (various naming conventions)
-        if safetensorsFiles.contains("model.safetensors") ||
-           safetensorsFiles.contains("diffusion_pytorch_model.safetensors") {
-            return (true, [])
-        }
-
-        // Klein bf16 models use flux-2-klein-*.safetensors naming
-        if safetensorsFiles.contains(where: { $0.hasPrefix("flux-2-klein") }) {
-            return (true, [])
-        }
-
-        // Check for sharded model
-        guard !safetensorsFiles.isEmpty else {
-            return (false, ["No safetensors files found"])
-        }
-
-        // Parse sharded pattern: <stem>-NNNNN-of-MMMMM.safetensors. Series are
-        // grouped by (stem, total) so a leftover shard of another series (a
-        // previous naming, an interrupted attempt) can neither complete nor
-        // break this one, whatever order the directory listing comes in.
-        struct Series: Hashable { let stem: String; let total: Int }
-        var found: [Series: Set<Int>] = [:]
-        for file in safetensorsFiles {
-            guard let shard = shardComponents(of: file) else { continue }
-            found[Series(stem: shard.stem, total: shard.total), default: []].insert(shard.index)
-        }
-
-        guard !found.isEmpty else { return (true, []) }
-
-        // Complete if any one series is whole; otherwise report the missing
-        // shards of the series closest to completion.
-        var bestMissing: (series: Series, missing: [Int])?
-        for (series, indices) in found {
-            let missing = Set(1...series.total).subtracting(indices).sorted()
-            if missing.isEmpty { return (true, []) }
-            if bestMissing == nil || missing.count < bestMissing!.missing.count {
-                bestMissing = (series, missing)
-            }
-        }
-        let best = bestMissing!
-        return (false, best.missing.map {
-            "\(best.series.stem)-\(String(format: "%05d", $0))-of-\(String(format: "%05d", best.series.total)).safetensors"
-        })
-    }
-
-    /// Splits `<stem>-NNNNN-of-MMMMM.safetensors` into its parts; `nil` for any
-    /// other name (or an implausible series: no real checkpoint has more than
-    /// a few hundred shards, and `Set(1...total)` must stay small).
-    private static func shardComponents(of file: String) -> (stem: String, index: Int, total: Int)? {
-        guard file.hasSuffix(".safetensors") else { return nil }
-        let name = String(file.dropLast(".safetensors".count))
-        let parts = name.split(separator: "-", omittingEmptySubsequences: false)
-        guard parts.count >= 4,
-              parts[parts.count - 2] == "of",
-              let index = Int(parts[parts.count - 3]),
-              let total = Int(parts[parts.count - 1]),
-              total > 0, total <= 10_000, index >= 1, index <= total else {
-            return nil
-        }
-        return (parts.dropLast(3).joined(separator: "-"), index, total)
+        SafetensorsDirectory.verifySeries(
+            at: path,
+            // Klein bf16 models ship a single flux-2-klein-*.safetensors.
+            singleFilePrefixes: ["flux-2-klein"])
     }
 
     // MARK: - Download
@@ -338,44 +288,31 @@ public class Flux2ModelDownloader: @unchecked Sendable {
         let destDir = location.url
         let fm = FileManager.default
 
-        // Weights relocated to a disk that isn't connected: not "missing", and
-        // re-downloading over the dangling links would silently undo the
-        // relocation and orphan the external copy. Applies to the default
-        // layout too — that is exactly how the consumer app relocates.
-        // Under App Sandbox, `stat` works everywhere but listing a directory
-        // outside an active security scope fails with EPERM. verifyModel
-        // swallows that into "no weights"; here it must not become a download.
-        if Self.isDirectoryUnreadable(destDir) {
-            throw Flux2DownloadError.destinationUnreadable(component.displayName, destDir)
-        }
-
-        let unreachable = Self.unreachableWeights(at: destDir)
-        if !unreachable.isEmpty {
-            throw Flux2DownloadError.weightsUnreachable(component.displayName, destDir, unreachable)
-        }
-
-        // Live links with a shard missing (interrupted relocation): downloading
-        // here would replace every live link with a local copy — the model
-        // must be repaired at the relocation target instead.
-        let relocated = Self.symlinkedWeights(at: destDir)
-        if !relocated.isEmpty {
-            throw Flux2DownloadError.weightsRelocated(component.displayName, destDir, relocated)
-        }
-
-        // If the destination's volume isn't mounted, `createDirectory(
-        // withIntermediateDirectories:)` would rebuild the whole missing tree
-        // on the boot volume and download into it. Applies to a catalog root
-        // on removable storage (`--models-dir`) as much as to an override.
-        if Self.isOnUnmountedVolume(destDir) {
-            throw Flux2DownloadError.destinationVolumeUnavailable(component.displayName, destDir)
+        // Everything knowable about the destination — sandbox scope, unmounted
+        // volume, relocation symlinks — decided before any network activity, so
+        // a doomed download fails in milliseconds with a precise reason instead
+        // of after gigabytes. Shared with `unavailableReason`.
+        if let problem = Self.destinationProblem(component, at: destDir) {
+            throw problem
         }
 
         // Read-only volumes (NTFS by default, a dirty exFAT remounted read-only)
-        // pass every check above; probe writability before transferring. The
-        // directory is created for the probe, and removed again if nothing
-        // gets downloaded into it (403 without a licence, offline, …).
-        let existedBefore = fm.fileExists(atPath: destDir.path)
+        // pass every check above; the only way to know is to create the
+        // directory and ask. Anything that throws before the first file lands
+        // then removes a directory we created ourselves, so a failed attempt
+        // (403 without a licence, offline, not writable) leaves no empty tree.
+        // The emptiness check also keeps a concurrent download of the same
+        // component — which callers must serialize anyway, since both would
+        // write the same files — from having its directory pulled away.
+        let createdDestination = !fm.fileExists(atPath: destDir.path)
         try fm.createDirectory(at: destDir, withIntermediateDirectories: true)
+        var transferStarted = false
+        defer {
+            if createdDestination, !transferStarted,
+               ((try? fm.contentsOfDirectory(atPath: destDir.path)) ?? []).isEmpty {
+                try? fm.removeItem(at: destDir)
+            }
+        }
         guard fm.isWritableFile(atPath: destDir.path) else {
             throw Flux2DownloadError.destinationNotWritable(component.displayName, destDir)
         }
@@ -386,32 +323,25 @@ public class Flux2ModelDownloader: @unchecked Sendable {
 
         Flux2Debug.log("Downloading \(component.displayName) from \(repoId)")
 
-        let filesToDownload: [String]
-        do {
-            // Get file list from HuggingFace API
-            let files = try await fetchFileList(repoId: repoId, subfolder: subfolder)
+        // Get file list from HuggingFace API
+        let files = try await fetchFileList(repoId: repoId, subfolder: subfolder)
 
-            // Filter to only necessary files. Small metadata first: if a write
-            // is still going to fail for a reason no probe can catch, it fails
-            // on a kilobyte of JSON rather than after a multi-gigabyte weight.
-            filesToDownload = files.filter { file in
-                file.hasSuffix(".safetensors") ||
-                file.hasSuffix(".json") ||
-                file == "tokenizer.model"
-            }.sorted { a, b in
-                let aWeight = a.hasSuffix(".safetensors"), bWeight = b.hasSuffix(".safetensors")
-                return aWeight == bWeight ? a < b : !aWeight
-            }
-
-            guard !filesToDownload.isEmpty else {
-                throw Flux2DownloadError.modelNotFound("No model files found in \(repoId)")
-            }
-        } catch {
-            if !existedBefore, ((try? fm.contentsOfDirectory(atPath: destDir.path)) ?? []).isEmpty {
-                try? fm.removeItem(at: destDir)
-            }
-            throw error
+        // Filter to only necessary files. Small metadata first: if a write is
+        // still going to fail for a reason no probe can catch, it fails on a
+        // kilobyte of JSON rather than after a multi-gigabyte weight.
+        let filesToDownload = files.filter { file in
+            file.hasSuffix(".safetensors") ||
+            file.hasSuffix(".json") ||
+            file == "tokenizer.model"
+        }.sorted { a, b in
+            let aWeight = a.hasSuffix(".safetensors"), bWeight = b.hasSuffix(".safetensors")
+            return aWeight == bWeight ? a < b : !aWeight
         }
+
+        guard !filesToDownload.isEmpty else {
+            throw Flux2DownloadError.modelNotFound("No model files found in \(repoId)")
+        }
+        transferStarted = true
 
         // Download each file
         var downloadedBytes: Int64 = 0
@@ -698,7 +628,7 @@ public enum Flux2DownloadError: LocalizedError {
     case deletionRefusedForOverride(String)
     case destinationVolumeUnavailable(String, URL)
     case weightsUnreachable(String, URL, [String])
-    case weightsRelocated(String, URL, [String])
+    case weightsRelocated(String, URL, missing: [String])
     case destinationUnreadable(String, URL)
     case destinationNotWritable(String, URL)
 
@@ -724,8 +654,8 @@ public enum Flux2DownloadError: LocalizedError {
             return "\(name) has a path override and was not deleted — that location may be its only copy (e.g. an external disk). Clear the override or remove the files manually."
         case .destinationVolumeUnavailable(let name, let url):
             return "\(name)'s directory (\(url.path)) is on a volume that isn't mounted — connect the external disk and retry."
-        case .weightsRelocated(let name, let url, let files):
-            return "\(name) at \(url.path) holds relocated weight files (symlinks: \(files.prefix(3).joined(separator: ", "))) but is incomplete — restore the missing files at the relocation target; downloading here would replace the links with local copies."
+        case .weightsRelocated(let name, let url, let missing):
+            return "\(name) at \(url.path) holds relocated weight files (symlinks) but is incomplete (\(missing.prefix(3).joined(separator: ", "))) — restore the missing files at the relocation target; downloading here would replace the live links with local copies."
         }
     }
 }

--- a/Sources/Flux2Core/Loading/ModelDownloader.swift
+++ b/Sources/Flux2Core/Loading/ModelDownloader.swift
@@ -46,10 +46,48 @@ public class Flux2ModelDownloader: @unchecked Sendable {
     }
 
     static func location(for component: ModelRegistry.ModelComponent) -> Location {
-        if let override = ModelRegistry.pathOverride(for: component) {
+        if let override = ModelRegistry.pathOverride(forComponent: component) {
             return Location(url: override, isOverride: true)
         }
-        return Location(url: ModelRegistry.defaultLocalPath(for: component), isOverride: false)
+        return Location(url: ModelRegistry.localPath(for: component), isOverride: false)
+    }
+
+    /// Why `findModelPath(for:)` is `nil` when there is more to it than "never
+    /// downloaded" — an override is set, or the weights are dangling symlinks
+    /// (relocated to a disk that isn't connected). `nil` when a plain download
+    /// would fix it. Meant for error messages: "run `flux2 download`" is wrong
+    /// advice in both cases.
+    public static func unavailableReason(for component: ModelRegistry.ModelComponent) -> String? {
+        let location = location(for: component)
+        guard findModelPath(for: component, at: location) == nil else { return nil }
+        let unreachable = unreachableWeights(at: location.url)
+        if location.isOverride {
+            if isOnUnmountedVolume(location.url) || !unreachable.isEmpty {
+                return "Its path override (\(location.url.path)) is on a disk that isn't connected — connect it and retry."
+            }
+            return "Its path override (\(location.url.path)) holds no complete model — restore the files there or clear the override."
+        }
+        if !unreachable.isEmpty {
+            return "Its weight files are symlinks to a disk that isn't connected (\(unreachable.prefix(3).joined(separator: ", "))) — connect it and retry."
+        }
+        return nil
+    }
+
+    /// `.safetensors` entries in `directory` that exist as symlinks but whose
+    /// target can't be reached — a model relocated to an external disk that is
+    /// currently unplugged. Such a model is neither loadable nor safely
+    /// re-downloadable: writing over the dangling links would silently undo
+    /// the relocation.
+    public static func unreachableWeights(at directory: URL) -> [String] {
+        let fm = FileManager.default
+        let contents = (try? fm.contentsOfDirectory(atPath: directory.path)) ?? []
+        return contents.filter { name in
+            guard name.hasSuffix(".safetensors"), !name.hasPrefix("._") else { return false }
+            let path = directory.appendingPathComponent(name).path
+            guard let attrs = try? fm.attributesOfItem(atPath: path),
+                  (attrs[.type] as? FileAttributeType) == .typeSymbolicLink else { return false }
+            return !fm.fileExists(atPath: path)
+        }.sorted()
     }
 
     /// Find local path for a model component
@@ -101,11 +139,17 @@ public class Flux2ModelDownloader: @unchecked Sendable {
         return isCompleteModel(at: modelPath) ? modelPath : nil
     }
 
-    /// True when `url` sits under a `/Volumes/<disk>` mount point that doesn't
-    /// currently exist. Walks up to the nearest existing ancestor: if that is
-    /// `/Volumes` itself, the disk isn't mounted. A missing *subfolder* on a
-    /// mounted disk (nearest ancestor is `/Volumes/<disk>` or deeper) is fine —
-    /// `createDirectory(withIntermediateDirectories:)` handles that normally.
+    /// True when `url` lives under `/Volumes` but not on a mounted volume: its
+    /// nearest existing ancestor is on the *boot* volume (same volume
+    /// identifier as `/`). That covers both an absent mount point (ancestor is
+    /// `/Volumes`) and a ghost mount-point directory left behind on the boot
+    /// volume after an unclean unmount. A missing subfolder on a mounted disk
+    /// resolves to an ancestor on that disk and is fine.
+    ///
+    /// Mounts outside `/Volumes` (`hdiutil -mountpoint`, sshfs under `$HOME`)
+    /// can't be told apart from a plain directory this way and are not
+    /// detected; the guard's job is a clear error *before* any network
+    /// transfer, not a complete mount oracle.
     static func isOnUnmountedVolume(_ url: URL) -> Bool {
         let fm = FileManager.default
         var ancestor = url.standardizedFileURL
@@ -114,7 +158,17 @@ public class Flux2ModelDownloader: @unchecked Sendable {
             if parent.path == ancestor.path { return false }
             ancestor = parent
         }
-        return ancestor.path == "/Volumes"
+        // The ancestor exists, so resolving is safe (the pitfall of
+        // resolvingSymlinksInPath only concerns dangling links).
+        let resolved = ancestor.resolvingSymlinksInPath()
+        let components = resolved.pathComponents
+        guard components.count >= 2, components[1].caseInsensitiveCompare("Volumes") == .orderedSame else {
+            return false
+        }
+        guard let ancestorVolume = try? resolved.resourceValues(forKeys: [.volumeIdentifierKey]).volumeIdentifier,
+              let rootVolume = try? URL(fileURLWithPath: "/").resourceValues(forKeys: [.volumeIdentifierKey]).volumeIdentifier
+        else { return components.count == 2 }
+        return ancestorVolume.isEqual(rootVolume)
     }
 
     /// A model directory counts as present when it has a `config.json` or
@@ -147,12 +201,18 @@ public class Flux2ModelDownloader: @unchecked Sendable {
     /// the directory listing is filtered through `fileExists(atPath:)`, which is
     /// `stat`-based and follows symlinks, so a weight file relocated to an
     /// external disk that is currently unmounted (a dangling symlink) is
-    /// reported as missing rather than counted by name.
+    /// reported as missing rather than counted by name. `._*` entries are
+    /// AppleDouble sidecars (exFAT/NTFS) and never weights.
+    ///
+    /// Sharded weights are recognised by their `-NNNNN-of-MMMMM` suffix
+    /// whatever the stem (`model-…`, `diffusion_pytorch_model-…`), and the
+    /// whole `1…M` series must be reachable.
     public static func verifyModel(at path: URL) -> (complete: Bool, missing: [String]) {
         let fm = FileManager.default
         let contents = (try? fm.contentsOfDirectory(atPath: path.path)) ?? []
         let safetensorsFiles = contents.filter {
-            $0.hasSuffix(".safetensors") && fm.fileExists(atPath: path.appendingPathComponent($0).path)
+            $0.hasSuffix(".safetensors") && !$0.hasPrefix("._")
+                && fm.fileExists(atPath: path.appendingPathComponent($0).path)
         }
 
         // Single file model (various naming conventions)
@@ -171,29 +231,21 @@ public class Flux2ModelDownloader: @unchecked Sendable {
             return (false, ["No safetensors files found"])
         }
 
-        // Parse sharded pattern
+        // Parse sharded pattern: <stem>-NNNNN-of-MMMMM.safetensors
+        var stem: String?
         var totalShards: Int?
         var foundIndices: Set<Int> = []
 
         for file in safetensorsFiles {
-            let name = file.replacingOccurrences(of: ".safetensors", with: "")
-            let parts = name.split(separator: "-")
-
-            guard parts.count == 4,
-                  parts[0] == "model",
-                  parts[2] == "of",
-                  let index = Int(parts[1]),
-                  let total = Int(parts[3]) else {
-                continue
-            }
-
+            guard let shard = shardComponents(of: file) else { continue }
             if totalShards == nil {
-                totalShards = total
+                totalShards = shard.total
+                stem = shard.stem
             }
-            foundIndices.insert(index)
+            foundIndices.insert(shard.index)
         }
 
-        if let total = totalShards {
+        if let total = totalShards, let stem {
             let expectedIndices = Set(1...total)
             let missing = expectedIndices.subtracting(foundIndices)
 
@@ -201,13 +253,29 @@ public class Flux2ModelDownloader: @unchecked Sendable {
                 return (true, [])
             } else {
                 let missingFiles = missing.sorted().map {
-                    "model-\(String(format: "%05d", $0))-of-\(String(format: "%05d", total)).safetensors"
+                    "\(stem)-\(String(format: "%05d", $0))-of-\(String(format: "%05d", total)).safetensors"
                 }
                 return (false, missingFiles)
             }
         }
 
         return (true, [])
+    }
+
+    /// Splits `<stem>-NNNNN-of-MMMMM.safetensors` into its parts; `nil` for any
+    /// other name.
+    private static func shardComponents(of file: String) -> (stem: String, index: Int, total: Int)? {
+        guard file.hasSuffix(".safetensors") else { return nil }
+        let name = String(file.dropLast(".safetensors".count))
+        let parts = name.split(separator: "-", omittingEmptySubsequences: false)
+        guard parts.count >= 4,
+              parts[parts.count - 2] == "of",
+              let index = Int(parts[parts.count - 3]),
+              let total = Int(parts[parts.count - 1]),
+              total > 0, index >= 1, index <= total else {
+            return nil
+        }
+        return (parts.dropLast(3).joined(separator: "-"), index, total)
     }
 
     // MARK: - Download
@@ -228,13 +296,40 @@ public class Flux2ModelDownloader: @unchecked Sendable {
             return existingPath
         }
 
-        // An override normally points at removable storage. Refuse before any
-        // network activity if its volume isn't there: `createDirectory(
-        // withIntermediateDirectories:)` would otherwise happily rebuild the
-        // whole missing tree on the boot volume and download into it.
+        // Everything that can be known about the destination is checked here,
+        // before any network activity, so a doomed download fails in
+        // milliseconds with a precise reason rather than after gigabytes.
         let destDir = location.url
+        let fm = FileManager.default
+
+        // Weights relocated to a disk that isn't connected: not "missing", and
+        // re-downloading over the dangling links would silently undo the
+        // relocation and orphan the external copy. Applies to the default
+        // layout too — that is exactly how the consumer app relocates.
+        let unreachable = Self.unreachableWeights(at: destDir)
+        if !unreachable.isEmpty {
+            throw Flux2DownloadError.weightsUnreachable(component.displayName, destDir, unreachable)
+        }
+
+        // An override normally points at removable storage. If its volume
+        // isn't mounted, `createDirectory(withIntermediateDirectories:)` would
+        // rebuild the whole missing tree on the boot volume and download into it.
         if location.isOverride, Self.isOnUnmountedVolume(destDir) {
             throw Flux2DownloadError.overrideVolumeUnavailable(component.displayName, destDir)
+        }
+
+        // Under App Sandbox, `stat` works everywhere but listing a directory
+        // outside an active security scope fails with EPERM. verifyModel
+        // swallows that into "no weights"; here it must not become a download.
+        if fm.fileExists(atPath: destDir.path), (try? fm.contentsOfDirectory(atPath: destDir.path)) == nil {
+            throw Flux2DownloadError.destinationUnreadable(component.displayName, destDir)
+        }
+
+        // Read-only volumes (NTFS by default, a dirty exFAT remounted read-only)
+        // pass every check above; probe writability before transferring.
+        try fm.createDirectory(at: destDir, withIntermediateDirectories: true)
+        guard fm.isWritableFile(atPath: destDir.path) else {
+            throw Flux2DownloadError.destinationNotWritable(component.displayName, destDir)
         }
 
         let repoId = Self.repoId(for: component)
@@ -246,19 +341,21 @@ public class Flux2ModelDownloader: @unchecked Sendable {
         // Get file list from HuggingFace API
         let files = try await fetchFileList(repoId: repoId, subfolder: subfolder)
 
-        // Filter to only necessary files
+        // Filter to only necessary files. Small metadata first: if a write is
+        // still going to fail for a reason no probe can catch, it fails on a
+        // kilobyte of JSON rather than after a multi-gigabyte weight transfer.
         let filesToDownload = files.filter { file in
             file.hasSuffix(".safetensors") ||
             file.hasSuffix(".json") ||
             file == "tokenizer.model"
+        }.sorted { a, b in
+            let aWeight = a.hasSuffix(".safetensors"), bWeight = b.hasSuffix(".safetensors")
+            return aWeight == bWeight ? a < b : !aWeight
         }
 
         guard !filesToDownload.isEmpty else {
             throw Flux2DownloadError.modelNotFound("No model files found in \(repoId)")
         }
-
-        // Create destination directory
-        try FileManager.default.createDirectory(at: destDir, withIntermediateDirectories: true)
 
         // Download each file
         var downloadedBytes: Int64 = 0
@@ -372,8 +469,10 @@ public class Flux2ModelDownloader: @unchecked Sendable {
             throw Flux2DownloadError.downloadFailed("Failed to download \(filePath)")
         }
 
-        // Move to destination
-        if FileManager.default.fileExists(atPath: destination.path) {
+        // Move to destination. `attributesOfItem` is lstat-based, so a dangling
+        // symlink counts as "something is there" and gets removed — otherwise
+        // `moveItem` fails with "already exists" against the stale link.
+        if (try? FileManager.default.attributesOfItem(atPath: destination.path)) != nil {
             try FileManager.default.removeItem(at: destination)
         }
         try FileManager.default.moveItem(at: tempURL, to: destination)
@@ -422,10 +521,14 @@ public class Flux2ModelDownloader: @unchecked Sendable {
     ///
     /// Refuses to delete a component that has a path override: the default
     /// locations are re-downloadable cache copies, but an override may be the
-    /// component's only copy (relocated wholesale to an external disk).
-    /// Removing it would be data loss, not cache cleanup. The guard and the
-    /// lookup share one override snapshot, so the guard can't be bypassed by an
-    /// override set between the two.
+    /// component's only copy (relocated wholesale to an external disk), and
+    /// nothing marks it as disposable the way the framework's own download
+    /// locations are. The guard and the lookup share one override snapshot, so
+    /// the guard can't be bypassed by an override set between the two.
+    ///
+    /// Without an override this removes whatever `findModelPath` resolves,
+    /// including a legacy cache-tier directory — unchanged, pre-existing
+    /// behavior.
     public static func delete(_ component: ModelRegistry.ModelComponent) throws {
         let location = location(for: component)
         if location.isOverride {
@@ -535,9 +638,12 @@ public enum Flux2DownloadError: LocalizedError {
     case downloadFailed(String)
     case verificationFailed([String])
     case insufficientSpace(required: Int64, available: Int64)
-    case pathOverrideUnsupported(String)
+    case invalidPathOverride(URL)
     case deletionRefusedForOverride(String)
     case overrideVolumeUnavailable(String, URL)
+    case weightsUnreachable(String, URL, [String])
+    case destinationUnreadable(String, URL)
+    case destinationNotWritable(String, URL)
 
     public var errorDescription: String? {
         switch self {
@@ -549,8 +655,14 @@ public enum Flux2DownloadError: LocalizedError {
             return "Verification failed, missing files: \(missing.joined(separator: ", "))"
         case .insufficientSpace(let required, let available):
             return "Insufficient disk space: need \(Flux2ModelDownloader.formatSize(required)), have \(Flux2ModelDownloader.formatSize(available))"
-        case .pathOverrideUnsupported(let name):
-            return "\(name) does not support a path override: it is loaded by TextEncoderModelDownloader, which has its own customModelsDirectory."
+        case .invalidPathOverride(let url):
+            return "A path override must be a file URL, got: \(url.absoluteString)"
+        case .weightsUnreachable(let name, let url, let files):
+            return "\(name) at \(url.path) has weight files that are symlinks to a disk that isn't connected (\(files.prefix(3).joined(separator: ", "))) — connect it and retry; re-downloading would silently undo the relocation."
+        case .destinationUnreadable(let name, let url):
+            return "\(name)'s directory (\(url.path)) exists but can't be listed — under App Sandbox it must lie inside an active security-scoped resource."
+        case .destinationNotWritable(let name, let url):
+            return "\(name)'s directory (\(url.path)) is not writable — is the volume mounted read-only?"
         case .deletionRefusedForOverride(let name):
             return "\(name) has a path override and was not deleted — that location may be its only copy (e.g. an external disk). Clear the override or remove the files manually."
         case .overrideVolumeUnavailable(let name, let url):

--- a/Sources/Flux2Core/Loading/ModelDownloader.swift
+++ b/Sources/Flux2Core/Loading/ModelDownloader.swift
@@ -33,20 +33,41 @@ public class Flux2ModelDownloader: @unchecked Sendable {
         findModelPath(for: component) != nil
     }
 
+    /// Where a component lives, captured from exactly one read of
+    /// `ModelRegistry.pathOverride(for:)`.
+    ///
+    /// Every public operation resolves this once up front and threads it
+    /// through, so a guard ("is this an override?") and the action it guards
+    /// ("delete what findModelPath returns") can never observe two different
+    /// override states within the same call.
+    struct Location {
+        let url: URL
+        let isOverride: Bool
+    }
+
+    static func location(for component: ModelRegistry.ModelComponent) -> Location {
+        if let override = ModelRegistry.pathOverride(for: component) {
+            return Location(url: override, isOverride: true)
+        }
+        return Location(url: ModelRegistry.defaultLocalPath(for: component), isOverride: false)
+    }
+
     /// Find local path for a model component
     public static func findModelPath(for component: ModelRegistry.ModelComponent) -> URL? {
+        findModelPath(for: component, at: location(for: component))
+    }
+
+    static func findModelPath(for component: ModelRegistry.ModelComponent, at location: Location) -> URL? {
+        // An override is authoritative: it's the only place we look. Never fall
+        // back to the cache-search tiers below just because one of them happens
+        // to hold an unrelated, independently-valid copy of the same component.
+        if location.isOverride {
+            return isCompleteModel(at: location.url) ? location.url : nil
+        }
+
         // Check our local models directory
-        let localPath = ModelRegistry.localPath(for: component)
-
-        // Check for config.json OR model_index.json (Klein models use the latter)
-        let hasConfig = FileManager.default.fileExists(atPath: localPath.appendingPathComponent("config.json").path)
-        let hasModelIndex = FileManager.default.fileExists(atPath: localPath.appendingPathComponent("model_index.json").path)
-
-        if hasConfig || hasModelIndex {
-            let verification = verifyModel(at: localPath)
-            if verification.complete {
-                return localPath
-            }
+        if isCompleteModel(at: location.url) {
+            return location.url
         }
 
         // Check configured models directory
@@ -57,14 +78,8 @@ public class Flux2ModelDownloader: @unchecked Sendable {
             path = path.appendingPathComponent(String(part))
         }
 
-        let cacheHasConfig = FileManager.default.fileExists(atPath: path.appendingPathComponent("config.json").path)
-        let cacheHasModelIndex = FileManager.default.fileExists(atPath: path.appendingPathComponent("model_index.json").path)
-
-        if cacheHasConfig || cacheHasModelIndex {
-            let verification = verifyModel(at: path)
-            if verification.complete {
-                return path
-            }
+        if isCompleteModel(at: path) {
+            return path
         }
 
         // Check legacy HuggingFace cache
@@ -83,19 +98,34 @@ public class Flux2ModelDownloader: @unchecked Sendable {
         }
 
         let modelPath = snapshotsDir.appendingPathComponent(latestSnapshot)
-        let configPath = modelPath.appendingPathComponent("config.json")
-        let modelIndexPath = modelPath.appendingPathComponent("model_index.json")
+        return isCompleteModel(at: modelPath) ? modelPath : nil
+    }
 
-        if FileManager.default.fileExists(atPath: configPath.path) ||
-           FileManager.default.fileExists(atPath: modelIndexPath.path) {
-            // Verify safetensors files are complete
-            let verification = verifyModel(at: modelPath)
-            if verification.complete {
-                return modelPath
-            }
+    /// True when `url` sits under a `/Volumes/<disk>` mount point that doesn't
+    /// currently exist. Walks up to the nearest existing ancestor: if that is
+    /// `/Volumes` itself, the disk isn't mounted. A missing *subfolder* on a
+    /// mounted disk (nearest ancestor is `/Volumes/<disk>` or deeper) is fine —
+    /// `createDirectory(withIntermediateDirectories:)` handles that normally.
+    static func isOnUnmountedVolume(_ url: URL) -> Bool {
+        let fm = FileManager.default
+        var ancestor = url.standardizedFileURL
+        while !fm.fileExists(atPath: ancestor.path) {
+            let parent = ancestor.deletingLastPathComponent()
+            if parent.path == ancestor.path { return false }
+            ancestor = parent
         }
+        return ancestor.path == "/Volumes"
+    }
 
-        return nil
+    /// A model directory counts as present when it has a `config.json` or
+    /// `model_index.json` (Klein models use the latter) and `verifyModel`
+    /// finds its weights complete.
+    private static func isCompleteModel(at path: URL) -> Bool {
+        let fm = FileManager.default
+        let hasConfig = fm.fileExists(atPath: path.appendingPathComponent("config.json").path)
+        let hasModelIndex = fm.fileExists(atPath: path.appendingPathComponent("model_index.json").path)
+        guard hasConfig || hasModelIndex else { return false }
+        return verifyModel(at: path).complete
     }
 
     /// Get HuggingFace repo ID for a component
@@ -111,10 +141,19 @@ public class Flux2ModelDownloader: @unchecked Sendable {
         }
     }
 
-    /// Verify model files are complete
+    /// Verify model files are complete.
+    ///
+    /// A `.safetensors` entry only counts if its bytes are actually reachable:
+    /// the directory listing is filtered through `fileExists(atPath:)`, which is
+    /// `stat`-based and follows symlinks, so a weight file relocated to an
+    /// external disk that is currently unmounted (a dangling symlink) is
+    /// reported as missing rather than counted by name.
     public static func verifyModel(at path: URL) -> (complete: Bool, missing: [String]) {
-        let contents = (try? FileManager.default.contentsOfDirectory(atPath: path.path)) ?? []
-        let safetensorsFiles = contents.filter { $0.hasSuffix(".safetensors") }
+        let fm = FileManager.default
+        let contents = (try? fm.contentsOfDirectory(atPath: path.path)) ?? []
+        let safetensorsFiles = contents.filter {
+            $0.hasSuffix(".safetensors") && fm.fileExists(atPath: path.appendingPathComponent($0).path)
+        }
 
         // Single file model (various naming conventions)
         if safetensorsFiles.contains("model.safetensors") ||
@@ -178,13 +217,24 @@ public class Flux2ModelDownloader: @unchecked Sendable {
         _ component: ModelRegistry.ModelComponent,
         progress: Flux2DownloadProgressCallback? = nil
     ) async throws -> URL {
+        // One override snapshot for the whole operation: the already-downloaded
+        // check and the write destination below must agree on where this
+        // component lives, even if an override is set/cleared mid-download.
+        let location = Self.location(for: component)
+
         // Check if already downloaded
-        if let existingPath = Self.findModelPath(for: component) {
-            let verification = Self.verifyModel(at: existingPath)
-            if verification.complete {
-                progress?(1.0, "Model already downloaded")
-                return existingPath
-            }
+        if let existingPath = Self.findModelPath(for: component, at: location) {
+            progress?(1.0, "Model already downloaded")
+            return existingPath
+        }
+
+        // An override normally points at removable storage. Refuse before any
+        // network activity if its volume isn't there: `createDirectory(
+        // withIntermediateDirectories:)` would otherwise happily rebuild the
+        // whole missing tree on the boot volume and download into it.
+        let destDir = location.url
+        if location.isOverride, Self.isOnUnmountedVolume(destDir) {
+            throw Flux2DownloadError.overrideVolumeUnavailable(component.displayName, destDir)
         }
 
         let repoId = Self.repoId(for: component)
@@ -208,7 +258,6 @@ public class Flux2ModelDownloader: @unchecked Sendable {
         }
 
         // Create destination directory
-        let destDir = ModelRegistry.localPath(for: component)
         try FileManager.default.createDirectory(at: destDir, withIntermediateDirectories: true)
 
         // Download each file
@@ -370,8 +419,19 @@ public class Flux2ModelDownloader: @unchecked Sendable {
     }
 
     /// Delete a downloaded model
+    ///
+    /// Refuses to delete a component that has a path override: the default
+    /// locations are re-downloadable cache copies, but an override may be the
+    /// component's only copy (relocated wholesale to an external disk).
+    /// Removing it would be data loss, not cache cleanup. The guard and the
+    /// lookup share one override snapshot, so the guard can't be bypassed by an
+    /// override set between the two.
     public static func delete(_ component: ModelRegistry.ModelComponent) throws {
-        guard let path = findModelPath(for: component) else {
+        let location = location(for: component)
+        if location.isOverride {
+            throw Flux2DownloadError.deletionRefusedForOverride(component.displayName)
+        }
+        guard let path = findModelPath(for: component, at: location) else {
             return
         }
 
@@ -475,6 +535,9 @@ public enum Flux2DownloadError: LocalizedError {
     case downloadFailed(String)
     case verificationFailed([String])
     case insufficientSpace(required: Int64, available: Int64)
+    case pathOverrideUnsupported(String)
+    case deletionRefusedForOverride(String)
+    case overrideVolumeUnavailable(String, URL)
 
     public var errorDescription: String? {
         switch self {
@@ -486,6 +549,12 @@ public enum Flux2DownloadError: LocalizedError {
             return "Verification failed, missing files: \(missing.joined(separator: ", "))"
         case .insufficientSpace(let required, let available):
             return "Insufficient disk space: need \(Flux2ModelDownloader.formatSize(required)), have \(Flux2ModelDownloader.formatSize(available))"
+        case .pathOverrideUnsupported(let name):
+            return "\(name) does not support a path override: it is loaded by TextEncoderModelDownloader, which has its own customModelsDirectory."
+        case .deletionRefusedForOverride(let name):
+            return "\(name) has a path override and was not deleted — that location may be its only copy (e.g. an external disk). Clear the override or remove the files manually."
+        case .overrideVolumeUnavailable(let name, let url):
+            return "\(name)'s path override (\(url.path)) is on a volume that isn't mounted — connect the external disk and retry."
         }
     }
 }

--- a/Sources/Flux2Core/Loading/ModelDownloader.swift
+++ b/Sources/Flux2Core/Loading/ModelDownloader.swift
@@ -112,14 +112,10 @@ public class Flux2ModelDownloader: @unchecked Sendable {
 
     /// The path exists (`stat` works) but can't be listed as a directory —
     /// under App Sandbox a missing security scope, otherwise a plain file
-    /// sitting where the model directory belongs.
+    /// sitting where the model directory belongs. Shared with
+    /// TextEncoderModelDownloader via `SafetensorsDirectory`.
     static func isDirectoryUnreadable(_ directory: URL) -> Bool {
-        let fm = FileManager.default
-        var isDir: ObjCBool = false
-        guard fm.fileExists(atPath: directory.path, isDirectory: &isDir), isDir.boolValue else {
-            return false
-        }
-        return (try? fm.contentsOfDirectory(atPath: directory.path)) == nil
+        SafetensorsDirectory.isDirectoryUnreadable(directory)
     }
 
     /// `.safetensors` entries that are symlinks, live or dangling: the model
@@ -189,37 +185,13 @@ public class Flux2ModelDownloader: @unchecked Sendable {
         return isCompleteModel(at: modelPath) ? modelPath : nil
     }
 
-    /// True when `url` lives under `/Volumes` but not on a mounted volume: its
-    /// nearest existing ancestor is on the *boot* volume (same volume
-    /// identifier as `/`). That covers both an absent mount point (ancestor is
-    /// `/Volumes`) and a ghost mount-point directory left behind on the boot
-    /// volume after an unclean unmount. A missing subfolder on a mounted disk
-    /// resolves to an ancestor on that disk and is fine.
-    ///
-    /// Mounts outside `/Volumes` (`hdiutil -mountpoint`, sshfs under `$HOME`)
-    /// can't be told apart from a plain directory this way and are not
-    /// detected; the guard's job is a clear error *before* any network
-    /// transfer, not a complete mount oracle.
+    /// True when `url` lives under `/Volumes` but not on a mounted volume.
+    /// Shared with TextEncoderModelDownloader via `SafetensorsDirectory`,
+    /// which documents the exact rule.
     static func isOnUnmountedVolume(_ url: URL) -> Bool {
-        let fm = FileManager.default
-        var ancestor = url.standardizedFileURL
-        while !fm.fileExists(atPath: ancestor.path) {
-            let parent = ancestor.deletingLastPathComponent()
-            if parent.path == ancestor.path { return false }
-            ancestor = parent
-        }
-        // The ancestor exists, so resolving is safe (the pitfall of
-        // resolvingSymlinksInPath only concerns dangling links).
-        let resolved = ancestor.resolvingSymlinksInPath()
-        let components = resolved.pathComponents
-        guard components.count >= 2, components[1].caseInsensitiveCompare("Volumes") == .orderedSame else {
-            return false
-        }
-        guard let ancestorVolume = try? resolved.resourceValues(forKeys: [.volumeIdentifierKey]).volumeIdentifier,
-              let rootVolume = try? URL(fileURLWithPath: "/").resourceValues(forKeys: [.volumeIdentifierKey]).volumeIdentifier
-        else { return components.count == 2 }
-        return ancestorVolume.isEqual(rootVolume)
+        SafetensorsDirectory.isOnUnmountedVolume(url)
     }
+
 
     /// A model directory counts as present when it has a `config.json` or
     /// `model_index.json` (Klein models use the latter) and `verifyModel`
@@ -298,17 +270,19 @@ public class Flux2ModelDownloader: @unchecked Sendable {
 
         // Read-only volumes (NTFS by default, a dirty exFAT remounted read-only)
         // pass every check above; the only way to know is to create the
-        // directory and ask. Anything that throws before the first file lands
-        // then removes a directory we created ourselves, so a failed attempt
-        // (403 without a licence, offline, not writable) leaves no empty tree.
-        // The emptiness check also keeps a concurrent download of the same
-        // component — which callers must serialize anyway, since both would
-        // write the same files — from having its directory pulled away.
+        // directory and ask. Anything that throws before a file actually
+        // lands then removes a directory we created ourselves, so a failed
+        // attempt (403 without a licence, offline, not writable, the first
+        // file's transfer itself failing) leaves no empty tree. Checking
+        // emptiness at the moment of the throw — rather than a "did we start"
+        // flag — is what also keeps a concurrent download of the same
+        // component (callers must serialize anyway, since both write the same
+        // files) from having its now non-empty directory pulled out from
+        // under it.
         let createdDestination = !fm.fileExists(atPath: destDir.path)
         try fm.createDirectory(at: destDir, withIntermediateDirectories: true)
-        var transferStarted = false
         defer {
-            if createdDestination, !transferStarted,
+            if createdDestination,
                ((try? fm.contentsOfDirectory(atPath: destDir.path)) ?? []).isEmpty {
                 try? fm.removeItem(at: destDir)
             }
@@ -341,7 +315,6 @@ public class Flux2ModelDownloader: @unchecked Sendable {
         guard !filesToDownload.isEmpty else {
             throw Flux2DownloadError.modelNotFound("No model files found in \(repoId)")
         }
-        transferStarted = true
 
         // Download each file
         var downloadedBytes: Int64 = 0
@@ -523,9 +496,30 @@ public class Flux2ModelDownloader: @unchecked Sendable {
         guard let path = findModelPath(for: component, at: location) else {
             return
         }
+        // An override isn't the only way to relocate a component: the
+        // consumer app's own workflow leaves the *default* directory in
+        // place and replaces the big weight files inside it with symlinks.
+        // That directory isn't a disposable cache copy either.
+        let relocated = SafetensorsDirectory.symlinkedWeights(at: path)
+        guard relocated.isEmpty else {
+            throw Flux2DownloadError.deletionRefusedForRelocatedWeights(component.displayName, path)
+        }
 
         try FileManager.default.removeItem(at: path)
         Flux2Debug.log("Deleted \(component.displayName)")
+    }
+
+    /// Whether this component's weights are relocated — an explicit
+    /// `ModelRegistry.pathOverride`, or the default directory's `.safetensors`
+    /// files themselves being symlinks to another disk. Either way `delete()`
+    /// refuses to remove it. A read-only status query (e.g. for a UI icon);
+    /// it does not participate in `delete()`'s own guard, which re-derives
+    /// its own snapshot.
+    public static func isRelocated(_ component: ModelRegistry.ModelComponent) -> Bool {
+        let location = location(for: component)
+        if location.isOverride { return true }
+        guard let path = findModelPath(for: component, at: location) else { return false }
+        return !SafetensorsDirectory.symlinkedWeights(at: path).isEmpty
     }
 
     /// Get total size of downloaded models
@@ -626,6 +620,7 @@ public enum Flux2DownloadError: LocalizedError {
     case insufficientSpace(required: Int64, available: Int64)
     case invalidPathOverride(URL)
     case deletionRefusedForOverride(String)
+    case deletionRefusedForRelocatedWeights(String, URL)
     case destinationVolumeUnavailable(String, URL)
     case weightsUnreachable(String, URL, [String])
     case weightsRelocated(String, URL, missing: [String])
@@ -652,6 +647,8 @@ public enum Flux2DownloadError: LocalizedError {
             return "\(name)'s directory (\(url.path)) is not writable — is the volume mounted read-only?"
         case .deletionRefusedForOverride(let name):
             return "\(name) has a path override and was not deleted — that location may be its only copy (e.g. an external disk). Clear the override or remove the files manually."
+        case .deletionRefusedForRelocatedWeights(let name, let url):
+            return "\(name) at \(url.path) has weight files that are symlinks to another disk and was not deleted — the external copy may not exist anywhere else. Remove the files manually if you're sure."
         case .destinationVolumeUnavailable(let name, let url):
             return "\(name)'s directory (\(url.path)) is on a volume that isn't mounted — connect the external disk and retry."
         case .weightsRelocated(let name, let url, let missing):

--- a/Sources/Flux2Core/Loading/ModelDownloader.swift
+++ b/Sources/Flux2Core/Loading/ModelDownloader.swift
@@ -60,17 +60,49 @@ public class Flux2ModelDownloader: @unchecked Sendable {
     public static func unavailableReason(for component: ModelRegistry.ModelComponent) -> String? {
         let location = location(for: component)
         guard findModelPath(for: component, at: location) == nil else { return nil }
-        let unreachable = unreachableWeights(at: location.url)
-        if location.isOverride {
-            if isOnUnmountedVolume(location.url) || !unreachable.isEmpty {
-                return "Its path override (\(location.url.path)) is on a disk that isn't connected — connect it and retry."
-            }
-            return "Its path override (\(location.url.path)) holds no complete model — restore the files there or clear the override."
+        let dir = location.url
+        let where_ = location.isOverride ? "Its path override (\(dir.path))" : "Its directory (\(dir.path))"
+
+        if isDirectoryUnreadable(dir) {
+            return "\(where_) exists but can't be listed — under App Sandbox it must lie inside an active security-scoped resource."
         }
+        if isOnUnmountedVolume(dir) {
+            return "\(where_) is on a disk that isn't connected — connect it and retry."
+        }
+        let unreachable = unreachableWeights(at: dir)
         if !unreachable.isEmpty {
-            return "Its weight files are symlinks to a disk that isn't connected (\(unreachable.prefix(3).joined(separator: ", "))) — connect it and retry."
+            return "\(where_) has weight files that are symlinks to a disk that isn't connected (\(unreachable.prefix(3).joined(separator: ", "))) — connect it and retry."
+        }
+        let relocated = symlinkedWeights(at: dir)
+        if !relocated.isEmpty {
+            let missing = verifyModel(at: dir).missing.prefix(3).joined(separator: ", ")
+            return "\(where_) holds relocated weights (symlinks) but is incomplete (\(missing)) — restore the missing files at the relocation target; re-downloading here would replace the links with local copies."
+        }
+        if location.isOverride {
+            return "\(where_) holds no complete model — restore the files there or clear the override."
         }
         return nil
+    }
+
+    /// The directory exists (`stat` works) but can't be listed — under App
+    /// Sandbox that is a missing security scope, not an empty model.
+    static func isDirectoryUnreadable(_ directory: URL) -> Bool {
+        let fm = FileManager.default
+        return fm.fileExists(atPath: directory.path)
+            && (try? fm.contentsOfDirectory(atPath: directory.path)) == nil
+    }
+
+    /// Every `.safetensors` entry in `directory` that is a symlink, live or
+    /// dangling: the model was relocated, and `download()` must not write
+    /// into it (it would replace the links with local copies).
+    public static func symlinkedWeights(at directory: URL) -> [String] {
+        let fm = FileManager.default
+        let contents = (try? fm.contentsOfDirectory(atPath: directory.path)) ?? []
+        return contents.filter { name in
+            guard name.hasSuffix(".safetensors"), !name.hasPrefix("._") else { return false }
+            let attrs = try? fm.attributesOfItem(atPath: directory.appendingPathComponent(name).path)
+            return (attrs?[.type] as? FileAttributeType) == .typeSymbolicLink
+        }.sorted()
     }
 
     /// `.safetensors` entries in `directory` that exist as symlinks but whose
@@ -89,6 +121,15 @@ public class Flux2ModelDownloader: @unchecked Sendable {
             return !fm.fileExists(atPath: path)
         }.sorted()
     }
+
+    /// The legacy `huggingface_hub`-style cache searched as a last resort
+    /// (`~/.cache/huggingface/hub`). Overridable so tests don't depend on
+    /// whatever snapshots the current user has lying around.
+    nonisolated(unsafe) public static var legacyHubCacheDirectory: URL =
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cache")
+            .appendingPathComponent("huggingface")
+            .appendingPathComponent("hub")
 
     /// Find local path for a model component
     public static func findModelPath(for component: ModelRegistry.ModelComponent) -> URL? {
@@ -121,11 +162,7 @@ public class Flux2ModelDownloader: @unchecked Sendable {
         }
 
         // Check legacy HuggingFace cache
-        let homeDir = FileManager.default.homeDirectoryForCurrentUser
-        let hubCache = homeDir
-            .appendingPathComponent(".cache")
-            .appendingPathComponent("huggingface")
-            .appendingPathComponent("hub")
+        let hubCache = legacyHubCacheDirectory
 
         let modelFolder = "models--\(repoId.replacingOccurrences(of: "/", with: "--"))"
         let snapshotsDir = hubCache.appendingPathComponent(modelFolder).appendingPathComponent("snapshots")
@@ -231,39 +268,38 @@ public class Flux2ModelDownloader: @unchecked Sendable {
             return (false, ["No safetensors files found"])
         }
 
-        // Parse sharded pattern: <stem>-NNNNN-of-MMMMM.safetensors
-        var stem: String?
-        var totalShards: Int?
-        var foundIndices: Set<Int> = []
-
+        // Parse sharded pattern: <stem>-NNNNN-of-MMMMM.safetensors. Series are
+        // grouped by (stem, total) so a leftover shard of another series (a
+        // previous naming, an interrupted attempt) can neither complete nor
+        // break this one, whatever order the directory listing comes in.
+        struct Series: Hashable { let stem: String; let total: Int }
+        var found: [Series: Set<Int>] = [:]
         for file in safetensorsFiles {
             guard let shard = shardComponents(of: file) else { continue }
-            if totalShards == nil {
-                totalShards = shard.total
-                stem = shard.stem
-            }
-            foundIndices.insert(shard.index)
+            found[Series(stem: shard.stem, total: shard.total), default: []].insert(shard.index)
         }
 
-        if let total = totalShards, let stem {
-            let expectedIndices = Set(1...total)
-            let missing = expectedIndices.subtracting(foundIndices)
+        guard !found.isEmpty else { return (true, []) }
 
-            if missing.isEmpty {
-                return (true, [])
-            } else {
-                let missingFiles = missing.sorted().map {
-                    "\(stem)-\(String(format: "%05d", $0))-of-\(String(format: "%05d", total)).safetensors"
-                }
-                return (false, missingFiles)
+        // Complete if any one series is whole; otherwise report the missing
+        // shards of the series closest to completion.
+        var bestMissing: (series: Series, missing: [Int])?
+        for (series, indices) in found {
+            let missing = Set(1...series.total).subtracting(indices).sorted()
+            if missing.isEmpty { return (true, []) }
+            if bestMissing == nil || missing.count < bestMissing!.missing.count {
+                bestMissing = (series, missing)
             }
         }
-
-        return (true, [])
+        let best = bestMissing!
+        return (false, best.missing.map {
+            "\(best.series.stem)-\(String(format: "%05d", $0))-of-\(String(format: "%05d", best.series.total)).safetensors"
+        })
     }
 
     /// Splits `<stem>-NNNNN-of-MMMMM.safetensors` into its parts; `nil` for any
-    /// other name.
+    /// other name (or an implausible series: no real checkpoint has more than
+    /// a few hundred shards, and `Set(1...total)` must stay small).
     private static func shardComponents(of file: String) -> (stem: String, index: Int, total: Int)? {
         guard file.hasSuffix(".safetensors") else { return nil }
         let name = String(file.dropLast(".safetensors".count))
@@ -272,7 +308,7 @@ public class Flux2ModelDownloader: @unchecked Sendable {
               parts[parts.count - 2] == "of",
               let index = Int(parts[parts.count - 3]),
               let total = Int(parts[parts.count - 1]),
-              total > 0, index >= 1, index <= total else {
+              total > 0, total <= 10_000, index >= 1, index <= total else {
             return nil
         }
         return (parts.dropLast(3).joined(separator: "-"), index, total)
@@ -306,27 +342,39 @@ public class Flux2ModelDownloader: @unchecked Sendable {
         // re-downloading over the dangling links would silently undo the
         // relocation and orphan the external copy. Applies to the default
         // layout too — that is exactly how the consumer app relocates.
+        // Under App Sandbox, `stat` works everywhere but listing a directory
+        // outside an active security scope fails with EPERM. verifyModel
+        // swallows that into "no weights"; here it must not become a download.
+        if Self.isDirectoryUnreadable(destDir) {
+            throw Flux2DownloadError.destinationUnreadable(component.displayName, destDir)
+        }
+
         let unreachable = Self.unreachableWeights(at: destDir)
         if !unreachable.isEmpty {
             throw Flux2DownloadError.weightsUnreachable(component.displayName, destDir, unreachable)
         }
 
-        // An override normally points at removable storage. If its volume
-        // isn't mounted, `createDirectory(withIntermediateDirectories:)` would
-        // rebuild the whole missing tree on the boot volume and download into it.
-        if location.isOverride, Self.isOnUnmountedVolume(destDir) {
-            throw Flux2DownloadError.overrideVolumeUnavailable(component.displayName, destDir)
+        // Live links with a shard missing (interrupted relocation): downloading
+        // here would replace every live link with a local copy — the model
+        // must be repaired at the relocation target instead.
+        let relocated = Self.symlinkedWeights(at: destDir)
+        if !relocated.isEmpty {
+            throw Flux2DownloadError.weightsRelocated(component.displayName, destDir, relocated)
         }
 
-        // Under App Sandbox, `stat` works everywhere but listing a directory
-        // outside an active security scope fails with EPERM. verifyModel
-        // swallows that into "no weights"; here it must not become a download.
-        if fm.fileExists(atPath: destDir.path), (try? fm.contentsOfDirectory(atPath: destDir.path)) == nil {
-            throw Flux2DownloadError.destinationUnreadable(component.displayName, destDir)
+        // If the destination's volume isn't mounted, `createDirectory(
+        // withIntermediateDirectories:)` would rebuild the whole missing tree
+        // on the boot volume and download into it. Applies to a catalog root
+        // on removable storage (`--models-dir`) as much as to an override.
+        if Self.isOnUnmountedVolume(destDir) {
+            throw Flux2DownloadError.destinationVolumeUnavailable(component.displayName, destDir)
         }
 
         // Read-only volumes (NTFS by default, a dirty exFAT remounted read-only)
-        // pass every check above; probe writability before transferring.
+        // pass every check above; probe writability before transferring. The
+        // directory is created for the probe, and removed again if nothing
+        // gets downloaded into it (403 without a licence, offline, …).
+        let existedBefore = fm.fileExists(atPath: destDir.path)
         try fm.createDirectory(at: destDir, withIntermediateDirectories: true)
         guard fm.isWritableFile(atPath: destDir.path) else {
             throw Flux2DownloadError.destinationNotWritable(component.displayName, destDir)
@@ -338,23 +386,31 @@ public class Flux2ModelDownloader: @unchecked Sendable {
 
         Flux2Debug.log("Downloading \(component.displayName) from \(repoId)")
 
-        // Get file list from HuggingFace API
-        let files = try await fetchFileList(repoId: repoId, subfolder: subfolder)
+        let filesToDownload: [String]
+        do {
+            // Get file list from HuggingFace API
+            let files = try await fetchFileList(repoId: repoId, subfolder: subfolder)
 
-        // Filter to only necessary files. Small metadata first: if a write is
-        // still going to fail for a reason no probe can catch, it fails on a
-        // kilobyte of JSON rather than after a multi-gigabyte weight transfer.
-        let filesToDownload = files.filter { file in
-            file.hasSuffix(".safetensors") ||
-            file.hasSuffix(".json") ||
-            file == "tokenizer.model"
-        }.sorted { a, b in
-            let aWeight = a.hasSuffix(".safetensors"), bWeight = b.hasSuffix(".safetensors")
-            return aWeight == bWeight ? a < b : !aWeight
-        }
+            // Filter to only necessary files. Small metadata first: if a write
+            // is still going to fail for a reason no probe can catch, it fails
+            // on a kilobyte of JSON rather than after a multi-gigabyte weight.
+            filesToDownload = files.filter { file in
+                file.hasSuffix(".safetensors") ||
+                file.hasSuffix(".json") ||
+                file == "tokenizer.model"
+            }.sorted { a, b in
+                let aWeight = a.hasSuffix(".safetensors"), bWeight = b.hasSuffix(".safetensors")
+                return aWeight == bWeight ? a < b : !aWeight
+            }
 
-        guard !filesToDownload.isEmpty else {
-            throw Flux2DownloadError.modelNotFound("No model files found in \(repoId)")
+            guard !filesToDownload.isEmpty else {
+                throw Flux2DownloadError.modelNotFound("No model files found in \(repoId)")
+            }
+        } catch {
+            if !existedBefore, ((try? fm.contentsOfDirectory(atPath: destDir.path)) ?? []).isEmpty {
+                try? fm.removeItem(at: destDir)
+            }
+            throw error
         }
 
         // Download each file
@@ -640,8 +696,9 @@ public enum Flux2DownloadError: LocalizedError {
     case insufficientSpace(required: Int64, available: Int64)
     case invalidPathOverride(URL)
     case deletionRefusedForOverride(String)
-    case overrideVolumeUnavailable(String, URL)
+    case destinationVolumeUnavailable(String, URL)
     case weightsUnreachable(String, URL, [String])
+    case weightsRelocated(String, URL, [String])
     case destinationUnreadable(String, URL)
     case destinationNotWritable(String, URL)
 
@@ -665,8 +722,10 @@ public enum Flux2DownloadError: LocalizedError {
             return "\(name)'s directory (\(url.path)) is not writable — is the volume mounted read-only?"
         case .deletionRefusedForOverride(let name):
             return "\(name) has a path override and was not deleted — that location may be its only copy (e.g. an external disk). Clear the override or remove the files manually."
-        case .overrideVolumeUnavailable(let name, let url):
-            return "\(name)'s path override (\(url.path)) is on a volume that isn't mounted — connect the external disk and retry."
+        case .destinationVolumeUnavailable(let name, let url):
+            return "\(name)'s directory (\(url.path)) is on a volume that isn't mounted — connect the external disk and retry."
+        case .weightsRelocated(let name, let url, let files):
+            return "\(name) at \(url.path) holds relocated weight files (symlinks: \(files.prefix(3).joined(separator: ", "))) but is incomplete — restore the missing files at the relocation target; downloading here would replace the links with local copies."
         }
     }
 }

--- a/Sources/Flux2Core/Loading/PrequantizedCheckpoint.swift
+++ b/Sources/Flux2Core/Loading/PrequantizedCheckpoint.swift
@@ -121,11 +121,14 @@ public enum Flux2PrequantizedCheckpoint {
             return "unknown"
         }
         let parts: [String] = entries.filter { $0.hasSuffix(".safetensors") && !$0.hasPrefix("._") }.sorted().map { name in
-            // Follow a relocation symlink: the fingerprint must track the
-            // real bytes, not the link's own constant size/mtime.
+            // Follow a relocation symlink: the fingerprint must track the real
+            // bytes, not the link's own constant size/mtime. An unreachable
+            // target gets a sentinel rather than falling through to the link's
+            // own lstat data, which would read as "the weights changed" and
+            // send the user to re-export instead of to reconnect the disk.
             let path = sourceModelPath.appendingPathComponent(name).path
-            let statPath = fm.fileExists(atPath: path)
-                ? URL(fileURLWithPath: path).resolvingSymlinksInPath().path : path
+            guard fm.fileExists(atPath: path) else { return "\(name):unreachable" }
+            let statPath = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
             let attrs = try? fm.attributesOfItem(atPath: statPath)
             let size = (attrs?[.size] as? NSNumber)?.int64Value ?? -1
             let mtime = (attrs?[.modificationDate] as? Date)?.timeIntervalSince1970 ?? -1
@@ -207,6 +210,15 @@ public enum Flux2PrequantizedCheckpoint {
             ("group_size", String(quantization.groupSize)),
             ("mode", quantization.mode.rawValue),
             ("component", component),
+            // The source directory's name is part of the identity, not just
+            // informational: the fingerprint below is name/size/mtime, and two
+            // same-architecture models (a distilled variant and its base) have
+            // identical weight file names and sizes, so a fingerprint can
+            // legitimately collide. Dropping this check would let a path
+            // override aimed at the wrong sibling load its checkpoint silently.
+            // A directory moved wholesale therefore invalidates its checkpoint —
+            // a slow standard load plus a warning, which is the safe failure.
+            ("source", sourceModelPath.lastPathComponent),
         ]
         for (key, value) in expected where metadata[key] != value {
             Flux2Debug.warning(
@@ -218,13 +230,6 @@ public enum Flux2PrequantizedCheckpoint {
             Flux2Debug.warning(
                 "Pre-quantized checkpoint is stale (source weights changed since export — re-download or update?) — falling back to standard load. Re-run `flux2 export-quantized` with force to refresh: \(url.path)")
             return false
-        }
-        // The fingerprint is the identity; the directory name is informational
-        // only — a model directory moved wholesale under a path override keeps
-        // its checkpoint valid.
-        if let source = metadata["source"], source != sourceModelPath.lastPathComponent {
-            Flux2Debug.log(
-                "Pre-quantized checkpoint was exported under '\(source)', now loading from '\(sourceModelPath.lastPathComponent)' (same weights per fingerprint)")
         }
         return true
     }

--- a/Sources/Flux2Core/Loading/PrequantizedCheckpoint.swift
+++ b/Sources/Flux2Core/Loading/PrequantizedCheckpoint.swift
@@ -73,14 +73,40 @@ public enum Flux2PrequantizedCheckpoint {
 
     /// Remove the export for this source/quantization pair (idempotent).
     /// Used by `export(force:)` to guarantee regeneration from the source.
+    /// A symlinked checkpoint (relocated to another disk) is left alone:
+    /// unlinking it would orphan the external copy and the subsequent save
+    /// would rebuild ~10 GB locally — `isSymlinked` lets the caller refuse.
     public static func remove(
         sourceModelPath: URL,
         quantization: TransformerQuantization,
         component: String = "transformer"
     ) {
+        guard !isSymlinked(sourceModelPath: sourceModelPath, quantization: quantization, component: component)
+        else { return }
         let url = weightsURL(
             sourceModelPath: sourceModelPath, quantization: quantization, component: component)
         try? FileManager.default.removeItem(at: url)
+    }
+
+    /// Whether the checkpoint file for this pair is a symlink (relocated).
+    public static func isSymlinked(
+        sourceModelPath: URL,
+        quantization: TransformerQuantization,
+        component: String = "transformer"
+    ) -> Bool {
+        let url = weightsURL(
+            sourceModelPath: sourceModelPath, quantization: quantization, component: component)
+        let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
+        return (attrs?[.type] as? FileAttributeType) == .typeSymbolicLink
+    }
+
+    /// stat-following size (a relocated checkpoint is a symlink; `URL`
+    /// resource values report the link's own length).
+    private static func fileSize(at url: URL) -> Int64? {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: url.path) else { return nil }
+        let resolved = url.resolvingSymlinksInPath()
+        return (try? fm.attributesOfItem(atPath: resolved.path))?[.size] as? Int64
     }
 
     // MARK: - Source fingerprint
@@ -94,9 +120,13 @@ public enum Flux2PrequantizedCheckpoint {
         guard let entries = try? fm.contentsOfDirectory(atPath: sourceModelPath.path) else {
             return "unknown"
         }
-        let parts: [String] = entries.filter { $0.hasSuffix(".safetensors") }.sorted().map { name in
-            let attrs = try? fm.attributesOfItem(
-                atPath: sourceModelPath.appendingPathComponent(name).path)
+        let parts: [String] = entries.filter { $0.hasSuffix(".safetensors") && !$0.hasPrefix("._") }.sorted().map { name in
+            // Follow a relocation symlink: the fingerprint must track the
+            // real bytes, not the link's own constant size/mtime.
+            let path = sourceModelPath.appendingPathComponent(name).path
+            let statPath = fm.fileExists(atPath: path)
+                ? URL(fileURLWithPath: path).resolvingSymlinksInPath().path : path
+            let attrs = try? fm.attributesOfItem(atPath: statPath)
             let size = (attrs?[.size] as? NSNumber)?.int64Value ?? -1
             let mtime = (attrs?[.modificationDate] as? Date)?.timeIntervalSince1970 ?? -1
             return "\(name):\(size):\(Int(mtime))"
@@ -131,8 +161,7 @@ public enum Flux2PrequantizedCheckpoint {
             maxEnd = max(maxEnd, end)
         }
         let expectedSize = Int64(8) + Int64(headerLen) + maxEnd
-        let actualSize = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize)
-            .map(Int64.init) ?? -1
+        let actualSize = fileSize(at: url) ?? -1
         if actualSize != expectedSize {
             Flux2Debug.warning(
                 "Pre-quantized checkpoint payload is incomplete (\(actualSize) bytes on disk, header declares \(expectedSize)) — the file is truncated or corrupt: \(url.path)")
@@ -178,7 +207,6 @@ public enum Flux2PrequantizedCheckpoint {
             ("group_size", String(quantization.groupSize)),
             ("mode", quantization.mode.rawValue),
             ("component", component),
-            ("source", sourceModelPath.lastPathComponent),
         ]
         for (key, value) in expected where metadata[key] != value {
             Flux2Debug.warning(
@@ -190,6 +218,13 @@ public enum Flux2PrequantizedCheckpoint {
             Flux2Debug.warning(
                 "Pre-quantized checkpoint is stale (source weights changed since export — re-download or update?) — falling back to standard load. Re-run `flux2 export-quantized` with force to refresh: \(url.path)")
             return false
+        }
+        // The fingerprint is the identity; the directory name is informational
+        // only — a model directory moved wholesale under a path override keeps
+        // its checkpoint valid.
+        if let source = metadata["source"], source != sourceModelPath.lastPathComponent {
+            Flux2Debug.log(
+                "Pre-quantized checkpoint was exported under '\(source)', now loading from '\(sourceModelPath.lastPathComponent)' (same weights per fingerprint)")
         }
         return true
     }

--- a/Sources/Flux2Core/Loading/WeightLoader.swift
+++ b/Sources/Flux2Core/Loading/WeightLoader.swift
@@ -14,7 +14,13 @@ public class Flux2WeightLoader {
     public static func loadWeights(from modelPath: String) throws -> [String: MLXArray] {
         let fm = FileManager.default
         let contents = try fm.contentsOfDirectory(atPath: modelPath)
-        let safetensorFiles = contents.filter { $0.hasSuffix(".safetensors") }.sorted()
+        // Same predicate as Flux2ModelDownloader.verifyModel: `._*` entries are
+        // AppleDouble sidecars (exFAT/NTFS), and a dangling symlink isn't a
+        // weight file — feeding either to loadArrays yields an opaque header error.
+        let safetensorFiles = contents.filter {
+            $0.hasSuffix(".safetensors") && !$0.hasPrefix("._")
+                && fm.fileExists(atPath: (modelPath as NSString).appendingPathComponent($0))
+        }.sorted()
 
         if safetensorFiles.isEmpty {
             throw Flux2WeightLoaderError.noWeightsFound(modelPath)
@@ -568,6 +574,8 @@ public class Flux2WeightLoader {
         _ weights: inout [String: MLXArray],
         to model: Flux2Transformer2DModel
     ) throws {
+        // mapTransformerWeights drains the inout dictionary; count first.
+        let loadedCount = weights.count
         let mapped = mapTransformerWeights(&weights)
 
         // Use MLX's built-in weight loading - flatten to get full paths
@@ -613,11 +621,14 @@ public class Flux2WeightLoader {
         // override) maps zero keys; loading it silently would produce noise.
         guard !updates.isEmpty else {
             throw Flux2Error.modelNotLoaded(
-                "None of the \(weights.count) loaded tensors match the transformer — the weight files belong to a different model or component")
+                "None of the \(loadedCount) loaded tensors match the transformer — the weight files belong to a different model or component")
         }
 
-        // Update model with new weights using the flattened format
-        _ = model.update(parameters: ModuleParameters.unflattened(updates))
+        // Update model with new weights using the flattened format. Shape
+        // verification turns a same-family wrong-variant directory (Klein 4B
+        // weights for a 9B config) into an error here instead of a Metal
+        // matmul abort at the first forward.
+        _ = try model.update(parameters: ModuleParameters.unflattened(updates), verify: .shapeMismatch)
 
         // Debug: print some weight shapes
         for (key, value) in updates.sorted(by: { $0.key < $1.key }).prefix(10) {
@@ -678,7 +689,7 @@ public class Flux2WeightLoader {
                 "None of the \(weights.count) loaded tensors match the VAE — the weight files belong to a different model or component")
         }
 
-        _ = model.update(parameters: ModuleParameters.unflattened(updates))
+        _ = try model.update(parameters: ModuleParameters.unflattened(updates), verify: .shapeMismatch)
 
         Flux2Debug.log("Applied \(updates.count) weights to VAE (\(notFound) not found)")
     }

--- a/Sources/Flux2Core/Loading/WeightLoader.swift
+++ b/Sources/Flux2Core/Loading/WeightLoader.swift
@@ -2,6 +2,7 @@
 // Copyright 2025 Vincent Gourbin
 
 import Foundation
+import FluxTextEncoders
 import MLX
 import MLXNN
 
@@ -12,15 +13,11 @@ public class Flux2WeightLoader {
     /// - Parameter modelPath: Path to directory containing safetensors files
     /// - Returns: Dictionary of weight name to MLXArray
     public static func loadWeights(from modelPath: String) throws -> [String: MLXArray] {
-        let fm = FileManager.default
-        let contents = try fm.contentsOfDirectory(atPath: modelPath)
-        // Same predicate as Flux2ModelDownloader.verifyModel: `._*` entries are
-        // AppleDouble sidecars (exFAT/NTFS), and a dangling symlink isn't a
-        // weight file — feeding either to loadArrays yields an opaque header error.
-        let safetensorFiles = contents.filter {
-            $0.hasSuffix(".safetensors") && !$0.hasPrefix("._")
-                && fm.fileExists(atPath: (modelPath as NSString).appendingPathComponent($0))
-        }.sorted()
+        // Same predicate the verifiers use: `._*` AppleDouble sidecars and
+        // dangling relocation symlinks are not loadable weights — feeding
+        // either to loadArrays yields an opaque header error.
+        let safetensorFiles = SafetensorsDirectory.reachableWeights(
+            at: URL(fileURLWithPath: modelPath, isDirectory: true))
 
         if safetensorFiles.isEmpty {
             throw Flux2WeightLoaderError.noWeightsFound(modelPath)

--- a/Sources/Flux2Core/Loading/WeightLoader.swift
+++ b/Sources/Flux2Core/Loading/WeightLoader.swift
@@ -13,11 +13,14 @@ public class Flux2WeightLoader {
     /// - Parameter modelPath: Path to directory containing safetensors files
     /// - Returns: Dictionary of weight name to MLXArray
     public static func loadWeights(from modelPath: String) throws -> [String: MLXArray] {
-        // Same predicate the verifiers use: `._*` AppleDouble sidecars and
-        // dangling relocation symlinks are not loadable weights — feeding
-        // either to loadArrays yields an opaque header error.
-        let safetensorFiles = SafetensorsDirectory.reachableWeights(
-            at: URL(fileURLWithPath: modelPath, isDirectory: true))
+        // Same series ModelDownloader.verifyModel verified complete — not
+        // every reachable .safetensors file, so a stray leftover shard from
+        // an earlier download or revision can't silently merge its tensors
+        // into the result. `._*` AppleDouble sidecars and dangling relocation
+        // symlinks are excluded the same way the verifier excludes them.
+        let safetensorFiles = SafetensorsDirectory.filesToLoad(
+            at: URL(fileURLWithPath: modelPath, isDirectory: true),
+            singleFilePrefixes: ["flux-2-klein"])
 
         if safetensorFiles.isEmpty {
             throw Flux2WeightLoaderError.noWeightsFound(modelPath)

--- a/Sources/Flux2Core/Loading/WeightLoader.swift
+++ b/Sources/Flux2Core/Loading/WeightLoader.swift
@@ -608,6 +608,14 @@ public class Flux2WeightLoader {
             Flux2Debug.log("... and \(notFound - 10) more missing parameters")
         }
 
+        // A directory that verified as "a model" but holds another component's
+        // weights (e.g. a VAE-only folder handed to the transformer via a path
+        // override) maps zero keys; loading it silently would produce noise.
+        guard !updates.isEmpty else {
+            throw Flux2Error.modelNotLoaded(
+                "None of the \(weights.count) loaded tensors match the transformer — the weight files belong to a different model or component")
+        }
+
         // Update model with new weights using the flattened format
         _ = model.update(parameters: ModuleParameters.unflattened(updates))
 
@@ -663,6 +671,11 @@ public class Flux2WeightLoader {
 
         if notFound > 10 {
             Flux2Debug.log("... and \(notFound - 10) more missing VAE parameters")
+        }
+
+        guard !updates.isEmpty else {
+            throw Flux2Error.modelNotLoaded(
+                "None of the \(weights.count) loaded tensors match the VAE — the weight files belong to a different model or component")
         }
 
         _ = model.update(parameters: ModuleParameters.unflattened(updates))

--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
@@ -820,14 +820,17 @@ public class Flux2Pipeline: @unchecked Sendable {
         // transformer loaded from a *different* directory (a path override
         // set or cleared since the load): the exists/remove decision above was
         // made against `sourcePath`, and the save must write there too.
-        if transformerSourcePath != sourcePath, transformerHasMergedLoRAs {
-            // The reload from `sourcePath` could only warn: the LoRA matrices
-            // were consumed by the fusion, so the session would silently
-            // continue base-only while `hasLoRA` still says true.
+        // Any unload below discards LoRA matrices that fusion already consumed:
+        // the reload can only warn, and the session would silently continue
+        // base-only while `hasLoRA` still says true. Guard on exactly the
+        // predicate that triggers the unload, or the check misses the case it
+        // was written for (resident checkpoint load, unchanged source path).
+        let mustReload = transformerLoadedFromPrequantized || transformerSourcePath != sourcePath
+        if mustReload, transformerHasMergedLoRAs {
             throw Flux2Error.invalidConfiguration(
-                "The resident transformer has merged LoRA weights and was loaded from \(transformerSourcePath?.path ?? "?"), but the export resolves to \(sourcePath.path) — unload the LoRAs (or reload them after the export) before exporting.")
+                "The resident transformer has merged LoRA weights (loaded from \(transformerSourcePath?.path ?? "?")) and this export has to reload it from \(sourcePath.path) — the merged matrices cannot be recovered. Unload the LoRAs, or reload them after the export.")
         }
-        if transformerLoadedFromPrequantized || transformerSourcePath != sourcePath {
+        if mustReload {
             unloadTransformer()
         }
         if Flux2PrequantizedCheckpoint.isSymlinked(
@@ -844,6 +847,14 @@ public class Flux2Pipeline: @unchecked Sendable {
 
         guard let transformer, let loadedSourcePath = transformerSourcePath else {
             throw Flux2Error.modelNotLoaded("Transformer not loaded — cannot export")
+        }
+        // `loadTransformer()` resolves the source path again internally. If a
+        // path override changed during the load (it blocks on multi-GB I/O),
+        // every decision above — exists/isValid/remove/isSymlinked — was made
+        // against a different directory than the one the save would write to.
+        guard loadedSourcePath == sourcePath else {
+            throw Flux2Error.invalidConfiguration(
+                "The transformer's location changed during the export (checked \(sourcePath.path), loaded \(loadedSourcePath.path)) — a path override was set or cleared mid-run. Retry the export.")
         }
         // Bake check AFTER the load, against the instance actually being
         // saved: `transformerHasMergedLoRAs` survives unloadLoRA (merged

--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
@@ -545,10 +545,18 @@ public class Flux2Pipeline: @unchecked Sendable {
             // Load weights with explicit memory management
             // For large models (Dev), this can temporarily use 2x memory during mapping
             Flux2Debug.log("Loading transformer weights from disk...")
-            var weights = try Flux2WeightLoader.loadWeights(from: modelPath)
-
-            Flux2Debug.log("Applying weights to model...")
-            try Flux2WeightLoader.applyTransformerWeights(&weights, to: transformer!)
+            var weights: [String: MLXArray]
+            do {
+                weights = try Flux2WeightLoader.loadWeights(from: modelPath)
+                Flux2Debug.log("Applying weights to model...")
+                try Flux2WeightLoader.applyTransformerWeights(&weights, to: transformer!)
+            } catch {
+                // `transformer` was assigned above; leaving a randomly
+                // initialised instance resident would make every later call
+                // short-circuit `guard transformer == nil` and produce noise.
+                unloadTransformer()
+                throw error
+            }
 
             // Explicitly release the raw weights dictionary to free memory
             // This is important for Dev model where weights can be ~32GB
@@ -721,14 +729,20 @@ public class Flux2Pipeline: @unchecked Sendable {
         // Load weights — prefer diffusion_pytorch_model.safetensors (standard diffusers file)
         // to avoid conflicts when directory contains multiple safetensors files
         let standardWeightsFile = weightsPath.appendingPathComponent("diffusion_pytorch_model.safetensors")
-        let weights: [String: MLXArray]
-        if FileManager.default.fileExists(atPath: standardWeightsFile.path) {
-            Flux2Debug.log("Loading VAE weights from diffusion_pytorch_model.safetensors")
-            weights = try Flux2WeightLoader.loadWeights(from: standardWeightsFile)
-        } else {
-            weights = try Flux2WeightLoader.loadWeights(from: weightsPath)
+        do {
+            let weights: [String: MLXArray]
+            if FileManager.default.fileExists(atPath: standardWeightsFile.path) {
+                Flux2Debug.log("Loading VAE weights from diffusion_pytorch_model.safetensors")
+                weights = try Flux2WeightLoader.loadWeights(from: standardWeightsFile)
+            } else {
+                weights = try Flux2WeightLoader.loadWeights(from: weightsPath)
+            }
+            try Flux2WeightLoader.applyVAEWeights(weights, to: vae!)
+        } catch {
+            // Don't leave a randomly initialised VAE resident (see loadTransformer).
+            vae = nil
+            throw error
         }
-        try Flux2WeightLoader.applyVAEWeights(weights, to: vae!)
 
         // Ensure weights are evaluated
         eval(vae!.parameters())
@@ -806,8 +820,23 @@ public class Flux2Pipeline: @unchecked Sendable {
         // transformer loaded from a *different* directory (a path override
         // set or cleared since the load): the exists/remove decision above was
         // made against `sourcePath`, and the save must write there too.
+        if transformerSourcePath != sourcePath, transformerHasMergedLoRAs {
+            // The reload from `sourcePath` could only warn: the LoRA matrices
+            // were consumed by the fusion, so the session would silently
+            // continue base-only while `hasLoRA` still says true.
+            throw Flux2Error.invalidConfiguration(
+                "The resident transformer has merged LoRA weights and was loaded from \(transformerSourcePath?.path ?? "?"), but the export resolves to \(sourcePath.path) — unload the LoRAs (or reload them after the export) before exporting.")
+        }
         if transformerLoadedFromPrequantized || transformerSourcePath != sourcePath {
             unloadTransformer()
+        }
+        if Flux2PrequantizedCheckpoint.isSymlinked(
+            sourceModelPath: sourcePath, quantization: quantization.transformer)
+        {
+            // remove() left the link alone; saving would replace it with a
+            // local file and silently undo the relocation.
+            throw Flux2Error.invalidConfiguration(
+                "The existing pre-quantized checkpoint under \(sourcePath.path) is a symlink (relocated to another disk) — regenerate it at the relocation target, or remove the link, before exporting here.")
         }
         skipPrequantizedCheckpoint = true
         defer { skipPrequantizedCheckpoint = false }

--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
@@ -841,11 +841,13 @@ public class Flux2Pipeline: @unchecked Sendable {
                 "The existing pre-quantized checkpoint under \(sourcePath.path) is a symlink (relocated to another disk) — regenerate it at the relocation target, or remove the link, before exporting here.")
         }
 
-        // Past this point the export mutates state.
-        if checkpointExists {
-            Flux2PrequantizedCheckpoint.remove(
-                sourceModelPath: sourcePath, quantization: quantization.transformer)
-        }
+        // Past this point the export mutates state — but not the existing
+        // checkpoint file: `save()` below writes to a temp file and replaces
+        // it atomically, so there is no need to (and must not) delete it
+        // ahead of the fallible reload/quantize/save that follows. Deleting
+        // it here would leave the user with NEITHER checkpoint if that reload
+        // then failed (disk I/O, OOM, a shape mismatch) — `force` regenerating
+        // from source is not worth losing the current file over.
         if mustReload {
             unloadTransformer()
         }

--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
@@ -503,7 +503,8 @@ public class Flux2Pipeline: @unchecked Sendable {
             case .klein9BKV:
                 downloadCmd = "flux2 download --model klein-9b-kv"
             }
-            throw Flux2Error.modelNotLoaded("\(model.displayName) transformer weights not found. Run: \(downloadCmd)")
+            let hint = Flux2ModelDownloader.unavailableReason(for: .transformer(variant)) ?? "Run: \(downloadCmd)"
+            throw Flux2Error.modelNotLoaded("\(model.displayName) transformer weights not found. \(hint)")
         }
 
         // Create model with appropriate config and memory optimization
@@ -695,7 +696,8 @@ public class Flux2Pipeline: @unchecked Sendable {
         Flux2Debug.log("Loading VAE (\(vaeVariant.displayName))...")
 
         guard let modelPath = Flux2ModelDownloader.findModelPath(for: .vae(vaeVariant)) else {
-            throw Flux2Error.modelNotLoaded("VAE weights not found for variant: \(vaeVariant.rawValue)")
+            let hint = Flux2ModelDownloader.unavailableReason(for: .vae(vaeVariant)).map { " \($0)" } ?? ""
+            throw Flux2Error.modelNotLoaded("VAE weights not found for variant: \(vaeVariant.rawValue).\(hint)")
         }
 
         // VAE files may be in 'vae' subdirectory (standard variant from Klein 4B repo)
@@ -773,8 +775,9 @@ public class Flux2Pipeline: @unchecked Sendable {
         let variant = ModelRegistry.TransformerVariant.variant(
             for: model, quantization: quantization.transformer)
         guard let sourcePath = Flux2ModelDownloader.findModelPath(for: .transformer(variant)) else {
-            throw Flux2Error.modelNotLoaded(
-                "\(model.displayName) transformer weights not found — download the model before exporting")
+            let hint = Flux2ModelDownloader.unavailableReason(for: .transformer(variant))
+                ?? "download the model before exporting"
+            throw Flux2Error.modelNotLoaded("\(model.displayName) transformer weights not found — \(hint)")
         }
 
         if Flux2PrequantizedCheckpoint.exists(
@@ -799,8 +802,11 @@ public class Flux2Pipeline: @unchecked Sendable {
 
         // The export must derive from the SOURCE weights, never from a
         // previous export: drop a checkpoint-loaded resident transformer and
-        // disable the fast path for the (re)load below.
-        if transformerLoadedFromPrequantized {
+        // disable the fast path for the (re)load below. Also drop a resident
+        // transformer loaded from a *different* directory (a path override
+        // set or cleared since the load): the exists/remove decision above was
+        // made against `sourcePath`, and the save must write there too.
+        if transformerLoadedFromPrequantized || transformerSourcePath != sourcePath {
             unloadTransformer()
         }
         skipPrequantizedCheckpoint = true
@@ -832,6 +838,7 @@ public class Flux2Pipeline: @unchecked Sendable {
         compiledForward = nil
         compiledForwardKey = nil
         transformer = nil
+        transformerSourcePath = nil
         transformerHasMergedLoRAs = false
         transformerLoadedFromPrequantized = false
         memoryManager.clearCache()

--- a/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
+++ b/Sources/Flux2Core/Pipeline/Flux2Pipeline.swift
@@ -794,52 +794,60 @@ public class Flux2Pipeline: @unchecked Sendable {
             throw Flux2Error.modelNotLoaded("\(model.displayName) transformer weights not found — \(hint)")
         }
 
-        if Flux2PrequantizedCheckpoint.exists(
+        let checkpointExists = Flux2PrequantizedCheckpoint.exists(
             sourceModelPath: sourcePath, quantization: quantization.transformer)
+
+        // Without force, only a VALID existing checkpoint is a no-op; an
+        // invalid/stale squatter is regenerated (the load-side warning tells
+        // users to re-run the export — that advice must work).
+        if checkpointExists, !force,
+           Flux2PrequantizedCheckpoint.isValid(
+               sourceModelPath: sourcePath, quantization: quantization.transformer)
         {
-            // Without force, only a VALID existing checkpoint is a no-op; an
-            // invalid/stale squatter is regenerated (the load-side warning
-            // tells users to re-run the export — that advice must work).
-            if !force,
-               Flux2PrequantizedCheckpoint.isValid(
-                   sourceModelPath: sourcePath, quantization: quantization.transformer)
-            {
-                let url = Flux2PrequantizedCheckpoint.weightsURL(
-                    sourceModelPath: sourcePath, quantization: quantization.transformer)
-                Flux2Debug.log(
-                    "Pre-quantized checkpoint already exists and is valid — nothing to do (pass force to regenerate from the source weights): \(url.path)")
-                return url
-            }
-            Flux2PrequantizedCheckpoint.remove(
+            let url = Flux2PrequantizedCheckpoint.weightsURL(
                 sourceModelPath: sourcePath, quantization: quantization.transformer)
+            Flux2Debug.log(
+                "Pre-quantized checkpoint already exists and is valid — nothing to do (pass force to regenerate from the source weights): \(url.path)")
+            return url
         }
 
-        // The export must derive from the SOURCE weights, never from a
-        // previous export: drop a checkpoint-loaded resident transformer and
-        // disable the fast path for the (re)load below. Also drop a resident
-        // transformer loaded from a *different* directory (a path override
-        // set or cleared since the load): the exists/remove decision above was
-        // made against `sourcePath`, and the save must write there too.
-        // Any unload below discards LoRA matrices that fusion already consumed:
-        // the reload can only warn, and the session would silently continue
-        // base-only while `hasLoRA` still says true. Guard on exactly the
-        // predicate that triggers the unload, or the check misses the case it
-        // was written for (resident checkpoint load, unchanged source path).
+        // Every reason to refuse is a pure predicate, so all of them run BEFORE
+        // anything is mutated: an export that aborts must not have deleted the
+        // user's existing checkpoint (`force` makes that ~10 GB irreversible)
+        // nor evicted a resident multi-GB transformer.
+
+        // The export must derive from the SOURCE weights, never from a previous
+        // export, so a checkpoint-loaded resident transformer has to be
+        // reloaded — as does one loaded from a *different* directory (a path
+        // override set or cleared since the load), since the decisions here are
+        // all made against `sourcePath` and the save must write there too.
+        // That reload discards LoRA matrices fusion already consumed: it can
+        // only warn, and the session would silently continue base-only while
+        // `hasLoRA` still says true. Guard on exactly the predicate that
+        // triggers the unload, or the check misses the case it was written for
+        // (resident checkpoint load, unchanged source path).
         let mustReload = transformerLoadedFromPrequantized || transformerSourcePath != sourcePath
         if mustReload, transformerHasMergedLoRAs {
             throw Flux2Error.invalidConfiguration(
                 "The resident transformer has merged LoRA weights (loaded from \(transformerSourcePath?.path ?? "?")) and this export has to reload it from \(sourcePath.path) — the merged matrices cannot be recovered. Unload the LoRAs, or reload them after the export.")
         }
-        if mustReload {
-            unloadTransformer()
-        }
         if Flux2PrequantizedCheckpoint.isSymlinked(
             sourceModelPath: sourcePath, quantization: quantization.transformer)
         {
-            // remove() left the link alone; saving would replace it with a
-            // local file and silently undo the relocation.
+            // Saving would replace the link with a local file and silently undo
+            // the relocation (`remove()` refuses to unlink it for the same
+            // reason), so refuse before touching anything.
             throw Flux2Error.invalidConfiguration(
                 "The existing pre-quantized checkpoint under \(sourcePath.path) is a symlink (relocated to another disk) — regenerate it at the relocation target, or remove the link, before exporting here.")
+        }
+
+        // Past this point the export mutates state.
+        if checkpointExists {
+            Flux2PrequantizedCheckpoint.remove(
+                sourceModelPath: sourcePath, quantization: quantization.transformer)
+        }
+        if mustReload {
+            unloadTransformer()
         }
         skipPrequantizedCheckpoint = true
         defer { skipPrequantizedCheckpoint = false }

--- a/Sources/FluxTextEncoders/Loading/SafetensorsDirectory.swift
+++ b/Sources/FluxTextEncoders/Loading/SafetensorsDirectory.swift
@@ -94,6 +94,47 @@ public enum SafetensorsDirectory {
         })
     }
 
+    /// The exact `.safetensors` file names that make up "the" model in
+    /// `directory` — the ones `verifySeries` found complete, not every
+    /// reachable `.safetensors` file.
+    ///
+    /// A directory can accumulate a stray leftover from an earlier download
+    /// or a different HF revision (e.g. a different shard count). Loading
+    /// every reachable file regardless of which series it belongs to would
+    /// silently merge that leftover's tensors into the result by key, with
+    /// no error. Falls back to every reachable file when no recognisable
+    /// series exists at all (an unusual layout) or none is complete —
+    /// callers only reach here after `verifySeries`/`findModelPath` already
+    /// confirmed completeness, so this is a defensive fallback, not the
+    /// expected path.
+    public static func filesToLoad(
+        at directory: URL,
+        singleFileNames: Set<String> = ["model.safetensors", "diffusion_pytorch_model.safetensors"],
+        singleFilePrefixes: [String] = []
+    ) -> [String] {
+        let weights = reachableWeights(at: directory)
+
+        if let single = weights.first(where: { singleFileNames.contains($0) }) {
+            return [single]
+        }
+        if !singleFilePrefixes.isEmpty {
+            let matches = weights.filter { name in singleFilePrefixes.contains { name.hasPrefix($0) } }
+            if !matches.isEmpty { return matches }
+        }
+
+        struct Series: Hashable { let stem: String; let total: Int }
+        var found: [Series: [Int: String]] = [:]
+        for file in weights {
+            guard let shard = shardComponents(of: file) else { continue }
+            found[Series(stem: shard.stem, total: shard.total), default: [:]][shard.index] = file
+        }
+        if let complete = found.first(where: { $0.key.total == $0.value.count }) {
+            return complete.value.sorted { $0.key < $1.key }.map { $0.value }
+        }
+
+        return weights
+    }
+
     /// Splits `<stem>-NNNNN-of-MMMMM.safetensors` into its parts; `nil` for any
     /// other name (or an implausible series — no real checkpoint has thousands
     /// of shards, and the index set built from it must stay small).
@@ -113,5 +154,49 @@ public enum SafetensorsDirectory {
 
     private static func isWeightName(_ name: String) -> Bool {
         name.hasSuffix(".safetensors") && !name.hasPrefix("._")
+    }
+
+    /// The path exists (`stat` works) but can't be listed as a directory —
+    /// under App Sandbox a missing security scope, otherwise a plain file
+    /// sitting where a model directory belongs.
+    public static func isDirectoryUnreadable(_ directory: URL) -> Bool {
+        let fm = FileManager.default
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: directory.path, isDirectory: &isDir), isDir.boolValue else {
+            return false
+        }
+        return (try? fm.contentsOfDirectory(atPath: directory.path)) == nil
+    }
+
+    /// True when `url` lives under `/Volumes` but not on a mounted volume: its
+    /// nearest existing ancestor is on the *boot* volume (same volume
+    /// identifier as `/`). That covers both an absent mount point (ancestor is
+    /// `/Volumes`) and a ghost mount-point directory left behind on the boot
+    /// volume after an unclean unmount. A missing subfolder on a mounted disk
+    /// resolves to an ancestor on that disk and is fine.
+    ///
+    /// Mounts outside `/Volumes` (`hdiutil -mountpoint`, sshfs under `$HOME`)
+    /// can't be told apart from a plain directory this way and are not
+    /// detected; the guard's job is a clear error *before* any network
+    /// transfer, not a complete mount oracle.
+    public static func isOnUnmountedVolume(_ url: URL) -> Bool {
+        let fm = FileManager.default
+        var ancestor = url.standardizedFileURL
+        while !fm.fileExists(atPath: ancestor.path) {
+            let parent = ancestor.deletingLastPathComponent()
+            if parent.path == ancestor.path { return false }
+            ancestor = parent
+        }
+        // The ancestor exists, so resolving is safe (the pitfall of
+        // resolvingSymlinksInPath only concerns dangling links).
+        let resolved = ancestor.resolvingSymlinksInPath()
+        let components = resolved.pathComponents
+        guard components.count >= 2, components[1].caseInsensitiveCompare("Volumes") == .orderedSame else {
+            return false
+        }
+        guard let ancestorVolume = try? resolved.resourceValues(forKeys: [.volumeIdentifierKey]).volumeIdentifier,
+              let rootVolume = try? URL(fileURLWithPath: "/").resourceValues(forKeys: [.volumeIdentifierKey]).volumeIdentifier
+        else { return components.count == 2 }
+        return ancestorVolume.isEqual(rootVolume)
     }
 }

--- a/Sources/FluxTextEncoders/Loading/SafetensorsDirectory.swift
+++ b/Sources/FluxTextEncoders/Loading/SafetensorsDirectory.swift
@@ -72,7 +72,13 @@ public enum SafetensorsDirectory {
 
         guard !weights.isEmpty else { return (false, ["No safetensors files found"]) }
 
-        struct Series: Hashable { let stem: String; let total: Int }
+        struct Series: Hashable, Comparable {
+            let stem: String
+            let total: Int
+            static func < (a: Series, b: Series) -> Bool {
+                a.stem != b.stem ? a.stem < b.stem : a.total < b.total
+            }
+        }
         var found: [Series: Set<Int>] = [:]
         for file in weights {
             guard let shard = shardComponents(of: file) else { continue }
@@ -80,10 +86,15 @@ public enum SafetensorsDirectory {
         }
         guard !found.isEmpty else { return (true, []) }
 
-        // Complete if any one series is whole; otherwise report the missing
-        // shards of the series closest to completion.
+        // Complete if any one series is whole (order-independent — `true` is
+        // `true` no matter which complete series was found first). Otherwise
+        // report the missing shards of the series closest to completion,
+        // breaking a tie by (stem, total) rather than `Dictionary`'s
+        // per-process-randomized iteration order, so the reported filenames
+        // don't vary run to run for the same on-disk state.
         var best: (series: Series, missing: [Int])?
-        for (series, indices) in found {
+        for series in found.keys.sorted() {
+            let indices = found[series]!
             let missing = Set(1...series.total).subtracting(indices).sorted()
             if missing.isEmpty { return (true, []) }
             if best == nil || missing.count < best!.missing.count { best = (series, missing) }
@@ -122,14 +133,27 @@ public enum SafetensorsDirectory {
             if !matches.isEmpty { return matches }
         }
 
-        struct Series: Hashable { let stem: String; let total: Int }
+        struct Series: Hashable, Comparable {
+            let stem: String
+            let total: Int
+            static func < (a: Series, b: Series) -> Bool {
+                a.stem != b.stem ? a.stem < b.stem : a.total < b.total
+            }
+        }
         var found: [Series: [Int: String]] = [:]
         for file in weights {
             guard let shard = shardComponents(of: file) else { continue }
             found[Series(stem: shard.stem, total: shard.total), default: [:]][shard.index] = file
         }
-        if let complete = found.first(where: { $0.key.total == $0.value.count }) {
-            return complete.value.sorted { $0.key < $1.key }.map { $0.value }
+        // `Dictionary` iteration order is randomized per process, so picking
+        // "first complete" without a tiebreak would make the choice between
+        // two independently-complete series (e.g. a stale one left behind by
+        // an upstream re-shard) vary run to run — the loaded weights would
+        // silently differ with no error. Sorting by (stem, total) makes the
+        // pick deterministic; which series wins is otherwise arbitrary since
+        // nothing here can know which one is "current".
+        if let complete = found.filter({ $0.key.total == $0.value.count }).keys.sorted().first {
+            return found[complete]!.sorted { $0.key < $1.key }.map { $0.value }
         }
 
         return weights

--- a/Sources/FluxTextEncoders/Loading/SafetensorsDirectory.swift
+++ b/Sources/FluxTextEncoders/Loading/SafetensorsDirectory.swift
@@ -1,0 +1,117 @@
+// SafetensorsDirectory.swift - Shared inspection of a model weight directory
+// Copyright 2025 Vincent Gourbin
+
+import Foundation
+
+/// How a model directory's `.safetensors` files look on disk.
+///
+/// Lives in `FluxTextEncoders` because `Flux2Core` depends on it: both
+/// downloaders (and their weight loaders) need the exact same answers about
+/// reachability, relocation symlinks and shard series. They used to carry
+/// separate copies, which is how the shard-series fix landed in one verifier
+/// and not the other.
+public enum SafetensorsDirectory {
+
+    /// `.safetensors` entries whose bytes are reachable right now.
+    ///
+    /// `fileExists` is `stat`-based and follows symlinks, so a weight relocated
+    /// to an external disk that is unplugged (a dangling link) is *not*
+    /// reachable. `._*` entries are AppleDouble sidecars written by macOS on
+    /// exFAT/NTFS volumes and are never weights — feeding one to
+    /// `loadArrays` yields an opaque "invalid json header length" error.
+    public static func reachableWeights(at directory: URL) -> [String] {
+        let fm = FileManager.default
+        let contents = (try? fm.contentsOfDirectory(atPath: directory.path)) ?? []
+        return contents.filter { name in
+            isWeightName(name) && fm.fileExists(atPath: directory.appendingPathComponent(name).path)
+        }.sorted()
+    }
+
+    /// `.safetensors` entries that are symlinks, live or dangling: the model
+    /// was relocated per-file to another disk. Writing into such a directory
+    /// replaces the links with local copies and orphans the external payload.
+    public static func symlinkedWeights(at directory: URL) -> [String] {
+        let fm = FileManager.default
+        let contents = (try? fm.contentsOfDirectory(atPath: directory.path)) ?? []
+        return contents.filter { name in
+            guard isWeightName(name) else { return false }
+            let attrs = try? fm.attributesOfItem(atPath: directory.appendingPathComponent(name).path)
+            return (attrs?[.type] as? FileAttributeType) == .typeSymbolicLink
+        }.sorted()
+    }
+
+    /// Symlinked weights whose target can't be reached — the relocation disk
+    /// isn't connected.
+    public static func unreachableWeights(at directory: URL) -> [String] {
+        let fm = FileManager.default
+        return symlinkedWeights(at: directory).filter {
+            !fm.fileExists(atPath: directory.appendingPathComponent($0).path)
+        }
+    }
+
+    /// Whether the reachable weights form a complete model, and which shards
+    /// are missing if not.
+    ///
+    /// Shards are recognised by their `-NNNNN-of-MMMMM` suffix whatever the
+    /// stem (`model-…`, `diffusion_pytorch_model-…`) and grouped by
+    /// (stem, total), so a leftover shard of another series can neither
+    /// complete nor break the real one, whatever order the listing comes in.
+    /// `singleFileNames` are stems accepted on their own (a one-file model).
+    public static func verifySeries(
+        at directory: URL,
+        singleFileNames: Set<String> = ["model.safetensors", "diffusion_pytorch_model.safetensors"],
+        singleFilePrefixes: [String] = []
+    ) -> (complete: Bool, missing: [String]) {
+        let weights = reachableWeights(at: directory)
+
+        if weights.contains(where: { singleFileNames.contains($0) }) { return (true, []) }
+        if !singleFilePrefixes.isEmpty,
+           weights.contains(where: { name in singleFilePrefixes.contains { name.hasPrefix($0) } }) {
+            return (true, [])
+        }
+
+        guard !weights.isEmpty else { return (false, ["No safetensors files found"]) }
+
+        struct Series: Hashable { let stem: String; let total: Int }
+        var found: [Series: Set<Int>] = [:]
+        for file in weights {
+            guard let shard = shardComponents(of: file) else { continue }
+            found[Series(stem: shard.stem, total: shard.total), default: []].insert(shard.index)
+        }
+        guard !found.isEmpty else { return (true, []) }
+
+        // Complete if any one series is whole; otherwise report the missing
+        // shards of the series closest to completion.
+        var best: (series: Series, missing: [Int])?
+        for (series, indices) in found {
+            let missing = Set(1...series.total).subtracting(indices).sorted()
+            if missing.isEmpty { return (true, []) }
+            if best == nil || missing.count < best!.missing.count { best = (series, missing) }
+        }
+        let closest = best!
+        return (false, closest.missing.map {
+            "\(closest.series.stem)-\(String(format: "%05d", $0))-of-\(String(format: "%05d", closest.series.total)).safetensors"
+        })
+    }
+
+    /// Splits `<stem>-NNNNN-of-MMMMM.safetensors` into its parts; `nil` for any
+    /// other name (or an implausible series — no real checkpoint has thousands
+    /// of shards, and the index set built from it must stay small).
+    public static func shardComponents(of file: String) -> (stem: String, index: Int, total: Int)? {
+        guard file.hasSuffix(".safetensors") else { return nil }
+        let name = String(file.dropLast(".safetensors".count))
+        let parts = name.split(separator: "-", omittingEmptySubsequences: false)
+        guard parts.count >= 4,
+              parts[parts.count - 2] == "of",
+              let index = Int(parts[parts.count - 3]),
+              let total = Int(parts[parts.count - 1]),
+              total > 0, total <= 10_000, index >= 1, index <= total else {
+            return nil
+        }
+        return (parts.dropLast(3).joined(separator: "-"), index, total)
+    }
+
+    private static func isWeightName(_ name: String) -> Bool {
+        name.hasSuffix(".safetensors") && !name.hasPrefix("._")
+    }
+}

--- a/Sources/FluxTextEncoders/Loading/TextEncoderModelDownloader.swift
+++ b/Sources/FluxTextEncoders/Loading/TextEncoderModelDownloader.swift
@@ -160,20 +160,36 @@ public class TextEncoderModelDownloader {
         SafetensorsDirectory.symlinkedWeights(at: directory)
     }
 
-    /// Refuse to let `hubApi.snapshot` write into a directory whose weights
-    /// are relocation symlinks. Once `verifyShardedModel` follows symlinks, a
-    /// relocated model with its disk unplugged reads "not downloaded"; the
-    /// Hub client would then unlink each dangling link and drop a local copy
-    /// in its place — silently undoing the relocation and orphaning the
-    /// external copy. Same for a live-but-incomplete series, where the fix is
-    /// to restore the missing shards at the relocation target instead.
+    /// Refuse to let `hubApi.snapshot` write into a directory that isn't a
+    /// safe destination — checked before any network activity, same
+    /// precedence Flux2Core's `destinationProblem` uses, so the two
+    /// downloaders fail the same way for the same causes:
+    ///
+    /// 1. Unreadable (App Sandbox: `stat` works outside an active security
+    ///    scope, `contentsOfDirectory` doesn't) — must not read as "empty".
+    /// 2. On an unmounted `/Volumes` disk — `HubApi`'s own
+    ///    `createDirectory(withIntermediateDirectories:)` has no such check,
+    ///    so without this it silently rebuilds the path on the boot volume.
+    /// 3. Relocation symlinks. Once `verifyShardedModel` follows symlinks, a
+    ///    relocated model with its disk unplugged reads "not downloaded"; the
+    ///    Hub client would then unlink each dangling link and drop a local
+    ///    copy in its place — silently undoing the relocation and orphaning
+    ///    the external copy. Same for a live-but-incomplete series, where the
+    ///    fix is to restore the missing shards at the relocation target.
     private static func refuseIfRelocated(repoId: String) throws {
         for destination in hubDestinations(repoId: repoId) {
+            if SafetensorsDirectory.isDirectoryUnreadable(destination) {
+                throw TextEncoderModelDownloaderError.destinationUnreadable(destination)
+            }
+            if SafetensorsDirectory.isOnUnmountedVolume(destination) {
+                throw TextEncoderModelDownloaderError.destinationVolumeUnavailable(destination)
+            }
             let links = SafetensorsDirectory.symlinkedWeights(at: destination)
             guard !links.isEmpty else { continue }
             let unreachable = SafetensorsDirectory.unreachableWeights(at: destination)
             throw unreachable.isEmpty
-                ? TextEncoderModelDownloaderError.weightsRelocated(destination, links)
+                ? TextEncoderModelDownloaderError.weightsRelocated(
+                    destination, missing: SafetensorsDirectory.verifySeries(at: destination).missing)
                 : TextEncoderModelDownloaderError.weightsUnreachable(destination, unreachable)
         }
     }
@@ -709,15 +725,21 @@ public enum TextEncoderModelDownloaderError: LocalizedError {
     case qwen35ModelNotFound
     case downloadFailed(String)
     case invalidToken
-    case weightsRelocated(URL, [String])
+    case weightsRelocated(URL, missing: [String])
     case weightsUnreachable(URL, [String])
+    case destinationUnreadable(URL)
+    case destinationVolumeUnavailable(URL)
 
     public var errorDescription: String? {
         switch self {
         case .weightsUnreachable(let url, let files):
             return "\(url.path) has weight files that are symlinks to a disk that isn't connected (\(files.prefix(3).joined(separator: ", "))) — connect it and retry; downloading here would replace the links with local copies."
-        case .weightsRelocated(let url, let files):
-            return "\(url.path) holds relocated weight files (symlinks: \(files.prefix(3).joined(separator: ", "))) but is incomplete — restore the missing shards at the relocation target; downloading here would replace the live links with local copies."
+        case .weightsRelocated(let url, let missing):
+            return "\(url.path) holds relocated weight files (symlinks) but is incomplete (\(missing.prefix(3).joined(separator: ", "))) — restore the missing shards at the relocation target; downloading here would replace the live links with local copies."
+        case .destinationUnreadable(let url):
+            return "\(url.path) exists but can't be listed — under App Sandbox it must lie inside an active security-scoped resource."
+        case .destinationVolumeUnavailable(let url):
+            return "\(url.path) is on a volume that isn't mounted — connect the external disk and retry."
         case .modelNotFound:
             return "Model not found"
         case .qwen3ModelNotFound:

--- a/Sources/FluxTextEncoders/Loading/TextEncoderModelDownloader.swift
+++ b/Sources/FluxTextEncoders/Loading/TextEncoderModelDownloader.swift
@@ -133,8 +133,16 @@ public class TextEncoderModelDownloader {
     /// Note: Does NOT trust index.json as some HF repos have mismatched index files
     /// Instead, detects safetensors files and verifies the series is complete
     public static func verifyShardedModel(at path: URL) -> (complete: Bool, missing: [String]) {
-        let contents = (try? FileManager.default.contentsOfDirectory(atPath: path.path)) ?? []
-        let safetensorsFiles = contents.filter { $0.hasSuffix(".safetensors") }
+        let fm = FileManager.default
+        let contents = (try? fm.contentsOfDirectory(atPath: path.path)) ?? []
+        // Only weights whose bytes are reachable count: `fileExists` is
+        // stat-based and follows symlinks, so a weight relocated to an
+        // external disk that is unplugged (dangling link) is missing, not
+        // present-by-name. `._` entries are AppleDouble sidecars on exFAT.
+        let safetensorsFiles = contents.filter {
+            $0.hasSuffix(".safetensors") && !$0.hasPrefix("._")
+                && fm.fileExists(atPath: path.appendingPathComponent($0).path)
+        }
 
         // Single file model
         if safetensorsFiles.contains("model.safetensors") {

--- a/Sources/FluxTextEncoders/Loading/TextEncoderModelDownloader.swift
+++ b/Sources/FluxTextEncoders/Loading/TextEncoderModelDownloader.swift
@@ -129,6 +129,41 @@ public class TextEncoderModelDownloader {
         return nil
     }
 
+    /// Where `hubApi.snapshot(from: repoId)` writes: `{hubDownloadDirectory}/{org}/{repo}`.
+    static func hubDestination(repoId: String) -> URL {
+        var url = hubDownloadDirectory
+        for component in repoId.split(separator: "/") {
+            url = url.appendingPathComponent(String(component))
+        }
+        return url
+    }
+
+    /// `.safetensors` entries in `directory` that are symlinks (live or
+    /// dangling): the model was relocated per-file to another disk.
+    public static func symlinkedWeights(at directory: URL) -> [String] {
+        let fm = FileManager.default
+        let contents = (try? fm.contentsOfDirectory(atPath: directory.path)) ?? []
+        return contents.filter { name in
+            guard name.hasSuffix(".safetensors"), !name.hasPrefix("._") else { return false }
+            let attrs = try? fm.attributesOfItem(atPath: directory.appendingPathComponent(name).path)
+            return (attrs?[.type] as? FileAttributeType) == .typeSymbolicLink
+        }.sorted()
+    }
+
+    /// Refuse to let `hubApi.snapshot` write into a directory whose weights
+    /// are relocation symlinks. Once `verifyShardedModel` follows symlinks, a
+    /// relocated model with its disk unplugged reads "not downloaded"; the
+    /// Hub client would then unlink each dangling link and drop a local copy
+    /// in its place — silently undoing the relocation and orphaning the
+    /// external copy. Same for a live-but-incomplete series.
+    private static func refuseIfRelocated(repoId: String) throws {
+        let destination = hubDestination(repoId: repoId)
+        let links = symlinkedWeights(at: destination)
+        if !links.isEmpty {
+            throw TextEncoderModelDownloaderError.weightsRelocated(destination, links)
+        }
+    }
+
     /// Verify that a sharded model has all required safetensors files
     /// Note: Does NOT trust index.json as some HF repos have mismatched index files
     /// Instead, detects safetensors files and verifies the series is complete
@@ -218,6 +253,7 @@ public class TextEncoderModelDownloader {
                 print("Re-downloading...")
             }
         }
+        try Self.refuseIfRelocated(repoId: model.repoId)
 
         progress?(0.0, "Starting download of \(model.name)...")
         print("\nDownloading \(model.name) from HuggingFace...")
@@ -314,6 +350,7 @@ public class TextEncoderModelDownloader {
                 print("Re-downloading...")
             }
         }
+        try Self.refuseIfRelocated(repoId: model.repoId)
 
         progress?(0.0, "Starting download of \(model.name)...")
         print("\nDownloading \(model.name) from HuggingFace...")
@@ -475,6 +512,7 @@ public class TextEncoderModelDownloader {
                 print("Re-downloading...")
             }
         }
+        try Self.refuseIfRelocated(repoId: model.repoId)
 
         progress?(0.0, "Starting download of \(model.name)...")
         print("\nDownloading \(model.name) from HuggingFace...")
@@ -591,6 +629,7 @@ public class TextEncoderModelDownloader {
                 return existingPath
             }
         }
+        try Self.refuseIfRelocated(repoId: model.repoId)
 
         progress?(0.0, "Starting download of \(model.name)...")
         print("\nDownloading \(model.name) from HuggingFace...")
@@ -656,6 +695,7 @@ public class TextEncoderModelDownloader {
         _ repoId: String,
         progress: TextEncoderDownloadProgressCallback? = nil
     ) async throws -> URL {
+        try Self.refuseIfRelocated(repoId: repoId)
         progress?(0.0, "Starting download...")
         print("\nDownloading from HuggingFace: \(repoId)")
 
@@ -719,9 +759,12 @@ public enum TextEncoderModelDownloaderError: LocalizedError {
     case qwen35ModelNotFound
     case downloadFailed(String)
     case invalidToken
+    case weightsRelocated(URL, [String])
 
     public var errorDescription: String? {
         switch self {
+        case .weightsRelocated(let url, let files):
+            return "\(url.path) holds relocated weight files (symlinks: \(files.prefix(3).joined(separator: ", "))) that are missing or unreachable — connect the disk or restore them at the relocation target; downloading here would replace the links with local copies."
         case .modelNotFound:
             return "Model not found"
         case .qwen3ModelNotFound:

--- a/Sources/FluxTextEncoders/Loading/TextEncoderModelDownloader.swift
+++ b/Sources/FluxTextEncoders/Loading/TextEncoderModelDownloader.swift
@@ -129,25 +129,35 @@ public class TextEncoderModelDownloader {
         return nil
     }
 
-    /// Where `hubApi.snapshot(from: repoId)` writes: `{hubDownloadDirectory}/{org}/{repo}`.
-    static func hubDestination(repoId: String) -> URL {
-        var url = hubDownloadDirectory
-        for component in repoId.split(separator: "/") {
-            url = url.appendingPathComponent(String(component))
+    /// Every directory a `hubApi.snapshot(from: repoId)` could land in.
+    ///
+    /// `makeHubApi` passes `downloadBase = customModelsDirectory.deletingLastPathComponent()`
+    /// and `HubApi` then appends its repo-type component (`models`) plus the
+    /// repo id, so the real write location only coincides with
+    /// `hubDownloadDirectory` — what `hubCachePath` looks up — when the
+    /// configured directory is itself named `models`. Guarding both covers
+    /// either naming.
+    static func hubDestinations(repoId: String) -> [URL] {
+        let repoComponents = repoId.split(separator: "/").map(String.init)
+        func appendRepo(to base: URL) -> URL {
+            repoComponents.reduce(base) { $0.appendingPathComponent($1) }
         }
-        return url
+        let lookupBase = hubDownloadDirectory
+        let writeBase = (customModelsDirectory?.deletingLastPathComponent()
+            ?? FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!)
+            .appendingPathComponent("models")
+        var destinations = [appendRepo(to: lookupBase)]
+        let writeDestination = appendRepo(to: writeBase)
+        if writeDestination.standardized != destinations[0].standardized {
+            destinations.append(writeDestination)
+        }
+        return destinations
     }
 
     /// `.safetensors` entries in `directory` that are symlinks (live or
     /// dangling): the model was relocated per-file to another disk.
     public static func symlinkedWeights(at directory: URL) -> [String] {
-        let fm = FileManager.default
-        let contents = (try? fm.contentsOfDirectory(atPath: directory.path)) ?? []
-        return contents.filter { name in
-            guard name.hasSuffix(".safetensors"), !name.hasPrefix("._") else { return false }
-            let attrs = try? fm.attributesOfItem(atPath: directory.appendingPathComponent(name).path)
-            return (attrs?[.type] as? FileAttributeType) == .typeSymbolicLink
-        }.sorted()
+        SafetensorsDirectory.symlinkedWeights(at: directory)
     }
 
     /// Refuse to let `hubApi.snapshot` write into a directory whose weights
@@ -155,12 +165,16 @@ public class TextEncoderModelDownloader {
     /// relocated model with its disk unplugged reads "not downloaded"; the
     /// Hub client would then unlink each dangling link and drop a local copy
     /// in its place — silently undoing the relocation and orphaning the
-    /// external copy. Same for a live-but-incomplete series.
+    /// external copy. Same for a live-but-incomplete series, where the fix is
+    /// to restore the missing shards at the relocation target instead.
     private static func refuseIfRelocated(repoId: String) throws {
-        let destination = hubDestination(repoId: repoId)
-        let links = symlinkedWeights(at: destination)
-        if !links.isEmpty {
-            throw TextEncoderModelDownloaderError.weightsRelocated(destination, links)
+        for destination in hubDestinations(repoId: repoId) {
+            let links = SafetensorsDirectory.symlinkedWeights(at: destination)
+            guard !links.isEmpty else { continue }
+            let unreachable = SafetensorsDirectory.unreachableWeights(at: destination)
+            throw unreachable.isEmpty
+                ? TextEncoderModelDownloaderError.weightsRelocated(destination, links)
+                : TextEncoderModelDownloaderError.weightsUnreachable(destination, unreachable)
         }
     }
 
@@ -168,71 +182,7 @@ public class TextEncoderModelDownloader {
     /// Note: Does NOT trust index.json as some HF repos have mismatched index files
     /// Instead, detects safetensors files and verifies the series is complete
     public static func verifyShardedModel(at path: URL) -> (complete: Bool, missing: [String]) {
-        let fm = FileManager.default
-        let contents = (try? fm.contentsOfDirectory(atPath: path.path)) ?? []
-        // Only weights whose bytes are reachable count: `fileExists` is
-        // stat-based and follows symlinks, so a weight relocated to an
-        // external disk that is unplugged (dangling link) is missing, not
-        // present-by-name. `._` entries are AppleDouble sidecars on exFAT.
-        let safetensorsFiles = contents.filter {
-            $0.hasSuffix(".safetensors") && !$0.hasPrefix("._")
-                && fm.fileExists(atPath: path.appendingPathComponent($0).path)
-        }
-
-        // Single file model
-        if safetensorsFiles.contains("model.safetensors") {
-            return (true, [])
-        }
-
-        // No safetensors files at all
-        guard !safetensorsFiles.isEmpty else {
-            return (false, ["No safetensors files found"])
-        }
-
-        // Parse sharded file pattern: model-XXXXX-of-YYYYY.safetensors
-        // Example: model-00001-of-00003.safetensors
-        var totalShards: Int?
-        var foundIndices: Set<Int> = []
-
-        for file in safetensorsFiles {
-            // Parse filename like "model-00001-of-00003.safetensors"
-            let name = file.replacingOccurrences(of: ".safetensors", with: "")
-            let parts = name.split(separator: "-")
-            // Expected: ["model", "00001", "of", "00003"]
-            guard parts.count == 4,
-                  parts[0] == "model",
-                  parts[2] == "of",
-                  let index = Int(parts[1]),
-                  let total = Int(parts[3]) else {
-                continue
-            }
-
-            if totalShards == nil {
-                totalShards = total
-            } else if totalShards != total {
-                // Inconsistent totals - mixed files
-                return (false, ["Inconsistent shard totals: \(totalShards!) vs \(total)"])
-            }
-
-            foundIndices.insert(index)
-        }
-
-        // If we found sharded files, verify all parts are present
-        if let total = totalShards {
-            let expectedIndices = Set(1...total)
-            let missing = expectedIndices.subtracting(foundIndices)
-
-            if missing.isEmpty {
-                return (true, [])
-            } else {
-                let missingFiles = missing.sorted().map { "model-\(String(format: "%05d", $0))-of-\(String(format: "%05d", total)).safetensors" }
-                return (false, missingFiles)
-            }
-        }
-
-        // Has some safetensors files but not in standard sharded format
-        // Consider it complete if there are any safetensors files
-        return (true, [])
+        SafetensorsDirectory.verifySeries(at: path, singleFileNames: ["model.safetensors"])
     }
 
     /// Download a model using Hub API
@@ -760,11 +710,14 @@ public enum TextEncoderModelDownloaderError: LocalizedError {
     case downloadFailed(String)
     case invalidToken
     case weightsRelocated(URL, [String])
+    case weightsUnreachable(URL, [String])
 
     public var errorDescription: String? {
         switch self {
+        case .weightsUnreachable(let url, let files):
+            return "\(url.path) has weight files that are symlinks to a disk that isn't connected (\(files.prefix(3).joined(separator: ", "))) — connect it and retry; downloading here would replace the links with local copies."
         case .weightsRelocated(let url, let files):
-            return "\(url.path) holds relocated weight files (symlinks: \(files.prefix(3).joined(separator: ", "))) that are missing or unreachable — connect the disk or restore them at the relocation target; downloading here would replace the links with local copies."
+            return "\(url.path) holds relocated weight files (symlinks: \(files.prefix(3).joined(separator: ", "))) but is incomplete — restore the missing shards at the relocation target; downloading here would replace the live links with local copies."
         case .modelNotFound:
             return "Model not found"
         case .qwen3ModelNotFound:

--- a/Sources/FluxTextEncoders/Loading/TextEncoderWeightLoader.swift
+++ b/Sources/FluxTextEncoders/Loading/TextEncoderWeightLoader.swift
@@ -12,10 +12,14 @@ public class TextEncoderWeightLoader {
 
     /// Load all weights from a model directory
     public static func loadWeights(from modelPath: String) throws -> [String: MLXArray] {
-        // Same predicate as the verifiers: `._*` AppleDouble sidecars and
-        // dangling relocation symlinks are not loadable weights.
-        let safetensorFiles = SafetensorsDirectory.reachableWeights(
-            at: URL(fileURLWithPath: modelPath, isDirectory: true))
+        // Same series TextEncoderModelDownloader.verifyShardedModel verified
+        // complete — not every reachable .safetensors file, so a stray
+        // leftover shard can't silently merge its tensors into the result.
+        // `._*` AppleDouble sidecars and dangling relocation symlinks are
+        // excluded the same way the verifier excludes them.
+        let safetensorFiles = SafetensorsDirectory.filesToLoad(
+            at: URL(fileURLWithPath: modelPath, isDirectory: true),
+            singleFileNames: ["model.safetensors"])
 
         if safetensorFiles.isEmpty {
             throw TextEncoderWeightLoaderError.noWeightsFound

--- a/Sources/FluxTextEncoders/Loading/TextEncoderWeightLoader.swift
+++ b/Sources/FluxTextEncoders/Loading/TextEncoderWeightLoader.swift
@@ -12,9 +12,10 @@ public class TextEncoderWeightLoader {
 
     /// Load all weights from a model directory
     public static func loadWeights(from modelPath: String) throws -> [String: MLXArray] {
-        let fm = FileManager.default
-        let contents = try fm.contentsOfDirectory(atPath: modelPath)
-        let safetensorFiles = contents.filter { $0.hasSuffix(".safetensors") }.sorted()
+        // Same predicate as the verifiers: `._*` AppleDouble sidecars and
+        // dangling relocation symlinks are not loadable weights.
+        let safetensorFiles = SafetensorsDirectory.reachableWeights(
+            at: URL(fileURLWithPath: modelPath, isDirectory: true))
 
         if safetensorFiles.isEmpty {
             throw TextEncoderWeightLoaderError.noWeightsFound

--- a/Sources/FluxTextEncoders/Model/MistralModel.swift
+++ b/Sources/FluxTextEncoders/Model/MistralModel.swift
@@ -290,9 +290,12 @@ extension MistralForCausalLM {
         }
 
         // Find safetensors files
-        let fm = FileManager.default
-        let contents = try fm.contentsOfDirectory(atPath: modelPath)
-        let safetensorFiles = contents.filter { $0.hasSuffix(".safetensors") }.sorted()
+        // Same series the verifier confirmed complete — not every reachable
+        // .safetensors file, so a stray leftover shard from an earlier
+        // download/revision can't silently merge its tensors into the result.
+        // Excludes AppleDouble `._*` sidecars and dangling relocation symlinks.
+        let safetensorFiles = SafetensorsDirectory.filesToLoad(
+            at: URL(fileURLWithPath: modelPath, isDirectory: true))
 
         if safetensorFiles.isEmpty {
             throw MistralModelError.noWeightsFound

--- a/Sources/FluxTextEncoders/Model/Qwen3/Qwen3Model.swift
+++ b/Sources/FluxTextEncoders/Model/Qwen3/Qwen3Model.swift
@@ -346,9 +346,12 @@ extension Qwen3ForCausalLM {
         }
 
         // Find safetensors files
-        let fm = FileManager.default
-        let contents = try fm.contentsOfDirectory(atPath: modelPath)
-        let safetensorFiles = contents.filter { $0.hasSuffix(".safetensors") }.sorted()
+        // Same series the verifier confirmed complete — not every reachable
+        // .safetensors file, so a stray leftover shard from an earlier
+        // download/revision can't silently merge its tensors into the result.
+        // Excludes AppleDouble `._*` sidecars and dangling relocation symlinks.
+        let safetensorFiles = SafetensorsDirectory.filesToLoad(
+            at: URL(fileURLWithPath: modelPath, isDirectory: true))
 
         if safetensorFiles.isEmpty {
             throw Qwen3ModelError.noWeightsFound

--- a/Sources/FluxTextEncoders/Model/Qwen35/Qwen35Model.swift
+++ b/Sources/FluxTextEncoders/Model/Qwen35/Qwen35Model.swift
@@ -228,9 +228,12 @@ extension Qwen35ForConditionalGeneration {
         }
 
         // Find safetensors
-        let fm = FileManager.default
-        let contents = try fm.contentsOfDirectory(atPath: modelPath)
-        let safetensorFiles = contents.filter { $0.hasSuffix(".safetensors") }.sorted()
+        // Same series the verifier confirmed complete — not every reachable
+        // .safetensors file, so a stray leftover shard from an earlier
+        // download/revision can't silently merge its tensors into the result.
+        // Excludes AppleDouble `._*` sidecars and dangling relocation symlinks.
+        let safetensorFiles = SafetensorsDirectory.filesToLoad(
+            at: URL(fileURLWithPath: modelPath, isDirectory: true))
 
         guard !safetensorFiles.isEmpty else {
             throw Qwen35ModelError.noWeightsFound

--- a/Sources/FluxTextEncoders/Model/Qwen35/Qwen35VLM.swift
+++ b/Sources/FluxTextEncoders/Model/Qwen35/Qwen35VLM.swift
@@ -298,9 +298,12 @@ extension Qwen35VLM {
         // Only the language model is quantized. Do NOT call quantize() on visionEncoder.
 
         // Load vision weights
-        let fm = FileManager.default
-        let contents = try fm.contentsOfDirectory(atPath: modelPath)
-        let safetensorFiles = contents.filter { $0.hasSuffix(".safetensors") }.sorted()
+        // Same series the verifier confirmed complete — not every reachable
+        // .safetensors file, so a stray leftover shard from an earlier
+        // download/revision can't silently merge its tensors into the result.
+        // Excludes AppleDouble `._*` sidecars and dangling relocation symlinks.
+        let safetensorFiles = SafetensorsDirectory.filesToLoad(
+            at: URL(fileURLWithPath: modelPath, isDirectory: true))
 
         var visionWeights: [String: MLXArray] = [:]
         for filename in safetensorFiles {

--- a/Sources/FluxTextEncoders/Model/Qwen3VL/Qwen3VLModel.swift
+++ b/Sources/FluxTextEncoders/Model/Qwen3VL/Qwen3VLModel.swift
@@ -309,9 +309,12 @@ extension Qwen3VLForCausalLM {
         }
 
         // Find safetensors files
-        let fm = FileManager.default
-        let contents = try fm.contentsOfDirectory(atPath: modelPath)
-        let safetensorFiles = contents.filter { $0.hasSuffix(".safetensors") }.sorted()
+        // Same series the verifier confirmed complete — not every reachable
+        // .safetensors file, so a stray leftover shard from an earlier
+        // download/revision can't silently merge its tensors into the result.
+        // Excludes AppleDouble `._*` sidecars and dangling relocation symlinks.
+        let safetensorFiles = SafetensorsDirectory.filesToLoad(
+            at: URL(fileURLWithPath: modelPath, isDirectory: true))
 
         if safetensorFiles.isEmpty {
             throw Qwen3VLModelError.noWeightsFound

--- a/Sources/FluxTextEncoders/Vision/MistralVLM.swift
+++ b/Sources/FluxTextEncoders/Vision/MistralVLM.swift
@@ -601,10 +601,13 @@ extension MistralVLM {
         debugPrint("[VLM] Model created."); fflush(stdout)
         logMemory("After model creation (random weights)")
 
-        // Find and load safetensors files FIRST to check which components are quantized
-        let fm = FileManager.default
-        let contents = try fm.contentsOfDirectory(atPath: modelPath)
-        let safetensorFiles = contents.filter { $0.hasSuffix(".safetensors") }.sorted()
+        // Find and load safetensors files FIRST to check which components are quantized.
+        // Same series the verifier confirmed complete — not every reachable
+        // .safetensors file, so a stray leftover shard from an earlier
+        // download/revision can't silently merge its tensors into the result.
+        // Excludes AppleDouble `._*` sidecars and dangling relocation symlinks.
+        let safetensorFiles = SafetensorsDirectory.filesToLoad(
+            at: URL(fileURLWithPath: modelPath, isDirectory: true))
 
         if safetensorFiles.isEmpty {
             throw MistralModelError.noWeightsFound

--- a/Tests/Flux2CoreTests/ModelDownloaderSizeTests.swift
+++ b/Tests/Flux2CoreTests/ModelDownloaderSizeTests.swift
@@ -24,9 +24,12 @@ final class ModelDownloaderSizeTests: XCTestCase {
             .appendingPathComponent("flux2-modelsize-\(UUID().uuidString)")
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let previous = ModelRegistry.customModelsDirectory
+        let previousHub = Flux2ModelDownloader.legacyHubCacheDirectory
         ModelRegistry.customModelsDirectory = dir
+        Flux2ModelDownloader.legacyHubCacheDirectory = dir.appendingPathComponent("no-hub-cache")
         defer {
             ModelRegistry.customModelsDirectory = previous
+            Flux2ModelDownloader.legacyHubCacheDirectory = previousHub
             try? FileManager.default.removeItem(at: dir)
         }
         return try body(dir)
@@ -149,6 +152,31 @@ final class ModelDownloaderSizeTests: XCTestCase {
             try Data(repeating: 0x42, count: 8).write(to: link)
         }
         XCTAssertTrue(Flux2ModelDownloader.verifyModel(at: dir).complete)
+    }
+
+    func testVerifyModelSeriesAreGroupedByStemAndTotal() throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("flux2-series-\(UUID().uuidString)")
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: dir) }
+        let write = { (name: String) in
+            try Data(repeating: 0x42, count: 8).write(to: dir.appendingPathComponent(name))
+        }
+
+        // A complete 2-shard series plus a leftover shard of a 7-shard series:
+        // complete, whatever order the listing yields.
+        try write("model-00001-of-00002.safetensors")
+        try write("model-00002-of-00002.safetensors")
+        try write("diffusion_pytorch_model-00001-of-00007.safetensors")
+        XCTAssertTrue(Flux2ModelDownloader.verifyModel(at: dir).complete)
+
+        // Two half series of different stems must not union into "complete".
+        try fm.removeItem(at: dir.appendingPathComponent("model-00001-of-00002.safetensors"))
+        try fm.removeItem(at: dir.appendingPathComponent("diffusion_pytorch_model-00001-of-00007.safetensors"))
+        try write("diffusion_pytorch_model-00001-of-00002.safetensors")
+        let result = Flux2ModelDownloader.verifyModel(at: dir)
+        XCTAssertFalse(result.complete)
+        XCTAssertEqual(result.missing.count, 1)
     }
 
     func testVerifyModelIgnoresAppleDoubleSidecars() throws {

--- a/Tests/Flux2CoreTests/ModelDownloaderSizeTests.swift
+++ b/Tests/Flux2CoreTests/ModelDownloaderSizeTests.swift
@@ -117,6 +117,52 @@ final class ModelDownloaderSizeTests: XCTestCase {
         }
     }
 
+    func testVerifyModelDiffusersShardsRequireTheWholeReachableSeries() throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("flux2-shards-\(UUID().uuidString)")
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: dir) }
+        try "{}".write(to: dir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+
+        // Shards 3-4 local, 1-2 dangling (partially unplugged relocation).
+        for i in 3...4 {
+            try Data(repeating: 0x42, count: 8).write(
+                to: dir.appendingPathComponent("diffusion_pytorch_model-0000\(i)-of-00004.safetensors"))
+        }
+        for i in 1...2 {
+            try fm.createSymbolicLink(
+                at: dir.appendingPathComponent("diffusion_pytorch_model-0000\(i)-of-00004.safetensors"),
+                withDestinationURL: dir.appendingPathComponent("unplugged/\(i).safetensors"))
+        }
+
+        let result = Flux2ModelDownloader.verifyModel(at: dir)
+        XCTAssertFalse(result.complete)
+        XCTAssertEqual(result.missing, [
+            "diffusion_pytorch_model-00001-of-00004.safetensors",
+            "diffusion_pytorch_model-00002-of-00004.safetensors",
+        ])
+
+        // Complete the series and it verifies.
+        for i in 1...2 {
+            let link = dir.appendingPathComponent("diffusion_pytorch_model-0000\(i)-of-00004.safetensors")
+            try fm.removeItem(at: link)
+            try Data(repeating: 0x42, count: 8).write(to: link)
+        }
+        XCTAssertTrue(Flux2ModelDownloader.verifyModel(at: dir).complete)
+    }
+
+    func testVerifyModelIgnoresAppleDoubleSidecars() throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("flux2-sidecar-\(UUID().uuidString)")
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: dir) }
+        try "{}".write(to: dir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+        // Only the exFAT sidecar is left after the real weight went away.
+        try Data(repeating: 0, count: 4).write(to: dir.appendingPathComponent("._flux-2-klein-4b.safetensors"))
+
+        XCTAssertFalse(Flux2ModelDownloader.verifyModel(at: dir).complete)
+    }
+
     // MARK: - directorySize(at:) edge cases (multi-hop chains, symlinked directories)
 
     func testDirectorySizeFollowsMultiHopSymlinkChain() throws {

--- a/Tests/Flux2CoreTests/ModelDownloaderSizeTests.swift
+++ b/Tests/Flux2CoreTests/ModelDownloaderSizeTests.swift
@@ -9,6 +9,7 @@
 
 import XCTest
 @testable import Flux2Core
+import FluxTextEncoders
 
 final class ModelDownloaderSizeTests: XCTestCase {
 
@@ -177,6 +178,26 @@ final class ModelDownloaderSizeTests: XCTestCase {
         let result = Flux2ModelDownloader.verifyModel(at: dir)
         XCTAssertFalse(result.complete)
         XCTAssertEqual(result.missing.count, 1)
+    }
+
+    func testFilesToLoadExcludesLeftoverShardOfADifferentSeries() throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("flux2-filestoload-\(UUID().uuidString)")
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: dir) }
+
+        // A complete 2-shard series (the real, current model)...
+        try Data(repeating: 0x41, count: 8).write(to: dir.appendingPathComponent("model-00001-of-00002.safetensors"))
+        try Data(repeating: 0x42, count: 8).write(to: dir.appendingPathComponent("model-00002-of-00002.safetensors"))
+        // ...plus a leftover shard of an unrelated 5-shard series (a stale
+        // download from a different HF revision).
+        try Data(repeating: 0x43, count: 8).write(to: dir.appendingPathComponent("model-00001-of-00005.safetensors"))
+
+        // Verification is still complete (a real series is whole)...
+        XCTAssertTrue(SafetensorsDirectory.verifySeries(at: dir).complete)
+        // ...but loading must not pull the stale leftover's tensors in too.
+        let files = SafetensorsDirectory.filesToLoad(at: dir)
+        XCTAssertEqual(files, ["model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"])
     }
 
     func testVerifyModelIgnoresAppleDoubleSidecars() throws {

--- a/Tests/Flux2CoreTests/ModelDownloaderSizeTests.swift
+++ b/Tests/Flux2CoreTests/ModelDownloaderSizeTests.swift
@@ -72,9 +72,48 @@ final class ModelDownloaderSizeTests: XCTestCase {
             let symlinkURL = modelDir.appendingPathComponent("model.safetensors")
             try fm.createSymbolicLink(at: symlinkURL, withDestinationURL: missingTarget)
 
-            let size = Flux2ModelDownloader.downloadedSize()
+            // The walk itself: the dangling link adds 0, not its own lstat size.
+            XCTAssertEqual(Flux2ModelDownloader.directorySize(at: modelDir), Int64(configData.count))
 
-            XCTAssertEqual(size, Int64(configData.count))
+            // And at the API level the model is no longer "downloaded" at all
+            // (verifyModel follows symlinks), so it contributes nothing.
+            XCTAssertEqual(Flux2ModelDownloader.downloadedSize(), 0)
+        }
+    }
+
+    // MARK: - verifyModel follows symlinks
+
+    func testVerifyModelCountsSymlinkedWeightWhoseTargetExists() throws {
+        try withSandbox { customDir in
+            let fm = FileManager.default
+            let modelDir = ModelRegistry.localPath(for: .vae(.standard))
+            let externalDir = customDir.appendingPathComponent("external")
+            try fm.createDirectory(at: modelDir, withIntermediateDirectories: true)
+            try fm.createDirectory(at: externalDir, withIntermediateDirectories: true)
+            try "{}".write(to: modelDir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+
+            let target = externalDir.appendingPathComponent("model.safetensors")
+            try Data(repeating: 0x42, count: 64).write(to: target)
+            try fm.createSymbolicLink(at: modelDir.appendingPathComponent("model.safetensors"), withDestinationURL: target)
+
+            XCTAssertTrue(Flux2ModelDownloader.verifyModel(at: modelDir).complete)
+            XCTAssertNotNil(Flux2ModelDownloader.findModelPath(for: .vae(.standard)))
+        }
+    }
+
+    func testVerifyModelTreatsBrokenSymlinkedWeightAsMissing() throws {
+        try withSandbox { customDir in
+            let fm = FileManager.default
+            let modelDir = ModelRegistry.localPath(for: .vae(.standard))
+            try fm.createDirectory(at: modelDir, withIntermediateDirectories: true)
+            try "{}".write(to: modelDir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+
+            // Unplugged external disk: the weight file's symlink dangles.
+            let missingTarget = customDir.appendingPathComponent("not-mounted/model.safetensors")
+            try fm.createSymbolicLink(at: modelDir.appendingPathComponent("model.safetensors"), withDestinationURL: missingTarget)
+
+            XCTAssertFalse(Flux2ModelDownloader.verifyModel(at: modelDir).complete)
+            XCTAssertNil(Flux2ModelDownloader.findModelPath(for: .vae(.standard)))
         }
     }
 

--- a/Tests/Flux2CoreTests/ModelDownloaderSizeTests.swift
+++ b/Tests/Flux2CoreTests/ModelDownloaderSizeTests.swift
@@ -200,6 +200,26 @@ final class ModelDownloaderSizeTests: XCTestCase {
         XCTAssertEqual(files, ["model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"])
     }
 
+    func testFilesToLoadIsDeterministicBetweenTwoCompleteSeries() throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("flux2-tiebreak-\(UUID().uuidString)")
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: dir) }
+
+        // Two independently-complete series (e.g. a stale one an upstream
+        // re-shard left behind). `Dictionary` iteration order is randomized
+        // per process, so without an explicit tiebreak this would pick either
+        // one at random on different runs.
+        try Data(repeating: 0x41, count: 8).write(to: dir.appendingPathComponent("a-00001-of-00001.safetensors"))
+        try Data(repeating: 0x42, count: 8).write(to: dir.appendingPathComponent("z-00001-of-00001.safetensors"))
+
+        // Repeat the call several times: a non-deterministic implementation
+        // would be very likely to disagree with itself across all of them.
+        let results = (0..<20).map { _ in SafetensorsDirectory.filesToLoad(at: dir) }
+        XCTAssertTrue(results.allSatisfy { $0 == results[0] })
+        XCTAssertEqual(results[0], ["a-00001-of-00001.safetensors"])
+    }
+
     func testVerifyModelIgnoresAppleDoubleSidecars() throws {
         let fm = FileManager.default
         let dir = fm.temporaryDirectory.appendingPathComponent("flux2-sidecar-\(UUID().uuidString)")

--- a/Tests/Flux2CoreTests/ModelPathOverrideTests.swift
+++ b/Tests/Flux2CoreTests/ModelPathOverrideTests.swift
@@ -220,10 +220,10 @@ final class ModelPathOverrideTests: XCTestCase {
             _ = try await Flux2ModelDownloader().download(.vae(.standard))
             XCTFail("Expected download() to refuse a relocated, incomplete series")
         } catch let error as Flux2DownloadError {
-            guard case .weightsRelocated(_, _, let files) = error else {
+            guard case .weightsRelocated(_, _, let missing) = error else {
                 return XCTFail("Unexpected error: \(error)")
             }
-            XCTAssertEqual(files.count, 3)
+            XCTAssertEqual(missing, ["diffusion_pytorch_model-00002-of-00004.safetensors"])
         }
         // Every live link is still a link.
         XCTAssertEqual(Flux2ModelDownloader.symlinkedWeights(at: modelDir).count, 3)

--- a/Tests/Flux2CoreTests/ModelPathOverrideTests.swift
+++ b/Tests/Flux2CoreTests/ModelPathOverrideTests.swift
@@ -294,4 +294,46 @@ final class ModelPathOverrideTests: XCTestCase {
         XCTAssertFalse(Flux2ModelDownloader.isOnUnmountedVolume(existing.appendingPathComponent("not/yet/created")))
         XCTAssertFalse(Flux2ModelDownloader.isOnUnmountedVolume(existing))
     }
+
+    // MARK: - delete() also refuses in-place relocation (no override needed)
+
+    func testDeleteRefusesInPlaceRelocatedWeightsWithoutAnOverride() throws {
+        // The consumer app's actual relocation workflow: default directory
+        // left in place, big weight files replaced with symlinks — no
+        // ModelRegistry.pathOverride involved at all.
+        let customDir = try makeTempDir("inplace")
+        let externalDir = customDir.appendingPathComponent("external")
+        defer { try? fm.removeItem(at: customDir) }
+        ModelRegistry.customModelsDirectory = customDir
+        try fm.createDirectory(at: externalDir, withIntermediateDirectories: true)
+        let modelDir = ModelRegistry.localPath(for: .vae(.standard))
+        try fm.createDirectory(at: modelDir, withIntermediateDirectories: true)
+        try "{}".write(to: modelDir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+        let target = externalDir.appendingPathComponent("model.safetensors")
+        try Data(repeating: 0x42, count: 64).write(to: target)
+        try fm.createSymbolicLink(at: modelDir.appendingPathComponent("model.safetensors"), withDestinationURL: target)
+
+        XCTAssertTrue(Flux2ModelDownloader.isRelocated(.vae(.standard)))
+
+        XCTAssertThrowsError(try Flux2ModelDownloader.delete(.vae(.standard))) { error in
+            guard case Flux2DownloadError.deletionRefusedForRelocatedWeights = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+        // The symlink (and its external target) must survive the refusal.
+        XCTAssertNotNil(try? fm.destinationOfSymbolicLink(atPath: modelDir.appendingPathComponent("model.safetensors").path))
+        XCTAssertTrue(fm.fileExists(atPath: target.path))
+    }
+
+    func testIsRelocatedFalseForAnOrdinaryDownload() throws {
+        let customDir = try makeTempDir("ordinary")
+        defer { try? fm.removeItem(at: customDir) }
+        ModelRegistry.customModelsDirectory = customDir
+        let modelDir = ModelRegistry.localPath(for: .vae(.standard))
+        try fm.createDirectory(at: modelDir, withIntermediateDirectories: true)
+        try writeCompleteModel(at: modelDir)
+
+        XCTAssertFalse(Flux2ModelDownloader.isRelocated(.vae(.standard)))
+        XCTAssertNoThrow(try Flux2ModelDownloader.delete(.vae(.standard)))
+    }
 }

--- a/Tests/Flux2CoreTests/ModelPathOverrideTests.swift
+++ b/Tests/Flux2CoreTests/ModelPathOverrideTests.swift
@@ -12,10 +12,22 @@ import XCTest
 final class ModelPathOverrideTests: XCTestCase {
 
     private let fm = FileManager.default
+    private var savedHubCache: URL!
+
+    override func setUp() {
+        super.setUp()
+        // The last-resort tier searches ~/.cache/huggingface/hub; point it at
+        // nothing so a snapshot on the developer's machine can't satisfy a
+        // "not downloaded" assertion.
+        savedHubCache = Flux2ModelDownloader.legacyHubCacheDirectory
+        Flux2ModelDownloader.legacyHubCacheDirectory = fm.temporaryDirectory
+            .appendingPathComponent("flux2-no-hub-\(UUID().uuidString)")
+    }
 
     override func tearDown() {
         ModelRegistry.clearPathOverrides()
         ModelRegistry.customModelsDirectory = nil
+        Flux2ModelDownloader.legacyHubCacheDirectory = savedHubCache
         super.tearDown()
     }
 
@@ -156,12 +168,65 @@ final class ModelPathOverrideTests: XCTestCase {
             _ = try await Flux2ModelDownloader().download(.vae(.standard))
             XCTFail("Expected download() to refuse an unmounted override volume")
         } catch let error as Flux2DownloadError {
-            guard case .overrideVolumeUnavailable = error else {
+            guard case .destinationVolumeUnavailable = error else {
                 return XCTFail("Unexpected error: \(error)")
             }
         }
         XCTAssertFalse(fm.fileExists(atPath: override.deletingLastPathComponent().deletingLastPathComponent().path))
         XCTAssertNotNil(Flux2ModelDownloader.unavailableReason(for: .vae(.standard)))
+    }
+
+    func testDownloadRefusesUnmountedCatalogRootWithoutOverride() async throws {
+        // `--models-dir /Volumes/<unplugged>/models`: same precise error as
+        // for an override, not a raw permission failure from mkdir.
+        ModelRegistry.customModelsDirectory = URL(fileURLWithPath: "/Volumes/flux2-test-\(UUID().uuidString)/models")
+
+        do {
+            _ = try await Flux2ModelDownloader().download(.vae(.standard))
+            XCTFail("Expected download() to refuse an unmounted catalog root")
+        } catch let error as Flux2DownloadError {
+            guard case .destinationVolumeUnavailable = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+        XCTAssertNotNil(Flux2ModelDownloader.unavailableReason(for: .vae(.standard)))
+    }
+
+    func testDownloadRefusesIncompleteRelocatedSeriesWithLiveLinks() async throws {
+        // Disk mounted, shards 1/3/4 are live links, shard 2's link is missing
+        // (interrupted relocation). Downloading here would replace the live
+        // links with local copies; the model must be repaired at the target.
+        let customDir = try makeTempDir("relocated")
+        defer { try? fm.removeItem(at: customDir) }
+        ModelRegistry.customModelsDirectory = customDir
+        let modelDir = ModelRegistry.localPath(for: .vae(.standard))
+        let external = customDir.appendingPathComponent("external")
+        try fm.createDirectory(at: modelDir, withIntermediateDirectories: true)
+        try fm.createDirectory(at: external, withIntermediateDirectories: true)
+        try "{}".write(to: modelDir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+        for i in [1, 3, 4] {
+            let name = "diffusion_pytorch_model-0000\(i)-of-00004.safetensors"
+            try Data(repeating: 0x42, count: 8).write(to: external.appendingPathComponent(name))
+            try fm.createSymbolicLink(at: modelDir.appendingPathComponent(name), withDestinationURL: external.appendingPathComponent(name))
+        }
+
+        XCTAssertNil(Flux2ModelDownloader.findModelPath(for: .vae(.standard)))
+        XCTAssertTrue(Flux2ModelDownloader.unreachableWeights(at: modelDir).isEmpty)
+        XCTAssertEqual(Flux2ModelDownloader.symlinkedWeights(at: modelDir).count, 3)
+        let reason = try XCTUnwrap(Flux2ModelDownloader.unavailableReason(for: .vae(.standard)))
+        XCTAssertTrue(reason.contains("00002-of-00004"), reason)
+
+        do {
+            _ = try await Flux2ModelDownloader().download(.vae(.standard))
+            XCTFail("Expected download() to refuse a relocated, incomplete series")
+        } catch let error as Flux2DownloadError {
+            guard case .weightsRelocated(_, _, let files) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(files.count, 3)
+        }
+        // Every live link is still a link.
+        XCTAssertEqual(Flux2ModelDownloader.symlinkedWeights(at: modelDir).count, 3)
     }
 
     func testDownloadRefusesDanglingWeightSymlinksInDefaultLayout() async throws {
@@ -218,8 +283,10 @@ final class ModelPathOverrideTests: XCTestCase {
     func testUnmountedVolumeDetection() throws {
         XCTAssertTrue(Flux2ModelDownloader.isOnUnmountedVolume(
             URL(fileURLWithPath: "/Volumes/flux2-nope-\(UUID().uuidString)/a/b/c")))
-        XCTAssertTrue(Flux2ModelDownloader.isOnUnmountedVolume(
-            URL(fileURLWithPath: "/volumes/flux2-nope-\(UUID().uuidString)")))
+        if fm.fileExists(atPath: "/volumes") {  // case-insensitive root filesystem only
+            XCTAssertTrue(Flux2ModelDownloader.isOnUnmountedVolume(
+                URL(fileURLWithPath: "/volumes/flux2-nope-\(UUID().uuidString)")))
+        }
 
         // A missing subfolder under an existing directory is not "unmounted".
         let existing = try makeTempDir("mounted")

--- a/Tests/Flux2CoreTests/ModelPathOverrideTests.swift
+++ b/Tests/Flux2CoreTests/ModelPathOverrideTests.swift
@@ -1,9 +1,9 @@
 // ModelPathOverrideTests.swift - Tests for ModelRegistry per-component path overrides
 // Copyright 2025 Vincent Gourbin
 //
-// Lets a caller redirect a single model component to an arbitrary URL (e.g.
-// one relocated to an external disk) without moving the rest of the catalog
-// under customModelsDirectory. See
+// Lets a caller redirect a single model component to an arbitrary directory
+// (e.g. one relocated to an external disk) without moving the rest of the
+// catalog under customModelsDirectory. See
 // Fluxforge Studio/docs/FRAMEWORK_ASKS_STORAGE.md ask #2.
 
 import XCTest
@@ -32,25 +32,24 @@ final class ModelPathOverrideTests: XCTestCase {
 
     // MARK: - Registry API
 
-    func testLocalPathReturnsOverrideWhenSet() throws {
-        let override = URL(fileURLWithPath: "/Volumes/External/flux2-vae")
+    func testResolvedPathReturnsOverrideWhileLocalPathStaysPure() throws {
+        let override = URL(fileURLWithPath: "/Volumes/External/flux2-vae", isDirectory: true)
         try ModelRegistry.setPathOverride(override, for: .vae(.standard))
 
-        XCTAssertEqual(ModelRegistry.localPath(for: .vae(.standard)), override)
+        XCTAssertEqual(ModelRegistry.resolvedPath(for: .vae(.standard)), override)
         XCTAssertEqual(ModelRegistry.pathOverride(for: .vae(.standard)), override)
-    }
-
-    func testDefaultLocalPathIgnoresOverride() throws {
-        try ModelRegistry.setPathOverride(URL(fileURLWithPath: "/Volumes/External/flux2-vae"), for: .vae(.standard))
-
-        XCTAssertFalse(ModelRegistry.defaultLocalPath(for: .vae(.standard)).path.hasPrefix("/Volumes/External"))
+        XCTAssertEqual(ModelRegistry.pathOverride(forComponent: .vae(.standard)), override)
+        // localPath is the catalog layout consumers derive relative paths from.
+        XCTAssertFalse(ModelRegistry.localPath(for: .vae(.standard)).path.hasPrefix("/Volumes/External"))
     }
 
     func testOverrideOnlyAffectsItsOwnComponent() throws {
         try ModelRegistry.setPathOverride(URL(fileURLWithPath: "/Volumes/External/flux2-vae"), for: .vae(.standard))
 
-        XCTAssertFalse(ModelRegistry.localPath(for: .transformer(.klein4B_bf16)).path.hasPrefix("/Volumes/External"))
         XCTAssertNil(ModelRegistry.pathOverride(for: .transformer(.klein4B_bf16)))
+        XCTAssertEqual(
+            ModelRegistry.resolvedPath(for: .transformer(.klein4B_bf16)),
+            ModelRegistry.localPath(for: .transformer(.klein4B_bf16)))
     }
 
     func testSettingNilClearsOverride() throws {
@@ -58,14 +57,27 @@ final class ModelPathOverrideTests: XCTestCase {
         try ModelRegistry.setPathOverride(nil, for: .vae(.standard))
 
         XCTAssertNil(ModelRegistry.pathOverride(for: .vae(.standard)))
-        XCTAssertEqual(ModelRegistry.localPath(for: .vae(.standard)), ModelRegistry.defaultLocalPath(for: .vae(.standard)))
     }
 
-    func testTextEncoderOverrideIsRejectedNotSilentlyInert() {
-        XCTAssertThrowsError(
-            try ModelRegistry.setPathOverride(URL(fileURLWithPath: "/Volumes/External/mistral"), for: .textEncoder(.mlx8bit))
-        )
-        XCTAssertNil(ModelRegistry.pathOverride(for: .textEncoder(.mlx8bit)))
+    func testNonFileURLIsRejected() {
+        XCTAssertThrowsError(try ModelRegistry.setPathOverride(URL(string: "https://example.com/vae")!, for: .vae(.standard)))
+        XCTAssertThrowsError(try ModelRegistry.setPathOverride(URL(string: "/Volumes/External/vae")!, for: .vae(.standard)))
+        XCTAssertNil(ModelRegistry.pathOverride(for: .vae(.standard)))
+    }
+
+    func testStoredOverrideIsStandardizedDirectoryURL() throws {
+        try ModelRegistry.setPathOverride(URL(fileURLWithPath: "/Volumes/External/./x/../flux2-vae"), for: .vae(.standard))
+
+        let stored = try XCTUnwrap(ModelRegistry.pathOverride(for: .vae(.standard)))
+        XCTAssertEqual(stored.path, "/Volumes/External/flux2-vae")
+        XCTAssertTrue(stored.hasDirectoryPath)
+    }
+
+    func testTextEncoderOverrideIsUnrepresentable() {
+        // `.textEncoder` is not an OverridableComponent; the ModelComponent
+        // read side simply never has an override for it.
+        XCTAssertNil(ModelRegistry.OverridableComponent(.textEncoder(.mlx8bit)))
+        XCTAssertNil(ModelRegistry.pathOverride(forComponent: .textEncoder(.mlx8bit)))
     }
 
     // MARK: - findModelPath / isDownloaded
@@ -80,6 +92,7 @@ final class ModelPathOverrideTests: XCTestCase {
         let found = Flux2ModelDownloader.findModelPath(for: .vae(.standard))
         XCTAssertEqual(found?.standardizedFileURL.path, overrideDir.standardizedFileURL.path)
         XCTAssertTrue(ModelRegistry.isDownloaded(.vae(.standard)))
+        XCTAssertNil(Flux2ModelDownloader.unavailableReason(for: .vae(.standard)))
     }
 
     func testFindModelPathDoesNotFallBackWhenOverrideIsIncomplete() throws {
@@ -92,7 +105,7 @@ final class ModelPathOverrideTests: XCTestCase {
             try? fm.removeItem(at: customDir)
         }
         ModelRegistry.customModelsDirectory = customDir
-        let defaultModelDir = ModelRegistry.defaultLocalPath(for: .vae(.standard))
+        let defaultModelDir = ModelRegistry.localPath(for: .vae(.standard))
         try fm.createDirectory(at: defaultModelDir, withIntermediateDirectories: true)
         try writeCompleteModel(at: defaultModelDir)
 
@@ -100,6 +113,7 @@ final class ModelPathOverrideTests: XCTestCase {
 
         XCTAssertNil(Flux2ModelDownloader.findModelPath(for: .vae(.standard)))
         XCTAssertFalse(ModelRegistry.isDownloaded(.vae(.standard)))
+        XCTAssertNotNil(Flux2ModelDownloader.unavailableReason(for: .vae(.standard)))
     }
 
     func testRegistryAndDownloaderAgreeOnExistingButEmptyDirectory() throws {
@@ -108,7 +122,7 @@ final class ModelPathOverrideTests: XCTestCase {
         let customDir = try makeTempDir("agree")
         defer { try? fm.removeItem(at: customDir) }
         ModelRegistry.customModelsDirectory = customDir
-        try fm.createDirectory(at: ModelRegistry.defaultLocalPath(for: .vae(.standard)), withIntermediateDirectories: true)
+        try fm.createDirectory(at: ModelRegistry.localPath(for: .vae(.standard)), withIntermediateDirectories: true)
 
         XCTAssertFalse(ModelRegistry.isDownloaded(.vae(.standard)))
         XCTAssertEqual(ModelRegistry.isDownloaded(.vae(.standard)), Flux2ModelDownloader.isDownloaded(.vae(.standard)))
@@ -147,11 +161,65 @@ final class ModelPathOverrideTests: XCTestCase {
             }
         }
         XCTAssertFalse(fm.fileExists(atPath: override.deletingLastPathComponent().deletingLastPathComponent().path))
+        XCTAssertNotNil(Flux2ModelDownloader.unavailableReason(for: .vae(.standard)))
     }
 
-    func testUnmountedVolumeDetectionOnlyTriggersForMissingMountPoint() throws {
+    func testDownloadRefusesDanglingWeightSymlinksInDefaultLayout() async throws {
+        // The consumer's shipped relocation: default directory, weights are
+        // absolute symlinks to the external disk, disk unplugged. This must not
+        // become a re-download (which would overwrite the links and orphan the
+        // external copy), and must fail before any network call.
+        let customDir = try makeTempDir("dangling")
+        defer { try? fm.removeItem(at: customDir) }
+        ModelRegistry.customModelsDirectory = customDir
+        let modelDir = ModelRegistry.localPath(for: .vae(.standard))
+        try fm.createDirectory(at: modelDir, withIntermediateDirectories: true)
+        try "{}".write(to: modelDir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+        let link = modelDir.appendingPathComponent("model.safetensors")
+        try fm.createSymbolicLink(at: link, withDestinationURL: customDir.appendingPathComponent("unplugged/model.safetensors"))
+
+        XCTAssertEqual(Flux2ModelDownloader.unreachableWeights(at: modelDir), ["model.safetensors"])
+        XCTAssertNil(Flux2ModelDownloader.findModelPath(for: .vae(.standard)))
+        XCTAssertNotNil(Flux2ModelDownloader.unavailableReason(for: .vae(.standard)))
+
+        do {
+            _ = try await Flux2ModelDownloader().download(.vae(.standard))
+            XCTFail("Expected download() to refuse dangling weight symlinks")
+        } catch let error as Flux2DownloadError {
+            guard case .weightsUnreachable(_, _, let files) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(files, ["model.safetensors"])
+        }
+        // The symlink is untouched.
+        XCTAssertNotNil(try? fm.destinationOfSymbolicLink(atPath: link.path))
+    }
+
+    func testDownloadRefusesReadOnlyDestinationBeforeAnyNetworkCall() async throws {
+        let overrideDir = try makeTempDir("readonly")
+        defer {
+            try? fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: overrideDir.path)
+            try? fm.removeItem(at: overrideDir)
+        }
+        try fm.setAttributes([.posixPermissions: 0o555], ofItemAtPath: overrideDir.path)
+        try XCTSkipIf(fm.isWritableFile(atPath: overrideDir.path), "Running as a user that ignores permission bits")
+        try ModelRegistry.setPathOverride(overrideDir, for: .vae(.standard))
+
+        do {
+            _ = try await Flux2ModelDownloader().download(.vae(.standard))
+            XCTFail("Expected download() to refuse a read-only destination")
+        } catch let error as Flux2DownloadError {
+            guard case .destinationNotWritable = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testUnmountedVolumeDetection() throws {
         XCTAssertTrue(Flux2ModelDownloader.isOnUnmountedVolume(
             URL(fileURLWithPath: "/Volumes/flux2-nope-\(UUID().uuidString)/a/b/c")))
+        XCTAssertTrue(Flux2ModelDownloader.isOnUnmountedVolume(
+            URL(fileURLWithPath: "/volumes/flux2-nope-\(UUID().uuidString)")))
 
         // A missing subfolder under an existing directory is not "unmounted".
         let existing = try makeTempDir("mounted")

--- a/Tests/Flux2CoreTests/ModelPathOverrideTests.swift
+++ b/Tests/Flux2CoreTests/ModelPathOverrideTests.swift
@@ -1,0 +1,162 @@
+// ModelPathOverrideTests.swift - Tests for ModelRegistry per-component path overrides
+// Copyright 2025 Vincent Gourbin
+//
+// Lets a caller redirect a single model component to an arbitrary URL (e.g.
+// one relocated to an external disk) without moving the rest of the catalog
+// under customModelsDirectory. See
+// Fluxforge Studio/docs/FRAMEWORK_ASKS_STORAGE.md ask #2.
+
+import XCTest
+@testable import Flux2Core
+
+final class ModelPathOverrideTests: XCTestCase {
+
+    private let fm = FileManager.default
+
+    override func tearDown() {
+        ModelRegistry.clearPathOverrides()
+        ModelRegistry.customModelsDirectory = nil
+        super.tearDown()
+    }
+
+    private func makeTempDir(_ label: String) throws -> URL {
+        let dir = fm.temporaryDirectory.appendingPathComponent("flux2-\(label)-\(UUID().uuidString)")
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func writeCompleteModel(at dir: URL) throws {
+        try "{}".write(to: dir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+        try Data(repeating: 0x42, count: 64).write(to: dir.appendingPathComponent("model.safetensors"))
+    }
+
+    // MARK: - Registry API
+
+    func testLocalPathReturnsOverrideWhenSet() throws {
+        let override = URL(fileURLWithPath: "/Volumes/External/flux2-vae")
+        try ModelRegistry.setPathOverride(override, for: .vae(.standard))
+
+        XCTAssertEqual(ModelRegistry.localPath(for: .vae(.standard)), override)
+        XCTAssertEqual(ModelRegistry.pathOverride(for: .vae(.standard)), override)
+    }
+
+    func testDefaultLocalPathIgnoresOverride() throws {
+        try ModelRegistry.setPathOverride(URL(fileURLWithPath: "/Volumes/External/flux2-vae"), for: .vae(.standard))
+
+        XCTAssertFalse(ModelRegistry.defaultLocalPath(for: .vae(.standard)).path.hasPrefix("/Volumes/External"))
+    }
+
+    func testOverrideOnlyAffectsItsOwnComponent() throws {
+        try ModelRegistry.setPathOverride(URL(fileURLWithPath: "/Volumes/External/flux2-vae"), for: .vae(.standard))
+
+        XCTAssertFalse(ModelRegistry.localPath(for: .transformer(.klein4B_bf16)).path.hasPrefix("/Volumes/External"))
+        XCTAssertNil(ModelRegistry.pathOverride(for: .transformer(.klein4B_bf16)))
+    }
+
+    func testSettingNilClearsOverride() throws {
+        try ModelRegistry.setPathOverride(URL(fileURLWithPath: "/Volumes/External/flux2-vae"), for: .vae(.standard))
+        try ModelRegistry.setPathOverride(nil, for: .vae(.standard))
+
+        XCTAssertNil(ModelRegistry.pathOverride(for: .vae(.standard)))
+        XCTAssertEqual(ModelRegistry.localPath(for: .vae(.standard)), ModelRegistry.defaultLocalPath(for: .vae(.standard)))
+    }
+
+    func testTextEncoderOverrideIsRejectedNotSilentlyInert() {
+        XCTAssertThrowsError(
+            try ModelRegistry.setPathOverride(URL(fileURLWithPath: "/Volumes/External/mistral"), for: .textEncoder(.mlx8bit))
+        )
+        XCTAssertNil(ModelRegistry.pathOverride(for: .textEncoder(.mlx8bit)))
+    }
+
+    // MARK: - findModelPath / isDownloaded
+
+    func testFindModelPathUsesOverrideWhenComplete() throws {
+        let overrideDir = try makeTempDir("override")
+        defer { try? fm.removeItem(at: overrideDir) }
+        try writeCompleteModel(at: overrideDir)
+
+        try ModelRegistry.setPathOverride(overrideDir, for: .vae(.standard))
+
+        let found = Flux2ModelDownloader.findModelPath(for: .vae(.standard))
+        XCTAssertEqual(found?.standardizedFileURL.path, overrideDir.standardizedFileURL.path)
+        XCTAssertTrue(ModelRegistry.isDownloaded(.vae(.standard)))
+    }
+
+    func testFindModelPathDoesNotFallBackWhenOverrideIsIncomplete() throws {
+        // Override points at an empty directory while a fully valid copy sits
+        // at the default location. The override is authoritative: no fallback.
+        let overrideDir = try makeTempDir("override-empty")
+        let customDir = try makeTempDir("default")
+        defer {
+            try? fm.removeItem(at: overrideDir)
+            try? fm.removeItem(at: customDir)
+        }
+        ModelRegistry.customModelsDirectory = customDir
+        let defaultModelDir = ModelRegistry.defaultLocalPath(for: .vae(.standard))
+        try fm.createDirectory(at: defaultModelDir, withIntermediateDirectories: true)
+        try writeCompleteModel(at: defaultModelDir)
+
+        try ModelRegistry.setPathOverride(overrideDir, for: .vae(.standard))
+
+        XCTAssertNil(Flux2ModelDownloader.findModelPath(for: .vae(.standard)))
+        XCTAssertFalse(ModelRegistry.isDownloaded(.vae(.standard)))
+    }
+
+    func testRegistryAndDownloaderAgreeOnExistingButEmptyDirectory() throws {
+        // Previously ModelRegistry.isDownloaded said "yes" for any existing
+        // directory while Flux2ModelDownloader required completeness.
+        let customDir = try makeTempDir("agree")
+        defer { try? fm.removeItem(at: customDir) }
+        ModelRegistry.customModelsDirectory = customDir
+        try fm.createDirectory(at: ModelRegistry.defaultLocalPath(for: .vae(.standard)), withIntermediateDirectories: true)
+
+        XCTAssertFalse(ModelRegistry.isDownloaded(.vae(.standard)))
+        XCTAssertEqual(ModelRegistry.isDownloaded(.vae(.standard)), Flux2ModelDownloader.isDownloaded(.vae(.standard)))
+    }
+
+    // MARK: - delete / download guards
+
+    func testDeleteRefusesComponentWithActiveOverride() throws {
+        let overrideDir = try makeTempDir("override-delete")
+        defer { try? fm.removeItem(at: overrideDir) }
+        try writeCompleteModel(at: overrideDir)
+
+        try ModelRegistry.setPathOverride(overrideDir, for: .vae(.standard))
+
+        XCTAssertThrowsError(try Flux2ModelDownloader.delete(.vae(.standard))) { error in
+            guard case Flux2DownloadError.deletionRefusedForOverride = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+        XCTAssertTrue(fm.fileExists(atPath: overrideDir.appendingPathComponent("model.safetensors").path))
+    }
+
+    func testDownloadRefusesOverrideOnUnmountedVolumeBeforeAnyNetworkCall() async throws {
+        // A /Volumes/<disk> that doesn't exist stands in for an unplugged
+        // external disk. The check runs before fetchFileList, so this test
+        // needs no network and must leave nothing behind.
+        let override = URL(fileURLWithPath: "/Volumes/flux2-test-\(UUID().uuidString)/models/flux2-vae")
+        try ModelRegistry.setPathOverride(override, for: .vae(.standard))
+
+        do {
+            _ = try await Flux2ModelDownloader().download(.vae(.standard))
+            XCTFail("Expected download() to refuse an unmounted override volume")
+        } catch let error as Flux2DownloadError {
+            guard case .overrideVolumeUnavailable = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+        XCTAssertFalse(fm.fileExists(atPath: override.deletingLastPathComponent().deletingLastPathComponent().path))
+    }
+
+    func testUnmountedVolumeDetectionOnlyTriggersForMissingMountPoint() throws {
+        XCTAssertTrue(Flux2ModelDownloader.isOnUnmountedVolume(
+            URL(fileURLWithPath: "/Volumes/flux2-nope-\(UUID().uuidString)/a/b/c")))
+
+        // A missing subfolder under an existing directory is not "unmounted".
+        let existing = try makeTempDir("mounted")
+        defer { try? fm.removeItem(at: existing) }
+        XCTAssertFalse(Flux2ModelDownloader.isOnUnmountedVolume(existing.appendingPathComponent("not/yet/created")))
+        XCTAssertFalse(Flux2ModelDownloader.isOnUnmountedVolume(existing))
+    }
+}

--- a/Tests/FluxTextEncodersTests/TextEncoderModelDirectoryTests.swift
+++ b/Tests/FluxTextEncodersTests/TextEncoderModelDirectoryTests.swift
@@ -221,13 +221,37 @@ final class TextEncoderModelDirectoryTests: XCTestCase {
             _ = try await TextEncoderModelDownloader().downloadQwen3(model)
             XCTFail("Expected downloadQwen3 to refuse a relocated model")
         } catch let error as TextEncoderModelDownloaderError {
-            guard case .weightsRelocated(_, let files) = error else {
+            // Dangling link: the disk is gone, distinct from a live but
+            // incomplete relocation (.weightsRelocated).
+            guard case .weightsUnreachable(_, let files) = error else {
                 return XCTFail("Unexpected error: \(error)")
             }
             XCTAssertEqual(files, ["model.safetensors"])
         }
         XCTAssertNotNil(try? FileManager.default.destinationOfSymbolicLink(
             atPath: modelDir.appendingPathComponent("model.safetensors").path))
+    }
+
+    func testVerifyShardedModelGroupsSeriesByStemAndTotal() throws {
+        // The text-encoder verifier shares Flux2Core's series logic now: a
+        // non-"model" stem is parsed, and a leftover shard of another series
+        // neither completes nor breaks the real one.
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("te-series-\(UUID().uuidString)")
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: dir) }
+        let write = { (name: String) in
+            try Data(repeating: 0x42, count: 8).write(to: dir.appendingPathComponent(name))
+        }
+
+        try write("qwen3-00001-of-00002.safetensors")
+        let partial = TextEncoderModelDownloader.verifyShardedModel(at: dir)
+        XCTAssertFalse(partial.complete)
+        XCTAssertEqual(partial.missing, ["qwen3-00002-of-00002.safetensors"])
+
+        try write("qwen3-00002-of-00002.safetensors")
+        try write("model-00001-of-00007.safetensors")  // leftover of another series
+        XCTAssertTrue(TextEncoderModelDownloader.verifyShardedModel(at: dir).complete)
     }
 
     // MARK: - Multiple switches

--- a/Tests/FluxTextEncodersTests/TextEncoderModelDirectoryTests.swift
+++ b/Tests/FluxTextEncodersTests/TextEncoderModelDirectoryTests.swift
@@ -188,6 +188,34 @@ final class TextEncoderModelDirectoryTests: XCTestCase {
         XCTAssertTrue(found!.path.hasPrefix(tempDir.path))
     }
 
+    func testFindQwen3ModelPathTreatsDanglingWeightSymlinkAsMissing() throws {
+        // A text encoder relocated to an external disk that is unplugged: the
+        // weight is a dangling symlink and must not count as present-by-name.
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("flux2-te-dangling-\(UUID().uuidString)")
+            .appendingPathComponent("models")
+        let model = Qwen3ModelInfo(
+            id: "test-qwen-dangling",
+            repoId: "test-org/qwen3-dangling",
+            name: "Qwen3 Test",
+            description: "Test Qwen3 model",
+            variant: .qwen3_4B_8bit,
+            parameters: "4B"
+        )
+        let modelDir = tempDir.appendingPathComponent("test-org").appendingPathComponent("qwen3-dangling")
+        try FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true)
+        try "{}".write(to: modelDir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(
+            at: modelDir.appendingPathComponent("model.safetensors"),
+            withDestinationURL: tempDir.appendingPathComponent("unplugged/model.safetensors"))
+        defer { try? FileManager.default.removeItem(at: tempDir.deletingLastPathComponent()) }
+
+        TextEncoderModelDownloader.customModelsDirectory = tempDir
+
+        XCTAssertFalse(TextEncoderModelDownloader.verifyShardedModel(at: modelDir).complete)
+        XCTAssertNil(TextEncoderModelDownloader.findQwen3ModelPath(for: model))
+    }
+
     // MARK: - Multiple switches
 
     func testSwitchingCustomDirectories() {

--- a/Tests/FluxTextEncodersTests/TextEncoderModelDirectoryTests.swift
+++ b/Tests/FluxTextEncodersTests/TextEncoderModelDirectoryTests.swift
@@ -188,7 +188,7 @@ final class TextEncoderModelDirectoryTests: XCTestCase {
         XCTAssertTrue(found!.path.hasPrefix(tempDir.path))
     }
 
-    func testFindQwen3ModelPathTreatsDanglingWeightSymlinkAsMissing() throws {
+    func testFindQwen3ModelPathTreatsDanglingWeightSymlinkAsMissing() async throws {
         // A text encoder relocated to an external disk that is unplugged: the
         // weight is a dangling symlink and must not count as present-by-name.
         let tempDir = FileManager.default.temporaryDirectory
@@ -214,6 +214,20 @@ final class TextEncoderModelDirectoryTests: XCTestCase {
 
         XCTAssertFalse(TextEncoderModelDownloader.verifyShardedModel(at: modelDir).complete)
         XCTAssertNil(TextEncoderModelDownloader.findQwen3ModelPath(for: model))
+
+        // And downloading must refuse (before any network call) rather than
+        // let the Hub client replace the link with a local copy.
+        do {
+            _ = try await TextEncoderModelDownloader().downloadQwen3(model)
+            XCTFail("Expected downloadQwen3 to refuse a relocated model")
+        } catch let error as TextEncoderModelDownloaderError {
+            guard case .weightsRelocated(_, let files) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(files, ["model.safetensors"])
+        }
+        XCTAssertNotNil(try? FileManager.default.destinationOfSymbolicLink(
+            atPath: modelDir.appendingPathComponent("model.safetensors").path))
     }
 
     // MARK: - Multiple switches

--- a/Tests/FluxTextEncodersTests/TextEncoderModelDirectoryTests.swift
+++ b/Tests/FluxTextEncodersTests/TextEncoderModelDirectoryTests.swift
@@ -232,6 +232,47 @@ final class TextEncoderModelDirectoryTests: XCTestCase {
             atPath: modelDir.appendingPathComponent("model.safetensors").path))
     }
 
+    func testDownloadQwen3RefusesIncompleteRelocatedSeriesWithMissingShardsNamed() async throws {
+        // Disk mounted (live links), but shard 2 of 2 was never relocated:
+        // the error must name the actually-missing shard, not the ones present.
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("flux2-te-relocated-\(UUID().uuidString)")
+            .appendingPathComponent("models")
+        let model = Qwen3ModelInfo(
+            id: "test-qwen-relocated",
+            repoId: "test-org/qwen3-relocated",
+            name: "Qwen3 Test",
+            description: "Test Qwen3 model",
+            variant: .qwen3_4B_8bit,
+            parameters: "4B"
+        )
+        let modelDir = tempDir.appendingPathComponent("test-org").appendingPathComponent("qwen3-relocated")
+        let externalDir = tempDir.appendingPathComponent("external")
+        try FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: externalDir, withIntermediateDirectories: true)
+        try "{}".write(to: modelDir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+        let shard1 = "model-00001-of-00002.safetensors"
+        try Data(repeating: 0x42, count: 8).write(to: externalDir.appendingPathComponent(shard1))
+        try FileManager.default.createSymbolicLink(
+            at: modelDir.appendingPathComponent(shard1), withDestinationURL: externalDir.appendingPathComponent(shard1))
+        defer { try? FileManager.default.removeItem(at: tempDir.deletingLastPathComponent()) }
+
+        TextEncoderModelDownloader.customModelsDirectory = tempDir
+
+        do {
+            _ = try await TextEncoderModelDownloader().downloadQwen3(model)
+            XCTFail("Expected downloadQwen3 to refuse an incomplete relocated series")
+        } catch let error as TextEncoderModelDownloaderError {
+            guard case .weightsRelocated(_, let missing) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(missing, ["model-00002-of-00002.safetensors"])
+        }
+        // The live link must survive the refused download.
+        XCTAssertNotNil(try? FileManager.default.destinationOfSymbolicLink(
+            atPath: modelDir.appendingPathComponent(shard1).path))
+    }
+
     func testVerifyShardedModelGroupsSeriesByStemAndTotal() throws {
         // The text-encoder verifier shares Flux2Core's series logic now: a
         // non-"model" stem is parsed, and a leftover shard of another series


### PR DESCRIPTION
## Summary
Implements Fluxforge Studio ask #2 (`docs/FRAMEWORK_ASKS_STORAGE.md`): redirect a **single** model component to an arbitrary directory — e.g. one relocated wholesale to an external disk — without moving the whole catalog under `customModelsDirectory`.

A first attempt shipped in #123's history and was reverted after two review rounds. This is a redesign around those findings, hardened by five further review passes on this branch (seven total).

**API**
- `ModelRegistry.setPathOverride(_:for: OverridableComponent)` (`.transformer` | `.vae`; `.textEncoder` is unrepresentable by the key type — it loads via `TextEncoderModelDownloader`, which never reads this registry). One atomic update under a lock; a non-file URL throws; stored as a lexically standardized directory URL.
- `localPath(for:)` stays the pure catalog layout (consumers derive `modelsDirectory`-relative paths from it); `resolvedPath(for:)` is the override-aware lookup.
- `Flux2ModelDownloader.location(for:)` takes one override snapshot per operation that `findModelPath` / `delete` / `download` thread through — a guard and the action it guards can never see two different override states. An override is authoritative (no fallback to cache tiers); `ModelRegistry.isDownloaded` delegates to the completeness check.

**Relocation safety — default layout and overrides alike**
- `verifyModel` / `verifyShardedModel` (now both backed by a shared `SafetensorsDirectory` enum, also used by the CLI and app targets) follow symlinks: a dangling weight is *missing*. Shards are parsed by `-NNNNN-of-MMMMM` whatever the stem, grouped by `(stem, total)` with a deterministic tiebreak; `._` AppleDouble sidecars are ignored.
- Every weight loader (transformer, VAE, and all five FluxTextEncoders model loaders — Mistral, Mistral VLM, Qwen3, Qwen3-VL, Qwen3.5, Qwen3.5-VL) loads exactly the files belonging to the verified-complete series, not every `.safetensors` file reachable in the directory — a stray leftover shard from an earlier download/revision can no longer silently merge its tensors into the result.
- `download()` refuses, before any network call: dangling weight links, live links with a missing shard (repairing would replace them with local copies), an unmounted `/Volumes` destination, an unreadable directory (App Sandbox scope), a read-only destination. The same guards apply to `TextEncoderModelDownloader`'s Hub-backed downloads.
- `delete()` refuses a component whose weights are relocated — via an explicit override **or** symlinked in place under the default directory (the consumer app's actual relocation workflow); Flux2App shows the refusal and swaps the delete button for an external-drive glyph in both cases.
- Pre-quantized checkpoints: size/fingerprint follow a relocation symlink, a symlinked checkpoint is never unlinked/rewritten by an export, and the export's refusal guards (merged LoRA, symlinked checkpoint) run before anything is mutated — a refused export no longer deletes the existing checkpoint or evicts a resident transformer.

**Loading**
- A failed weight load no longer leaves a randomly initialised transformer/VAE resident; `update(parameters:verify: .shapeMismatch)` turns a wrong same-family variant into an error instead of a Metal abort; zero-matching-tensor directories throw.
- Pipeline errors explain the actual cause via `unavailableReason(for:)` (override / unplugged disk / relocated-incomplete / sandbox scope) instead of "run `flux2 download`".

Known, documented limits: mounts outside `/Volumes` aren't detected as unmounted; an identical-shape wrong variant behind an override isn't detectable; the legacy Hub-cache and flat-directory fallback tiers aren't covered by the relocation guards (only the primary location is).

## Test plan
- [x] `ModelPathOverrideTests`, `ModelDownloaderSizeTests`, `TextEncoderModelDirectoryTests` — override API, authoritative/no-fallback, delete refusal (override and in-place), download refusals (unmounted volume, dangling/relocated links, read-only destination) with no network and no residue, deterministic shard-series selection, `._` sidecar handling.
- [x] `xcodebuild test -scheme Flux2Swift-Package -destination 'platform=macOS' -skipPackagePluginValidation -only-testing:Flux2CoreTests -only-testing:FluxTextEncodersTests` — 418 + 157 tests, 0 failures; full package builds clean.
- [x] Reviewed locally via `/code-review` (Sonnet), seven passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)