### PR TITLE
feat(chains): Image Preparation — barn-door Live Area formatting for I2I

### DIFF
--- a/Sources/Flux2CLI/Flux2CLI.swift
+++ b/Sources/Flux2CLI/Flux2CLI.swift
@@ -433,7 +433,7 @@ struct ImageToImage: AsyncParsableCommand {
     @Option(name: .long, help: "Prepared: Live Area barn-door rect as normalized x,y,width,height (e.g. 0.1,0.1,0.8,0.8) — what the model sees and where the result pastes back")
     var liveArea: String?
 
-    @Option(name: .long, help: "Prepared: sub-rect of the Live Area actually regenerated, normalized x,y,width,height — advanced; defaults to the whole Live Area")
+    @Option(name: .long, help: "Prepared: sub-rect actually regenerated, normalized x,y,width,height AGAINST THE FULL ORIGINAL IMAGE (same coordinate space as --live-area, not relative to it) — must overlap --live-area; advanced, defaults to the whole Live Area")
     var processArea: String?
 
     @Flag(name: .long, help: "Prepared: skip pasting the generated result back into the original — output the generated canvas as-is")

--- a/Sources/Flux2CLI/Flux2CLI.swift
+++ b/Sources/Flux2CLI/Flux2CLI.swift
@@ -411,6 +411,34 @@ struct ImageToImage: AsyncParsableCommand {
     @Option(name: .long, help: "Max VAE encode budget per reference image, in megapixels (1 MP = 1024×1024; default 1.0). Raise for higher-fidelity conditioning at the cost of memory; e.g. 4.0 ≈ 2048².")
     var maxReferenceMegapixels: Double?
 
+    // MARK: - Image Preparation (barn-door Live Area + megapixel budget)
+    // See docs/ImagePreparation.md. Setting any of these flags (or --prepared)
+    // enables the prepared pipeline instead of the legacy plain-reference path.
+
+    @Flag(name: .long, help: "Format the reference image and apply the megapixel budget before generating, compositing the result back into the original (see docs/ImagePreparation.md)")
+    var prepared: Bool = false
+
+    @Option(name: .long, help: "Prepared: bias crop/pad toward original aspect, horizontal, or vertical (original, horizontal, vertical)")
+    var favour: String?
+
+    @Option(name: .long, help: "Prepared: fit the reference to the model's step size by cropping or padding (crop, pad)")
+    var method: String?
+
+    @Option(name: .long, help: "Prepared: fine-tune how aggressively the image is scaled before crop/pad (0.1-1.0)")
+    var prepScale: Double?
+
+    @Option(name: .long, help: "Prepared: total pixel budget for generation, in megapixels (0.25-4.0, default 1.0)")
+    var megapixels: Double?
+
+    @Option(name: .long, help: "Prepared: Live Area barn-door rect as normalized x,y,width,height (e.g. 0.1,0.1,0.8,0.8) — what the model sees and where the result pastes back")
+    var liveArea: String?
+
+    @Option(name: .long, help: "Prepared: sub-rect of the Live Area actually regenerated, normalized x,y,width,height — advanced; defaults to the whole Live Area")
+    var processArea: String?
+
+    @Flag(name: .long, help: "Prepared: skip pasting the generated result back into the original — output the generated canvas as-is")
+    var noComposite: Bool = false
+
     @Flag(name: .long, help: "Enhance prompt with visual details using Mistral before encoding")
     var upsamplePrompt: Bool = false
 
@@ -561,9 +589,56 @@ struct ImageToImage: AsyncParsableCommand {
             }
         }
 
-        // Show output dimensions
-        let outputWidth = width ?? refImages[0].width
-        let outputHeight = height ?? refImages[0].height
+        // Image Preparation: format the reference(s) to the model's step size,
+        // apply the barn-door Live Area + megapixel budget, and remember the
+        // composition plan (if any) to paste the result back after generation.
+        // See docs/ImagePreparation.md. Any prep flag (or --prepared) enables
+        // this; otherwise the legacy plain-reference path is unchanged.
+        let usesPreparation = ImageToImagePreparationSupport.usesPreparation(
+            prepared: prepared, favour: favour, method: method, scale: prepScale,
+            megapixels: megapixels, liveArea: liveArea, processArea: processArea,
+            noComposite: noComposite)
+
+        // Image Preparation derives its own output size from the megapixel
+        // budget/aspect; --width/--height would be silently ignored (a real
+        // ~2x resolution surprise for a legacy caller that adds one prep flag
+        // without dropping its existing --width/--height). Reject explicitly.
+        if usesPreparation, width != nil || height != nil {
+            throw ValidationError("--width/--height are not compatible with Image Preparation flags (--prepared, --favour, --method, --prep-scale, --megapixels, --live-area, --process-area, --no-composite) — use --megapixels and --favour to control output size instead")
+        }
+
+        let pipelineImages: [CGImage]
+        let outputWidth: Int
+        let outputHeight: Int
+        var compositionPlan: ImageCompositionPlan?
+        var preparationSettings: ImagePreparationSettings?
+
+        if usesPreparation {
+            let settings = try ImageToImagePreparationSupport.buildSettings(
+                favour: favour, method: method, scale: prepScale, megapixels: megapixels,
+                liveArea: liveArea, processArea: processArea, noComposite: noComposite)
+            let preparedInput = try ImagePreparation.prepare(referenceImages: refImages, settings: settings)
+            pipelineImages = preparedInput.images
+            outputWidth = preparedInput.width
+            outputHeight = preparedInput.height
+            compositionPlan = preparedInput.compositionPlan
+            preparationSettings = settings
+            if verbose {
+                print("Image Preparation: \(settings.sizingMethod.rawValue.lowercased()), favour \(settings.sizingFavor.rawValue.lowercased()), \(String(format: "%.2f", settings.megapixelBudget)) MP budget\(compositionPlan != nil ? ", composite back" : "")")
+            }
+            // The composite geometry is fully determined by the plan above, not
+            // by the generated pixels. Validate it now, before any network/GPU
+            // work, instead of discarding a completed multi-minute generation
+            // if `--process-area`/`--live-area` turn out to map to an empty
+            // canvas rect.
+            if let compositionPlan {
+                try ImagePreparation.validateComposable(compositionPlan)
+            }
+        } else {
+            pipelineImages = refImages
+            outputWidth = width ?? refImages[0].width
+            outputHeight = height ?? refImages[0].height
+        }
 
         print("I2I \(outputWidth)x\(outputHeight), \(actualSteps) steps, guidance \(actualGuidance), \(refImages.count) ref image(s)\(seed.map { ", seed \($0)" } ?? "")...")
         if verbose {
@@ -665,15 +740,34 @@ struct ImageToImage: AsyncParsableCommand {
         // Reference-encode budget policy: framework owns the mechanism (a per-image
         // pixel ceiling); the CLI just maps the user-facing megapixel flag to pixels.
         // 1 MP == 1024×1024, so the default resolves to the historical 1024² budget.
-        let maxReferencePixels = maxReferenceMegapixels
-            .map { max(32 * 32, Int(($0 * 1024 * 1024).rounded())) } ?? (1024 * 1024)
+        //
+        // Image Preparation already rendered the (never-upsampled) reference at
+        // settings.megapixelBudget; without an explicit --max-reference-megapixels
+        // override, re-capping the encode at the unrelated historical 1024²
+        // default here would silently throw away that fidelity (e.g. `--megapixels
+        // 2.0` renders a ~2MP reference, then this recompresses it to ~1MP before
+        // the VAE ever sees it).
+        let maxReferencePixels: Int
+        if let maxReferenceMegapixels {
+            maxReferencePixels = max(32 * 32, Int((maxReferenceMegapixels * 1024 * 1024).rounded()))
+        } else if let preparationSettings {
+            maxReferencePixels = max(32 * 32, ImagePreparation.conditioningPixelBudget(for: preparationSettings.megapixelBudget))
+        } else {
+            maxReferencePixels = 1024 * 1024
+        }
 
-        let image = try await pipeline.generateImageToImage(
+        // Captured by value for the @Sendable checkpoint closure below — checkpoints
+        // are composited the same way the final image is, so a Live-Area run's
+        // intermediate saves show the same framing as the final output instead of
+        // the bare, un-composited generation canvas.
+        let compositionPlanForCheckpoints = compositionPlan
+
+        var image = try await pipeline.generateImageToImage(
             prompt: prompt,
-            images: refImages,
+            images: pipelineImages,
             interpretImagePaths: interpretImagePaths.isEmpty ? nil : interpretImagePaths,
-            height: height,
-            width: width,
+            height: outputHeight,
+            width: outputWidth,
             steps: actualSteps,
             guidance: actualGuidance,
             seed: seed,
@@ -689,7 +783,13 @@ struct ImageToImage: AsyncParsableCommand {
                 if let dir = checkpointDir {
                     let checkpointPath = "\(dir)/step_\(String(format: "%03d", step)).png"
                     do {
-                        try saveImage(checkpointImage, to: checkpointPath)
+                        let toSave: CGImage
+                        if let compositionPlanForCheckpoints {
+                            toSave = try ImagePreparation.composite(checkpointImage, using: compositionPlanForCheckpoints)
+                        } else {
+                            toSave = checkpointImage
+                        }
+                        try saveImage(toSave, to: checkpointPath)
                         print("\n  Checkpoint saved: step_\(String(format: "%03d", step)).png")
                     } catch {
                         print("\n  Failed to save checkpoint at step \(step): \(error.localizedDescription)")
@@ -699,6 +799,16 @@ struct ImageToImage: AsyncParsableCommand {
         )
 
         print()
+
+        // Paste the generated patch back into the full-resolution original
+        // (Image Preparation, Live Area / partial edits only — a full-frame
+        // edit has no surrounding pixels to preserve and skips this).
+        if let compositionPlan {
+            image = try ImagePreparation.composite(image, using: compositionPlan)
+            if verbose {
+                print("Composited into original (\(image.width)x\(image.height))")
+            }
+        }
 
         let elapsed = Date().timeIntervalSince(startTime)
         print("Generation completed in \(String(format: "%.1f", elapsed))s")

--- a/Sources/Flux2CLI/ImageToImagePreparation.swift
+++ b/Sources/Flux2CLI/ImageToImagePreparation.swift
@@ -10,7 +10,11 @@ import Foundation
 
 enum ImageToImagePreparationSupport {
     static func parseNormalizedRect(_ value: String, label: String) throws -> CGRect {
-        let parts = value.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+        // omittingEmptySubsequences: false — the default (true) silently
+        // collapses a stray double comma ("0.1,,0.1,0.8,0.8") into 4 parts
+        // instead of 5, so the malformed input passes the count check with
+        // shifted values rather than being rejected.
+        let parts = value.split(separator: ",", omittingEmptySubsequences: false).map { $0.trimmingCharacters(in: .whitespaces) }
         // `Double("nan")`/`Double("inf")` parse successfully in Swift, so the
         // count/Double(...) guard alone lets a typo like `--live-area
         // nan,0.1,0.8,0.8` through silently — clampUnitRect degrades it to
@@ -61,6 +65,13 @@ enum ImageToImagePreparationSupport {
         processArea: String?,
         noComposite: Bool
     ) -> Bool {
+        // --no-composite is deliberately NOT a trigger on its own: it only
+        // means anything once Image Preparation is already active (the
+        // legacy path has no composite-back step to skip), but its name
+        // doesn't suggest "also reformat/resize the reference" — a caller
+        // adding just --no-composite to an existing invocation would get
+        // silent, unrequested cropping/resizing (and possibly a surprise
+        // --width/--height conflict) instead of the no-op they'd expect.
         prepared
             || favour != nil
             || method != nil
@@ -68,7 +79,6 @@ enum ImageToImagePreparationSupport {
             || megapixels != nil
             || liveArea != nil
             || processArea != nil
-            || noComposite
     }
 
     static func buildSettings(

--- a/Sources/Flux2CLI/ImageToImagePreparation.swift
+++ b/Sources/Flux2CLI/ImageToImagePreparation.swift
@@ -1,0 +1,108 @@
+// ImageToImagePreparation.swift - CLI flag parsing for `flux2 i2i --prepared`
+// Copyright 2025 Vincent Gourbin
+//
+// Originally contributed by Bill Evans (@realnotsteve) in PR #99.
+
+import ArgumentParser
+import CoreGraphics
+import Flux2Core
+import Foundation
+
+enum ImageToImagePreparationSupport {
+    static func parseNormalizedRect(_ value: String, label: String) throws -> CGRect {
+        let parts = value.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+        // `Double("nan")`/`Double("inf")` parse successfully in Swift, so the
+        // count/Double(...) guard alone lets a typo like `--live-area
+        // nan,0.1,0.8,0.8` through silently — clampUnitRect degrades it to
+        // the full frame with no error. Reject explicitly instead.
+        guard parts.count == 4,
+              let x = Double(parts[0]), x.isFinite,
+              let y = Double(parts[1]), y.isFinite,
+              let w = Double(parts[2]), w.isFinite,
+              let h = Double(parts[3]), h.isFinite else {
+            throw ValidationError("\(label) must be four finite numbers x,y,width,height (e.g. 0.1,0.1,0.8,0.8)")
+        }
+        return ImagePreparation.clampUnitRect(CGRect(x: x, y: y, width: w, height: h))
+    }
+
+    private static func parseFiniteFraction(_ value: Double, flag: String) throws -> Double {
+        guard value.isFinite else {
+            throw ValidationError("\(flag) must be a finite number")
+        }
+        return value
+    }
+
+    static func parseFavor(_ value: String) throws -> ImageSizingFavor {
+        switch value.lowercased() {
+        case "original": return .original
+        case "horizontal": return .horizontal
+        case "vertical": return .vertical
+        default:
+            throw ValidationError("Invalid favour: \(value). Use original, horizontal, or vertical")
+        }
+    }
+
+    static func parseMethod(_ value: String) throws -> ImageSizingMethod {
+        switch value.lowercased() {
+        case "crop": return .crop
+        case "pad": return .pad
+        default:
+            throw ValidationError("Invalid method: \(value). Use crop or pad")
+        }
+    }
+
+    static func usesPreparation(
+        prepared: Bool,
+        favour: String?,
+        method: String?,
+        scale: Double?,
+        megapixels: Double?,
+        liveArea: String?,
+        processArea: String?,
+        noComposite: Bool
+    ) -> Bool {
+        prepared
+            || favour != nil
+            || method != nil
+            || scale != nil
+            || megapixels != nil
+            || liveArea != nil
+            || processArea != nil
+            || noComposite
+    }
+
+    static func buildSettings(
+        favour: String?,
+        method: String?,
+        scale: Double?,
+        megapixels: Double?,
+        liveArea: String?,
+        processArea: String?,
+        noComposite: Bool
+    ) throws -> ImagePreparationSettings {
+        var settings = ImagePreparationSettings()
+        if let favour {
+            settings.sizingFavor = try parseFavor(favour)
+        }
+        if let method {
+            settings.sizingMethod = try parseMethod(method)
+        }
+        if let scale {
+            settings.preparationScale = try parseFiniteFraction(scale, flag: "--prep-scale")
+        }
+        if let megapixels {
+            settings.megapixelBudget = try parseFiniteFraction(megapixels, flag: "--megapixels")
+        }
+        if let liveArea {
+            settings.contextArea = try parseNormalizedRect(liveArea, label: "--live-area")
+        }
+        if let processArea {
+            settings.processArea = try parseNormalizedRect(processArea, label: "--process-area")
+        }
+        if noComposite {
+            settings.compositeBack = false
+        }
+        settings.clampValues()
+        return settings
+    }
+}

--- a/Sources/Flux2Core/ImageCoordinateMapper.swift
+++ b/Sources/Flux2Core/ImageCoordinateMapper.swift
@@ -1,0 +1,20 @@
+// ImageCoordinateMapper.swift - Image-space <-> CoreGraphics draw-space rect mapping
+// Copyright 2025 Vincent Gourbin
+//
+// Originally contributed by Bill Evans (@realnotsteve) in PR #99.
+
+import CoreGraphics
+
+/// Bridges image-space rectangles (`CGImage.cropping`, pixel buffers, and the
+/// SwiftUI preview use a top-left origin) to CoreGraphics draw rectangles
+/// (`CGContext.draw` uses a bottom-left origin for the destination rect).
+public enum ImageCoordinateMapper {
+    public static func contextDrawRect(forTopLeftRect rect: CGRect, canvasHeight: CGFloat) -> CGRect {
+        CGRect(
+            x: rect.minX,
+            y: canvasHeight - rect.maxY,
+            width: rect.width,
+            height: rect.height
+        )
+    }
+}

--- a/Sources/Flux2Core/ImagePreparation.swift
+++ b/Sources/Flux2Core/ImagePreparation.swift
@@ -1,0 +1,564 @@
+// ImagePreparation.swift - Barn-door Live Area formatting, sizing, and paste-back composite for I2I
+// Copyright 2025 Vincent Gourbin
+//
+// Originally contributed by Bill Evans (@realnotsteve) in PR #99; this file
+// carries the Image Preparation core (formatting, Live Area, megapixel budget,
+// composite). See docs/ImagePreparation.md.
+
+import CoreGraphics
+import Foundation
+
+public enum ImagePreparation {
+    public static let generationSizeMultiple = 32
+    public static let referenceConditioningArea = 1024 * 1024
+
+    public static func clampUnitRect(_ rect: CGRect) -> CGRect {
+        // A NaN axis (a caller-supplied "nan" numeric string) survives
+        // min/max unclamped — Swift's max(nan, x) returns nan when nan is the
+        // *first* argument — and CGRect.intersection then silently discards
+        // that axis instead of erroring. Replace with the full-frame default
+        // before clamping rather than propagate NaN further.
+        guard rect.minX.isFinite, rect.minY.isFinite, rect.width.isFinite, rect.height.isFinite else {
+            return CGRect(x: 0, y: 0, width: 1, height: 1)
+        }
+        let minSize: CGFloat = 0.01
+        let width = min(max(rect.width, minSize), 1)
+        let height = min(max(rect.height, minSize), 1)
+        let x = min(max(rect.minX, 0), 1 - width)
+        let y = min(max(rect.minY, 0), 1 - height)
+        return CGRect(x: x, y: y, width: width, height: height)
+    }
+
+    public static func snapToMultiple(_ value: Int, multiple: Int) -> Int {
+        guard multiple > 0 else { return value }
+        return max(multiple, ((value + multiple - 1) / multiple) * multiple)
+    }
+
+    /// Round `value` DOWN to `multiple` (floor), never below `multiple` itself.
+    /// The single home for the floor-to-alignment step — the reference-render
+    /// sizing below routes through here so it can't drift.
+    public static func floorToMultiple(_ value: Int, multiple: Int) -> Int {
+        guard multiple > 0 else { return value }
+        return max(multiple, (value / multiple) * multiple)
+    }
+
+    public static func referenceMatchedSize(
+        width: Int,
+        height: Int,
+        maxArea: Int = referenceConditioningArea,
+        multiple: Int = generationSizeMultiple
+    ) -> (width: Int, height: Int) {
+        var w = Double(max(1, width))
+        var h = Double(max(1, height))
+        let area = w * h
+        if area > Double(maxArea) {
+            let scale = (Double(maxArea) / area).squareRoot()
+            w *= scale
+            h *= scale
+        }
+        // .rounded(), not truncation: a scale computation landing just under
+        // an exact integer (e.g. 999.9999999997) would otherwise drop a whole
+        // alignment step before flooring, undershooting the requested budget
+        // by up to `multiple` pixels on either axis for no reason.
+        let flooredWidth = floorToMultiple(Int(w.rounded()), multiple: multiple)
+        let flooredHeight = floorToMultiple(Int(h.rounded()), multiple: multiple)
+        return (flooredWidth, flooredHeight)
+    }
+
+    public static func conditioningPixelBudget(for megapixelBudget: Double) -> Int {
+        let clamped = min(max(megapixelBudget, ImagePreparationSettings.minMegapixelBudget), ImagePreparationSettings.maxMegapixelBudget)
+        return Int((clamped * 1_000_000).rounded())
+    }
+
+    public static func budgetFilledSize(
+        sourceAspect: Double,
+        settings: ImagePreparationSettings
+    ) -> (width: Int, height: Int) {
+        let targetAspect: Double
+        switch settings.sizingFavor {
+        case .original:
+            targetAspect = sourceAspect
+        case .horizontal:
+            targetAspect = max(sourceAspect, 4.0 / 3.0)
+        case .vertical:
+            targetAspect = min(sourceAspect, 3.0 / 4.0)
+        }
+
+        let scale = min(max(settings.preparationScale, 0.1), 1.0)
+        let pixelBudget = Double(conditioningPixelBudget(for: settings.megapixelBudget)) * scale * scale
+        let rawHeight = (pixelBudget / max(targetAspect, 0.0001)).squareRoot()
+        let rawWidth = rawHeight * targetAspect
+
+        return (
+            snapToMultiple(Int(rawWidth.rounded()), multiple: settings.pixelAlignment),
+            snapToMultiple(Int(rawHeight.rounded()), multiple: settings.pixelAlignment)
+        )
+    }
+
+    public static func generationSize(
+        referenceImage: CGImage,
+        settings: ImagePreparationSettings
+    ) -> (width: Int, height: Int) {
+        var settings = settings
+        settings.clampValues()
+        let sourceRect = integralPixelRect(from: settings.contextArea, in: referenceImage)
+        let sourceAspect = Double(sourceRect.width) / Double(sourceRect.height)
+        let size = budgetFilledSize(sourceAspect: sourceAspect, settings: settings)
+        return referenceMatchedSize(
+            width: size.width,
+            height: size.height,
+            maxArea: conditioningPixelBudget(for: settings.megapixelBudget),
+            multiple: settings.pixelAlignment
+        )
+    }
+
+    /// Apply Image Formatting (Favour + crop/pad) to the full reference frame at an
+    /// explicit canvas size. Used for aligned A/B preview and variant saves.
+    public static func formatToCanvas(
+        referenceImage: CGImage,
+        settings: ImagePreparationSettings,
+        targetWidth: Int,
+        targetHeight: Int
+    ) throws -> CGImage {
+        var settings = settings
+        settings.clampValues()
+        settings.contextArea = CGRect(x: 0, y: 0, width: 1, height: 1)
+
+        let contextRect = integralPixelRect(from: settings.contextArea, in: referenceImage)
+        let contextImage = try cropImage(referenceImage, to: contextRect)
+        let transform = preparationTransform(
+            sourceWidth: contextImage.width,
+            sourceHeight: contextImage.height,
+            targetWidth: targetWidth,
+            targetHeight: targetHeight,
+            method: settings.sizingMethod
+        )
+        return try renderImage(
+            contextImage,
+            targetWidth: targetWidth,
+            targetHeight: targetHeight,
+            transform: transform
+        )
+    }
+
+    public static func prepare(
+        referenceImages: [CGImage],
+        settings: ImagePreparationSettings
+    ) throws -> PreparedImageToImageInput {
+        guard let original = referenceImages.first else {
+            throw Flux2Error.invalidConfiguration("Add a reference image before generating")
+        }
+
+        var settings = settings
+        settings.clampValues()
+
+        let (contextRect, processRect) = resolvedRects(settings: settings, image: original)
+        let targetSize = generationSize(referenceImage: original, settings: settings)
+
+        let contextImage = try cropImage(original, to: contextRect)
+        let transform = preparationTransform(
+            sourceWidth: contextImage.width,
+            sourceHeight: contextImage.height,
+            targetWidth: targetSize.width,
+            targetHeight: targetSize.height,
+            method: settings.sizingMethod
+        )
+
+        // Conditioning fidelity: never UP-sample the reference the VAE encodes.
+        // Up-sampling a low-quality JPEG (Core Graphics .high) smears its 8x8
+        // block edges into fuzzy gradients that FLUX.2 reads as real structure —
+        // out of distribution, since super-resolution priors are trained on
+        // native degraded JPEGs, not interpolated ones. Render the reference at
+        // native scale (clamped so the render never exceeds 1.0) and let the
+        // model perform the enlargement generatively. The output canvas and the
+        // composite mapping stay at targetSize via `transform`.
+        let referenceSize = referenceRenderSize(
+            contextWidth: contextImage.width,
+            contextHeight: contextImage.height,
+            targetSize: targetSize,
+            outputScale: transform.scale,
+            alignment: settings.pixelAlignment
+        )
+        let referenceTransform = preparationTransform(
+            sourceWidth: contextImage.width,
+            sourceHeight: contextImage.height,
+            targetWidth: referenceSize.width,
+            targetHeight: referenceSize.height,
+            method: settings.sizingMethod
+        )
+        let preparedFirstImage = try renderImage(
+            contextImage,
+            targetWidth: referenceSize.width,
+            targetHeight: referenceSize.height,
+            transform: referenceTransform
+        )
+
+        let preparedAdditionalImages = try referenceImages.dropFirst().map { image in
+            try formatFullFrameReference(image, settings: settings)
+        }
+        // Fix 2: a full-frame edit (process area covers the whole original) has no
+        // surrounding pixels to preserve, so there's nothing to composite back —
+        // pasting the patch into the original would only down-sample the budget
+        // canvas to the source resolution. Skip the plan so a full-frame
+        // enlarge/rebuild outputs at the budget size. Partial / Live-Area edits
+        // still paste back into the full-resolution original.
+        let fullFrame = isFullFrame(processRect: processRect, original: original)
+        let plan = ImageCompositionPlan(
+            originalImage: original,
+            contextRect: contextRect,
+            processRect: processRect,
+            transform: transform
+        )
+
+        return PreparedImageToImageInput(
+            images: [preparedFirstImage] + preparedAdditionalImages,
+            width: targetSize.width,
+            height: targetSize.height,
+            compositionPlan: (settings.compositeBack && !fullFrame) ? plan : nil
+        )
+    }
+
+    /// Apply Image Formatting to a full-frame reference (Favour, Method, scale, megapixel budget).
+    /// Used for additional conditioning images that do not use Live Area.
+    public static func formatFullFrameReference(
+        _ referenceImage: CGImage,
+        settings: ImagePreparationSettings
+    ) throws -> CGImage {
+        var settings = settings
+        settings.clampValues()
+        settings.contextArea = CGRect(x: 0, y: 0, width: 1, height: 1)
+
+        let targetSize = generationSize(referenceImage: referenceImage, settings: settings)
+
+        // Never upsample: same rationale as the primary reference (see
+        // referenceRenderSize's doc on prepare()) — a secondary reference
+        // smaller than the budget/aspect target was previously rendered
+        // straight to the full target size, smearing an interpolated
+        // reference into the VAE. Render at native scale instead when the
+        // source is smaller, and let the model enlarge generatively.
+        let outputScale = CGFloat(targetSize.width) / CGFloat(max(1, referenceImage.width))
+        let renderSize = referenceRenderSize(
+            contextWidth: referenceImage.width,
+            contextHeight: referenceImage.height,
+            targetSize: targetSize,
+            outputScale: outputScale,
+            alignment: settings.pixelAlignment
+        )
+        return try formatToCanvas(
+            referenceImage: referenceImage,
+            settings: settings,
+            targetWidth: renderSize.width,
+            targetHeight: renderSize.height
+        )
+    }
+
+    /// The region of the generated canvas that actually lands back in the
+    /// original image, or throws the same error `composite()` would.
+    ///
+    /// Depends only on `plan` and the canvas size the plan was built for
+    /// (`plan.transform.targetWidth/targetHeight`) — not on any generated
+    /// pixels — so it can validate a plan is composable *before* running
+    /// generation, instead of discarding a completed (possibly multi-minute)
+    /// generation if `--process-area`/`--live-area` turn out to map to an
+    /// empty canvas rect.
+    public static func validateComposable(_ plan: ImageCompositionPlan) throws {
+        _ = try visibleCanvasRect(for: plan, canvasWidth: plan.transform.targetWidth, canvasHeight: plan.transform.targetHeight)
+    }
+
+    private static func visibleCanvasRect(for plan: ImageCompositionPlan, canvasWidth: Int, canvasHeight: Int) throws -> CGRect {
+        let processInContext = plan.processRect.offsetBy(dx: -plan.contextRect.minX, dy: -plan.contextRect.minY)
+        let mappedProcessRect = plan.transform.canvasRect(forSourceRect: processInContext)
+        let canvasBounds = CGRect(x: 0, y: 0, width: canvasWidth, height: canvasHeight)
+        let visibleCanvasRect = mappedProcessRect.intersection(canvasBounds)
+
+        guard !visibleCanvasRect.isNull, visibleCanvasRect.width > 0, visibleCanvasRect.height > 0 else {
+            throw Flux2Error.imageProcessingFailed("Process area falls outside the generated canvas")
+        }
+        return visibleCanvasRect
+    }
+
+    public static func composite(
+        _ generatedImage: CGImage,
+        using plan: ImageCompositionPlan
+    ) throws -> CGImage {
+        // The plan's transform (scale/offset) was computed for a specific
+        // canvas size during prepare(); compositing against an image of a
+        // different size would silently map the patch using a coordinate
+        // space it wasn't built for, rather than failing loudly.
+        guard generatedImage.width == plan.transform.targetWidth, generatedImage.height == plan.transform.targetHeight else {
+            throw Flux2Error.imageProcessingFailed(
+                "Generated image (\(generatedImage.width)x\(generatedImage.height)) does not match the composition plan's canvas (\(plan.transform.targetWidth)x\(plan.transform.targetHeight))")
+        }
+        // Known ~1-2px edge tolerance: generatedCropRect is rounded outward in
+        // canvas space, then mapped back through the inverse transform and
+        // rounded outward again for destinationRect below. Two independent
+        // outward-rounding steps across a scale factor can each add a
+        // fractional pixel, so the pasted patch can overshoot the intended
+        // Live Area by a pixel or two rather than landing pixel-exact.
+        let visibleCanvasRect = try visibleCanvasRect(for: plan, canvasWidth: generatedImage.width, canvasHeight: generatedImage.height)
+        let generatedCropRect = integralPixelRect(visibleCanvasRect, imageWidth: generatedImage.width, imageHeight: generatedImage.height)
+        let generatedPatch = try cropImage(generatedImage, to: generatedCropRect)
+        let visibleSourceRect = plan.transform.sourceRect(forCanvasRect: generatedCropRect)
+        let destinationRect = integralPixelRect(
+            visibleSourceRect.offsetBy(dx: plan.contextRect.minX, dy: plan.contextRect.minY),
+            imageWidth: plan.originalImage.width,
+            imageHeight: plan.originalImage.height
+        )
+
+        guard let context = makeImageContext(width: plan.originalImage.width, height: plan.originalImage.height) else {
+            throw Flux2Error.imageProcessingFailed("Failed to create composition context")
+        }
+
+        context.interpolationQuality = .high
+        context.draw(
+            plan.originalImage,
+            in: ImageCoordinateMapper.contextDrawRect(
+                forTopLeftRect: CGRect(x: 0, y: 0, width: plan.originalImage.width, height: plan.originalImage.height),
+                canvasHeight: CGFloat(plan.originalImage.height)
+            )
+        )
+        context.draw(
+            generatedPatch,
+            in: ImageCoordinateMapper.contextDrawRect(
+                forTopLeftRect: destinationRect,
+                canvasHeight: CGFloat(plan.originalImage.height)
+            )
+        )
+
+        guard let compositedImage = context.makeImage() else {
+            throw Flux2Error.imageProcessingFailed("Failed to composite generated patch")
+        }
+
+        return compositedImage
+    }
+
+    // MARK: - Private helpers
+
+    /// Size for the conditioning reference render. When the output canvas would
+    /// up-sample the source (`outputScale > 1`), cap the reference at the source's
+    /// native pixels (clamped per-dimension and floored to `alignment`) so the VAE
+    /// encodes real pixels, never interpolation-smeared ones. When the source is
+    /// already at/above budget, the reference matches the output size as before.
+    private static func referenceRenderSize(
+        contextWidth: Int,
+        contextHeight: Int,
+        targetSize: (width: Int, height: Int),
+        outputScale: CGFloat,
+        alignment: Int
+    ) -> (width: Int, height: Int) {
+        guard outputScale > 1 else { return targetSize }
+        let rawWidth = min(Int(CGFloat(targetSize.width) / outputScale), contextWidth)
+        let rawHeight = min(Int(CGFloat(targetSize.height) / outputScale), contextHeight)
+        let flooredWidth = floorToMultiple(rawWidth, multiple: alignment)
+        let flooredHeight = floorToMultiple(rawHeight, multiple: alignment)
+        return (flooredWidth, flooredHeight)
+    }
+
+    /// Whether the resolved `processRect` covers the whole original — a full-frame
+    /// edit with no surrounding pixels to preserve. Drives the Fix 2 composite skip.
+    static func isFullFrame(processRect: CGRect, original: CGImage) -> Bool {
+        processRect.minX <= 0
+            && processRect.minY <= 0
+            && processRect.width >= CGFloat(original.width)
+            && processRect.height >= CGFloat(original.height)
+    }
+
+    /// Whether `settings` resolves to a full-frame edit on `image`: the process
+    /// area covers the whole image. Resolves the process rect through the exact
+    /// same path `prepare()` uses, so this and `prepare()`'s own full-frame check
+    /// (which additionally skips composite-back for a full-frame edit — Fix 2)
+    /// can never disagree about the rect-cover geometry.
+    ///
+    /// This is *not* the same question as "will `prepare()` return a composite
+    /// plan": that also depends on `settings.compositeBack` (`--no-composite`),
+    /// which this predicate does not consult. A caller deciding "will the result
+    /// paste back into the original" needs
+    /// `settings.compositeBack && !isFullFrame(settings:image:)`.
+    public static func isFullFrame(settings: ImagePreparationSettings, image: CGImage) -> Bool {
+        isFullFrame(processRect: resolvedRects(settings: settings, image: image).process, original: image)
+    }
+
+    /// The integral context + process rects for `settings` on `image` — the single
+    /// derivation shared by `prepare()` and `isFullFrame(settings:image:)` so the
+    /// composite-back decision and the public predicate can never disagree.
+    private static func resolvedRects(
+        settings: ImagePreparationSettings,
+        image: CGImage
+    ) -> (context: CGRect, process: CGRect) {
+        var settings = settings
+        settings.clampValues()
+        let contextRect = integralPixelRect(from: settings.contextArea, in: image)
+        let processRect = integralProcessRect(in: image, contextRect: contextRect, processArea: settings.processArea)
+        return (contextRect, processRect)
+    }
+
+    private static func preparationTransform(
+        sourceWidth: Int,
+        sourceHeight: Int,
+        targetWidth: Int,
+        targetHeight: Int,
+        method: ImageSizingMethod
+    ) -> ImagePreparationTransform {
+        let xScale = CGFloat(targetWidth) / CGFloat(max(sourceWidth, 1))
+        let yScale = CGFloat(targetHeight) / CGFloat(max(sourceHeight, 1))
+        let scale = method == .crop ? max(xScale, yScale) : min(xScale, yScale)
+        let drawnWidth = CGFloat(sourceWidth) * scale
+        let drawnHeight = CGFloat(sourceHeight) * scale
+
+        return ImagePreparationTransform(
+            targetWidth: targetWidth,
+            targetHeight: targetHeight,
+            scale: scale,
+            offsetX: (CGFloat(targetWidth) - drawnWidth) / 2,
+            offsetY: (CGFloat(targetHeight) - drawnHeight) / 2
+        )
+    }
+
+    private static func renderImage(
+        _ image: CGImage,
+        targetWidth: Int,
+        targetHeight: Int,
+        transform: ImagePreparationTransform
+    ) throws -> CGImage {
+        guard let context = makeImageContext(width: targetWidth, height: targetHeight) else {
+            throw Flux2Error.imageProcessingFailed("Failed to create prepared image context")
+        }
+
+        context.interpolationQuality = .high
+        let drawRect = CGRect(
+            x: transform.offsetX,
+            y: transform.offsetY,
+            width: CGFloat(image.width) * transform.scale,
+            height: CGFloat(image.height) * transform.scale
+        )
+        context.draw(
+            image,
+            in: ImageCoordinateMapper.contextDrawRect(
+                forTopLeftRect: drawRect,
+                canvasHeight: CGFloat(targetHeight)
+            )
+        )
+
+        guard let renderedImage = context.makeImage() else {
+            throw Flux2Error.imageProcessingFailed("Failed to render prepared image")
+        }
+
+        return renderedImage
+    }
+
+    private static func cropImage(_ image: CGImage, to rect: CGRect) throws -> CGImage {
+        let cropRect = integralPixelRect(rect, imageWidth: image.width, imageHeight: image.height)
+
+        if let cropped = image.cropping(to: cropRect) {
+            return cropped
+        }
+
+        guard let context = makeImageContext(
+            width: integralDimension(cropRect.width),
+            height: integralDimension(cropRect.height)
+        ) else {
+            throw Flux2Error.imageProcessingFailed("Failed to create crop context")
+        }
+
+        let sourceDrawRect = CGRect(
+            x: -cropRect.minX,
+            y: -cropRect.minY,
+            width: CGFloat(image.width),
+            height: CGFloat(image.height)
+        )
+        context.draw(
+            image,
+            in: ImageCoordinateMapper.contextDrawRect(
+                forTopLeftRect: sourceDrawRect,
+                canvasHeight: CGFloat(integralDimension(cropRect.height))
+            )
+        )
+
+        guard let croppedImage = context.makeImage() else {
+            throw Flux2Error.imageProcessingFailed("Failed to crop image")
+        }
+
+        return croppedImage
+    }
+
+    private static func integralProcessRect(
+        in image: CGImage,
+        contextRect: CGRect,
+        processArea: CGRect?
+    ) -> CGRect {
+        guard let processArea else {
+            return contextRect
+        }
+
+        let rawProcessRect = pixelRect(from: clampUnitRect(processArea), in: image)
+        let clampedProcessRect = rawProcessRect.intersection(contextRect)
+
+        guard !clampedProcessRect.isNull, clampedProcessRect.width > 0, clampedProcessRect.height > 0 else {
+            return contextRect
+        }
+
+        return integralPixelRect(clampedProcessRect, imageWidth: image.width, imageHeight: image.height)
+    }
+
+    private static func pixelRect(from normalizedRect: CGRect, in image: CGImage) -> CGRect {
+        CGRect(
+            x: normalizedRect.minX * CGFloat(image.width),
+            y: normalizedRect.minY * CGFloat(image.height),
+            width: normalizedRect.width * CGFloat(image.width),
+            height: normalizedRect.height * CGFloat(image.height)
+        )
+    }
+
+    private static func integralPixelRect(from normalizedRect: CGRect, in image: CGImage) -> CGRect {
+        integralPixelRect(
+            pixelRect(from: clampUnitRect(normalizedRect), in: image),
+            imageWidth: image.width,
+            imageHeight: image.height
+        )
+    }
+
+    private static func integralPixelRect(_ rect: CGRect, imageWidth: Int, imageHeight: Int) -> CGRect {
+        let imageBounds = CGRect(x: 0, y: 0, width: imageWidth, height: imageHeight)
+        let bounded = rect.intersection(imageBounds)
+
+        guard !bounded.isNull, bounded.width > 0, bounded.height > 0 else {
+            // `min(imageWidth, 1)` always evaluates to 1 for any real image —
+            // fall back to the full image bounds, not a degenerate 1x1 rect.
+            return CGRect(x: 0, y: 0, width: max(1, imageWidth), height: max(1, imageHeight))
+        }
+
+        let minX = floor(bounded.minX)
+        let minY = floor(bounded.minY)
+        let maxX = ceil(bounded.maxX)
+        let maxY = ceil(bounded.maxY)
+
+        return CGRect(
+            x: min(max(minX, 0), CGFloat(max(imageWidth - 1, 0))),
+            y: min(max(minY, 0), CGFloat(max(imageHeight - 1, 0))),
+            width: max(1, min(maxX, CGFloat(imageWidth)) - minX),
+            height: max(1, min(maxY, CGFloat(imageHeight)) - minY)
+        )
+    }
+
+    private static func integralDimension(_ value: CGFloat) -> Int {
+        max(1, Int(value.rounded()))
+    }
+
+    private static func makeImageContext(width: Int, height: Int) -> CGContext? {
+        CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )
+    }
+
+    /// Crop a reference image to a normalized top-left unit rectangle.
+    public static func cropReferenceImage(_ image: CGImage, normalizedRect: CGRect) throws -> CGImage {
+        let rect = integralPixelRect(from: normalizedRect, in: image)
+        return try cropImage(image, to: rect)
+    }
+}

--- a/Sources/Flux2Core/ImagePreparation.swift
+++ b/Sources/Flux2Core/ImagePreparation.swift
@@ -66,7 +66,13 @@ public enum ImagePreparation {
     }
 
     public static func conditioningPixelBudget(for megapixelBudget: Double) -> Int {
-        let clamped = min(max(megapixelBudget, ImagePreparationSettings.minMegapixelBudget), ImagePreparationSettings.maxMegapixelBudget)
+        // Public entry point — sanitize independently of ImagePreparationSettings
+        // .clampValues() (a caller may call this directly with a raw Double).
+        // `min`/`max` don't sanitize NaN (`max(nan, x)` is `nan` when nan is the
+        // first argument), which would otherwise reach `Int(_.rounded())` below
+        // — a Swift runtime trap, not a graceful fallback.
+        let budget = megapixelBudget.isFinite ? megapixelBudget : 1.0
+        let clamped = min(max(budget, ImagePreparationSettings.minMegapixelBudget), ImagePreparationSettings.maxMegapixelBudget)
         return Int((clamped * 1_000_000).rounded())
     }
 
@@ -74,6 +80,7 @@ public enum ImagePreparation {
         sourceAspect: Double,
         settings: ImagePreparationSettings
     ) -> (width: Int, height: Int) {
+        let sourceAspect = sourceAspect.isFinite && sourceAspect > 0 ? sourceAspect : 1.0
         let targetAspect: Double
         switch settings.sizingFavor {
         case .original:
@@ -84,7 +91,8 @@ public enum ImagePreparation {
             targetAspect = min(sourceAspect, 3.0 / 4.0)
         }
 
-        let scale = min(max(settings.preparationScale, 0.1), 1.0)
+        let rawScale = settings.preparationScale.isFinite ? settings.preparationScale : 1.0
+        let scale = min(max(rawScale, 0.1), 1.0)
         let pixelBudget = Double(conditioningPixelBudget(for: settings.megapixelBudget)) * scale * scale
         let rawHeight = (pixelBudget / max(targetAspect, 0.0001)).squareRoot()
         let rawWidth = rawHeight * targetAspect
@@ -152,7 +160,7 @@ public enum ImagePreparation {
         var settings = settings
         settings.clampValues()
 
-        let (contextRect, processRect) = resolvedRects(settings: settings, image: original)
+        let (contextRect, processRect) = try resolvedRects(settings: settings, image: original)
         let targetSize = generationSize(referenceImage: original, settings: settings)
 
         let contextImage = try cropImage(original, to: contextRect)
@@ -236,7 +244,20 @@ public enum ImagePreparation {
         // straight to the full target size, smearing an interpolated
         // reference into the VAE. Render at native scale instead when the
         // source is smaller, and let the model enlarge generatively.
-        let outputScale = CGFloat(targetSize.width) / CGFloat(max(1, referenceImage.width))
+        //
+        // The real scale factor is method-dependent (crop takes max(x,y)
+        // scale, pad takes min) and must come from the same
+        // preparationTransform the actual render below uses — a width-only
+        // ratio under-detects upsampling for any settings where Favour/Method
+        // reshape the aspect ratio (e.g. --favour vertical with --method
+        // crop can scale by height far more than by width).
+        let outputScale = preparationTransform(
+            sourceWidth: referenceImage.width,
+            sourceHeight: referenceImage.height,
+            targetWidth: targetSize.width,
+            targetHeight: targetSize.height,
+            method: settings.sizingMethod
+        ).scale
         let renderSize = referenceRenderSize(
             contextWidth: referenceImage.width,
             contextHeight: referenceImage.height,
@@ -289,12 +310,14 @@ public enum ImagePreparation {
             throw Flux2Error.imageProcessingFailed(
                 "Generated image (\(generatedImage.width)x\(generatedImage.height)) does not match the composition plan's canvas (\(plan.transform.targetWidth)x\(plan.transform.targetHeight))")
         }
-        // Known ~1-2px edge tolerance: generatedCropRect is rounded outward in
-        // canvas space, then mapped back through the inverse transform and
-        // rounded outward again for destinationRect below. Two independent
-        // outward-rounding steps across a scale factor can each add a
-        // fractional pixel, so the pasted patch can overshoot the intended
-        // Live Area by a pixel or two rather than landing pixel-exact.
+        // Known edge tolerance: generatedCropRect is rounded outward in canvas
+        // space, then mapped back through the inverse transform and rounded
+        // outward again for destinationRect below. Each outward rounding step
+        // is amplified by 1/plan.transform.scale on the way back to source
+        // space, so the pasted patch can overshoot the intended Live Area by
+        // more than a token pixel or two when the Live Area was drawn much
+        // larger than the megapixel budget (a small transform.scale) — not
+        // pixel-exact in general.
         let visibleCanvasRect = try visibleCanvasRect(for: plan, canvasWidth: generatedImage.width, canvasHeight: generatedImage.height)
         let generatedCropRect = integralPixelRect(visibleCanvasRect, imageWidth: generatedImage.width, imageHeight: generatedImage.height)
         let generatedPatch = try cropImage(generatedImage, to: generatedCropRect)
@@ -375,7 +398,15 @@ public enum ImagePreparation {
     /// paste back into the original" needs
     /// `settings.compositeBack && !isFullFrame(settings:image:)`.
     public static func isFullFrame(settings: ImagePreparationSettings, image: CGImage) -> Bool {
-        isFullFrame(processRect: resolvedRects(settings: settings, image: image).process, original: image)
+        guard let rects = try? resolvedRects(settings: settings, image: image) else {
+            // A --process-area that doesn't overlap the Live Area fails to
+            // resolve (see integralProcessRect) — prepare() surfaces that as
+            // a real error; this read-only predicate has nowhere to throw to,
+            // so it conservatively reports "not full-frame" rather than
+            // guessing whether compositing should be skipped.
+            return false
+        }
+        return isFullFrame(processRect: rects.process, original: image)
     }
 
     /// The integral context + process rects for `settings` on `image` — the single
@@ -384,11 +415,11 @@ public enum ImagePreparation {
     private static func resolvedRects(
         settings: ImagePreparationSettings,
         image: CGImage
-    ) -> (context: CGRect, process: CGRect) {
+    ) throws -> (context: CGRect, process: CGRect) {
         var settings = settings
         settings.clampValues()
         let contextRect = integralPixelRect(from: settings.contextArea, in: image)
-        let processRect = integralProcessRect(in: image, contextRect: contextRect, processArea: settings.processArea)
+        let processRect = try integralProcessRect(in: image, contextRect: contextRect, processArea: settings.processArea)
         return (contextRect, processRect)
     }
 
@@ -485,7 +516,7 @@ public enum ImagePreparation {
         in image: CGImage,
         contextRect: CGRect,
         processArea: CGRect?
-    ) -> CGRect {
+    ) throws -> CGRect {
         guard let processArea else {
             return contextRect
         }
@@ -494,7 +525,13 @@ public enum ImagePreparation {
         let clampedProcessRect = rawProcessRect.intersection(contextRect)
 
         guard !clampedProcessRect.isNull, clampedProcessRect.width > 0, clampedProcessRect.height > 0 else {
-            return contextRect
+            // A non-overlapping --process-area used to fall back to the whole
+            // Live Area here, silently — the pre-flight validateComposable()
+            // check can't catch this because by the time it runs, this
+            // substitution already happened and looks like a normal,
+            // trivially-valid full-Live-Area plan.
+            throw Flux2Error.invalidConfiguration(
+                "--process-area does not overlap the Live Area (--live-area) — check both rects together")
         }
 
         return integralPixelRect(clampedProcessRect, imageWidth: image.width, imageHeight: image.height)

--- a/Sources/Flux2Core/ImagePreparationTypes.swift
+++ b/Sources/Flux2Core/ImagePreparationTypes.swift
@@ -1,0 +1,103 @@
+// ImagePreparationTypes.swift - Settings and geometry types for ImagePreparation
+// Copyright 2025 Vincent Gourbin
+//
+// Originally contributed by Bill Evans (@realnotsteve) in PR #99.
+
+import CoreGraphics
+import Foundation
+
+public enum ImageSizingFavor: String, CaseIterable, Codable, Sendable, Identifiable {
+    case original = "Original"
+    case horizontal = "Horizontal"
+    case vertical = "Vertical"
+
+    public var id: String { rawValue }
+}
+
+public enum ImageSizingMethod: String, CaseIterable, Codable, Sendable, Identifiable {
+    case crop = "Crop"
+    case pad = "Pad"
+
+    public var id: String { rawValue }
+}
+
+/// Normalized (0…1) barn-door / live region and formatting controls for I2I.
+public struct ImagePreparationSettings: Sendable {
+    public var sizingFavor: ImageSizingFavor = .original
+    public var sizingMethod: ImageSizingMethod = .crop
+    public var preparationScale: Double = 1.0
+    public var megapixelBudget: Double = 1.0
+    public var contextArea: CGRect = CGRect(x: 0, y: 0, width: 1, height: 1)
+    public var processArea: CGRect?
+    public var pixelAlignment: Int = ImagePreparation.generationSizeMultiple
+    /// When true, paste the generated patch back into the full-resolution original.
+    public var compositeBack: Bool = true
+
+    public init() {}
+
+    public static let minMegapixelBudget = 0.25
+    public static let maxMegapixelBudget = 4.0
+
+    public mutating func clampValues() {
+        // `min`/`max` do not sanitize NaN (Swift returns the non-NaN operand
+        // only when it's the *second* argument; `max(nan, 1.0)` is `nan`), so
+        // a caller-supplied NaN/infinite value survives straight through and
+        // later crashes `Int((nan * 1_000_000).rounded())` with no
+        // diagnostic. Replace with the default before clamping.
+        if !preparationScale.isFinite { preparationScale = 1.0 }
+        if !megapixelBudget.isFinite { megapixelBudget = 1.0 }
+        preparationScale = min(max(preparationScale, 0.1), 1.0)
+        megapixelBudget = min(max(megapixelBudget, Self.minMegapixelBudget), Self.maxMegapixelBudget)
+        contextArea = ImagePreparation.clampUnitRect(contextArea)
+        if let processArea {
+            self.processArea = ImagePreparation.clampUnitRect(processArea)
+        }
+    }
+}
+
+public struct ImagePreparationTransform: Sendable {
+    public let targetWidth: Int
+    public let targetHeight: Int
+    public let scale: CGFloat
+    public let offsetX: CGFloat
+    public let offsetY: CGFloat
+
+    public func canvasRect(forSourceRect sourceRect: CGRect) -> CGRect {
+        CGRect(
+            x: sourceRect.minX * scale + offsetX,
+            y: sourceRect.minY * scale + offsetY,
+            width: sourceRect.width * scale,
+            height: sourceRect.height * scale
+        )
+    }
+
+    public func sourceRect(forCanvasRect canvasRect: CGRect) -> CGRect {
+        CGRect(
+            x: (canvasRect.minX - offsetX) / scale,
+            y: (canvasRect.minY - offsetY) / scale,
+            width: canvasRect.width / scale,
+            height: canvasRect.height / scale
+        )
+    }
+}
+
+public struct ImageCompositionPlan: Sendable {
+    public let originalImage: CGImage
+    public let contextRect: CGRect
+    public let processRect: CGRect
+    public let transform: ImagePreparationTransform
+}
+
+public struct PreparedImageToImageInput: Sendable {
+    public let images: [CGImage]
+    public let width: Int
+    public let height: Int
+    public let compositionPlan: ImageCompositionPlan?
+
+    public init(images: [CGImage], width: Int, height: Int, compositionPlan: ImageCompositionPlan?) {
+        self.images = images
+        self.width = width
+        self.height = height
+        self.compositionPlan = compositionPlan
+    }
+}

--- a/Tests/Flux2CoreTests/ImageCoordinateMapperTests.swift
+++ b/Tests/Flux2CoreTests/ImageCoordinateMapperTests.swift
@@ -1,0 +1,132 @@
+// ImageCoordinateMapperTests.swift - Image-space <-> CoreGraphics draw-space rect mapping
+// Copyright 2025 Vincent Gourbin
+//
+// Originally contributed by Bill Evans (@realnotsteve) in PR #99.
+
+import CoreGraphics
+@testable import Flux2Core
+import XCTest
+
+final class ImageCoordinateMapperTests: XCTestCase {
+    func testTopLeftRectConvertsToCoreGraphicsDestinationRect() {
+        let rect = CGRect(x: 10, y: 20, width: 30, height: 40)
+
+        XCTAssertEqual(
+            ImageCoordinateMapper.contextDrawRect(forTopLeftRect: rect, canvasHeight: 200),
+            CGRect(x: 10, y: 140, width: 30, height: 40)
+        )
+    }
+
+    func testMappedImageDrawLandsInRequestedTopLeftPixels() throws {
+        let patch = try makeImage(
+            width: 2,
+            height: 2,
+            pixels: [
+                .red, .green,
+                .blue, .white,
+            ]
+        )
+        var canvas = [UInt8](repeating: 0, count: 4 * 4 * 4)
+        let context = try makeContext(width: 4, height: 4, data: &canvas)
+        context.interpolationQuality = .none
+
+        context.draw(
+            patch,
+            in: ImageCoordinateMapper.contextDrawRect(
+                forTopLeftRect: CGRect(x: 1, y: 0, width: 2, height: 2),
+                canvasHeight: 4
+            )
+        )
+
+        XCTAssertEqual(pixelName(canvas, width: 4, x: 1, y: 0), "red")
+        XCTAssertEqual(pixelName(canvas, width: 4, x: 2, y: 0), "green")
+        XCTAssertEqual(pixelName(canvas, width: 4, x: 1, y: 1), "blue")
+        XCTAssertEqual(pixelName(canvas, width: 4, x: 2, y: 1), "white")
+        XCTAssertEqual(pixelName(canvas, width: 4, x: 1, y: 2), "black")
+    }
+
+    func testUnmappedImageDrawLandsOnWrongVerticalSide() throws {
+        let patch = try makeImage(
+            width: 1,
+            height: 1,
+            pixels: [.red]
+        )
+        var canvas = [UInt8](repeating: 0, count: 4 * 4 * 4)
+        let context = try makeContext(width: 4, height: 4, data: &canvas)
+        context.interpolationQuality = .none
+
+        context.draw(patch, in: CGRect(x: 1, y: 0, width: 1, height: 1))
+
+        XCTAssertEqual(pixelName(canvas, width: 4, x: 1, y: 0), "black")
+        XCTAssertEqual(pixelName(canvas, width: 4, x: 1, y: 3), "red")
+    }
+}
+
+private enum TestPixel {
+    case black
+    case red
+    case green
+    case blue
+    case white
+
+    var rgba: [UInt8] {
+        switch self {
+        case .black: return [0, 0, 0, 255]
+        case .red: return [255, 0, 0, 255]
+        case .green: return [0, 255, 0, 255]
+        case .blue: return [0, 0, 255, 255]
+        case .white: return [255, 255, 255, 255]
+        }
+    }
+}
+
+private func makeImage(width: Int, height: Int, pixels: [TestPixel]) throws -> CGImage {
+    let data = Data(pixels.flatMap(\.rgba))
+    guard let provider = CGDataProvider(data: data as CFData),
+          let image = CGImage(
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bitsPerPixel: 32,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent
+          ) else {
+        throw XCTSkip("Could not create test image")
+    }
+    return image
+}
+
+private func makeContext(width: Int, height: Int, data: inout [UInt8]) throws -> CGContext {
+    guard let context = CGContext(
+        data: &data,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: width * 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ) else {
+        throw XCTSkip("Could not create test context")
+    }
+    return context
+}
+
+private func pixelName(_ data: [UInt8], width: Int, x: Int, y: Int) -> String {
+    let index = (y * width + x) * 4
+    let red = data[index]
+    let green = data[index + 1]
+    let blue = data[index + 2]
+
+    switch (red, green, blue) {
+    case (255, 0, 0): return "red"
+    case (0, 255, 0): return "green"
+    case (0, 0, 255): return "blue"
+    case (255, 255, 255): return "white"
+    default: return "black"
+    }
+}

--- a/Tests/Flux2CoreTests/ImagePreparationFullFrameTests.swift
+++ b/Tests/Flux2CoreTests/ImagePreparationFullFrameTests.swift
@@ -1,0 +1,162 @@
+// ImagePreparationFullFrameTests.swift - Full-frame composite skip and floor primitive
+// Copyright 2025 Vincent Gourbin
+//
+// Originally contributed by Bill Evans (@realnotsteve) in PR #99.
+
+import CoreGraphics
+@testable import Flux2Core
+import XCTest
+
+/// Pins the behavior the clean/size/invent pipeline relies on: a full-frame
+/// edit outputs at the budget size instead of being down-sampled back to the
+/// source.
+final class ImagePreparationFullFrameTests: XCTestCase {
+    private func makeImage(width: Int, height: Int) -> CGImage {
+        let context = CGContext(
+            data: nil, width: width, height: height,
+            bitsPerComponent: 8, bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        return context.makeImage()!
+    }
+
+    func testFloorToMultiple() {
+        XCTAssertEqual(ImagePreparation.floorToMultiple(64, multiple: 32), 64)
+        XCTAssertEqual(ImagePreparation.floorToMultiple(63, multiple: 32), 32)
+        XCTAssertEqual(ImagePreparation.floorToMultiple(95, multiple: 32), 64)
+        XCTAssertEqual(ImagePreparation.floorToMultiple(10, multiple: 32), 32)   // never below the multiple
+        XCTAssertEqual(ImagePreparation.floorToMultiple(0, multiple: 32), 32)
+        XCTAssertEqual(ImagePreparation.floorToMultiple(100, multiple: 0), 100)  // guard: non-positive multiple
+    }
+
+    func testIsFullFramePredicate() {
+        let image = makeImage(width: 200, height: 100)
+        XCTAssertTrue(ImagePreparation.isFullFrame(
+            processRect: CGRect(x: 0, y: 0, width: 200, height: 100), original: image))
+        XCTAssertFalse(ImagePreparation.isFullFrame(
+            processRect: CGRect(x: 10, y: 0, width: 190, height: 100), original: image))
+        XCTAssertFalse(ImagePreparation.isFullFrame(
+            processRect: CGRect(x: 0, y: 0, width: 100, height: 100), original: image))
+    }
+
+    func testFullFrameEditSkipsCompositePlan() throws {
+        let image = makeImage(width: 1500, height: 1000)
+        var settings = ImagePreparationSettings()
+        settings.megapixelBudget = 1.0
+        settings.compositeBack = true  // full contextArea + nil processArea => full-frame
+
+        let result = try ImagePreparation.prepare(referenceImages: [image], settings: settings)
+        XCTAssertNil(result.compositionPlan, "Full-frame edit must skip composite-back (Fix 2)")
+        // Output lands at the budget size, not the source size.
+        XCTAssertEqual(result.width % 32, 0)
+        XCTAssertEqual(result.height % 32, 0)
+        XCTAssertLessThanOrEqual(result.width * result.height, 1_000_000 + 32 * 32)
+        XCTAssertLessThan(result.width, image.width)  // 1500x1000 source enlarges/shrinks to ~1MP budget
+    }
+
+    func testPartialEditKeepsCompositePlan() throws {
+        let image = makeImage(width: 1500, height: 1000)
+        var settings = ImagePreparationSettings()
+        settings.megapixelBudget = 1.0
+        settings.compositeBack = true
+        settings.processArea = CGRect(x: 0.25, y: 0.25, width: 0.5, height: 0.5)
+
+        let result = try ImagePreparation.prepare(referenceImages: [image], settings: settings)
+        XCTAssertNotNil(result.compositionPlan, "Partial edit must composite back into the original")
+    }
+
+    func testFullFrameWithCompositeBackOffStaysNil() throws {
+        let image = makeImage(width: 800, height: 800)
+        var settings = ImagePreparationSettings()
+        settings.megapixelBudget = 1.0
+        settings.compositeBack = false
+
+        let result = try ImagePreparation.prepare(referenceImages: [image], settings: settings)
+        XCTAssertNil(result.compositionPlan)
+    }
+
+    func testClampUnitRectReplacesNaNAxisWithFullFrame() {
+        let withNaN = CGRect(x: CGFloat.nan, y: 0.1, width: 0.8, height: 0.8)
+        XCTAssertEqual(ImagePreparation.clampUnitRect(withNaN), CGRect(x: 0, y: 0, width: 1, height: 1))
+    }
+
+    func testClampValuesReplacesNaNBudgetAndScaleWithDefaults() {
+        var settings = ImagePreparationSettings()
+        settings.megapixelBudget = .nan
+        settings.preparationScale = .nan
+        settings.clampValues()
+        XCTAssertEqual(settings.megapixelBudget, 1.0)
+        XCTAssertEqual(settings.preparationScale, 1.0)
+    }
+
+    func testReferenceMatchedSizeRoundsRatherThanTruncates() {
+        // width=1983, height=4, maxArea=1983 => scale = sqrt(1983/7932) = 0.5
+        // exactly (both operands exactly representable), so the scaled width
+        // is exactly 991.5 — a clean tie that lands in a *different* 32px
+        // bucket depending on whether it's truncated or rounded:
+        // truncate: Int(991.5) = 991 -> floorToMultiple = 960
+        // round:    Int(991.5.rounded()) = 992 -> floorToMultiple = 992
+        let (width, _) = ImagePreparation.referenceMatchedSize(
+            width: 1983, height: 4, maxArea: 1983, multiple: 32)
+        XCTAssertEqual(width, 992)
+        XCTAssertNotEqual(width, 960, "still truncating instead of rounding")
+    }
+
+    func testValidateComposableThrowsForEmptyIntersection() throws {
+        let image = makeImage(width: 1200, height: 900)
+        var settings = ImagePreparationSettings()
+        settings.megapixelBudget = 1.0
+        settings.processArea = CGRect(x: 0.25, y: 0.25, width: 0.5, height: 0.5)
+
+        let prepared = try ImagePreparation.prepare(referenceImages: [image], settings: settings)
+        let plan = try XCTUnwrap(prepared.compositionPlan)
+
+        // A valid plan validates without throwing...
+        XCTAssertNoThrow(try ImagePreparation.validateComposable(plan))
+
+        // ...and this check runs before generation: it must reject a plan
+        // whose process rect can't map onto its own canvas, without needing
+        // a generated image at all (a completed multi-minute generation must
+        // never be the first place this is discovered).
+        let brokenPlan = ImageCompositionPlan(
+            originalImage: plan.originalImage,
+            contextRect: plan.contextRect,
+            processRect: CGRect(x: 999_999, y: 999_999, width: 10, height: 10),
+            transform: plan.transform
+        )
+        XCTAssertThrowsError(try ImagePreparation.validateComposable(brokenPlan))
+    }
+
+    func testCompositeRejectsGeneratedImageOfTheWrongSize() throws {
+        let image = makeImage(width: 1200, height: 900)
+        var settings = ImagePreparationSettings()
+        settings.megapixelBudget = 1.0
+        settings.processArea = CGRect(x: 0.25, y: 0.25, width: 0.5, height: 0.5)
+
+        let prepared = try ImagePreparation.prepare(referenceImages: [image], settings: settings)
+        let plan = try XCTUnwrap(prepared.compositionPlan)
+
+        // A generated image of the wrong size must not be silently
+        // mapped through geometry the plan wasn't built for.
+        let wrongSize = makeImage(width: 64, height: 64)
+        XCTAssertThrowsError(try ImagePreparation.composite(wrongSize, using: plan))
+    }
+
+    /// The public settings+image predicate must classify edits identically to the
+    /// composite-back decision inside prepare() — the same resolved rects back both.
+    func testPublicIsFullFramePredicateMatchesPrepareClassification() throws {
+        let image = makeImage(width: 1200, height: 900)
+
+        var full = ImagePreparationSettings()
+        full.megapixelBudget = 1.0
+        full.compositeBack = true
+        XCTAssertTrue(ImagePreparation.isFullFrame(settings: full, image: image))
+        XCTAssertNil(try ImagePreparation.prepare(referenceImages: [image], settings: full).compositionPlan)
+
+        var partial = full
+        partial.processArea = CGRect(x: 0.2, y: 0.2, width: 0.4, height: 0.4)
+        XCTAssertFalse(ImagePreparation.isFullFrame(settings: partial, image: image))
+        XCTAssertNotNil(try ImagePreparation.prepare(referenceImages: [image], settings: partial).compositionPlan)
+    }
+}

--- a/Tests/Flux2CoreTests/ImagePreparationFullFrameTests.swift
+++ b/Tests/Flux2CoreTests/ImagePreparationFullFrameTests.swift
@@ -103,6 +103,18 @@ final class ImagePreparationFullFrameTests: XCTestCase {
         XCTAssertNotEqual(width, 960, "still truncating instead of rounding")
     }
 
+    func testPrepareThrowsWhenProcessAreaDoesNotOverlapLiveArea() throws {
+        let image = makeImage(width: 1200, height: 900)
+        var settings = ImagePreparationSettings()
+        settings.contextArea = CGRect(x: 0, y: 0, width: 0.3, height: 0.3)   // Live Area: top-left corner
+        settings.processArea = CGRect(x: 0.7, y: 0.7, width: 0.3, height: 0.3)  // does not overlap
+
+        // Previously silently substituted the whole Live Area instead of
+        // erroring — a typo'd, non-overlapping pair must be rejected, not
+        // silently regenerate a different region than requested.
+        XCTAssertThrowsError(try ImagePreparation.prepare(referenceImages: [image], settings: settings))
+    }
+
     func testValidateComposableThrowsForEmptyIntersection() throws {
         let image = makeImage(width: 1200, height: 900)
         var settings = ImagePreparationSettings()

--- a/Tests/Flux2CoreTests/ImagePreparationMultiReferenceTests.swift
+++ b/Tests/Flux2CoreTests/ImagePreparationMultiReferenceTests.swift
@@ -1,0 +1,72 @@
+// ImagePreparationMultiReferenceTests.swift - Multi-reference formatting behavior
+// Copyright 2025 Vincent Gourbin
+//
+// Originally contributed by Bill Evans (@realnotsteve) in PR #99.
+
+import CoreGraphics
+import Flux2Core
+import XCTest
+
+final class ImagePreparationMultiReferenceTests: XCTestCase {
+    func testPrepareFormatsEveryReferenceImage() throws {
+        let primary = Self.makeSolidImage(width: 800, height: 600)
+        let secondary = Self.makeSolidImage(width: 1920, height: 1080)
+
+        var settings = ImagePreparationSettings()
+        settings.sizingFavor = .horizontal
+        settings.sizingMethod = .pad
+        settings.megapixelBudget = 1.0
+
+        let prepared = try ImagePreparation.prepare(
+            referenceImages: [primary, secondary],
+            settings: settings
+        )
+
+        XCTAssertEqual(prepared.images.count, 2)
+
+        for image in prepared.images {
+            XCTAssertEqual(image.width % settings.pixelAlignment, 0)
+            XCTAssertEqual(image.height % settings.pixelAlignment, 0)
+        }
+
+        XCTAssertNotEqual(prepared.images[1].width, secondary.width)
+        XCTAssertNotEqual(prepared.images[1].height, secondary.height)
+    }
+
+    /// A secondary reference smaller than the megapixel budget must not be
+    /// upsampled to fill it — same "never upsample, let the model enlarge"
+    /// rule the primary reference already followed.
+    func testSecondaryReferenceSmallerThanBudgetIsNotUpsampled() throws {
+        let primary = Self.makeSolidImage(width: 1200, height: 900)
+        let smallSecondary = Self.makeSolidImage(width: 200, height: 150)  // well under 1 MP
+
+        var settings = ImagePreparationSettings()
+        settings.megapixelBudget = 1.0  // budget would want ~1152x864 at this aspect
+
+        let prepared = try ImagePreparation.prepare(
+            referenceImages: [primary, smallSecondary],
+            settings: settings
+        )
+
+        let secondaryPrepared = prepared.images[1]
+        XCTAssertLessThanOrEqual(secondaryPrepared.width, smallSecondary.width)
+        XCTAssertLessThanOrEqual(secondaryPrepared.height, smallSecondary.height)
+    }
+
+    private static func makeSolidImage(width: Int, height: Int) -> CGImage {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        ), let image = context.makeImage() else {
+            fatalError("Failed to create test image")
+        }
+        return image
+    }
+}

--- a/Tests/Flux2CoreTests/ImagePreparationMultiReferenceTests.swift
+++ b/Tests/Flux2CoreTests/ImagePreparationMultiReferenceTests.swift
@@ -53,6 +53,29 @@ final class ImagePreparationMultiReferenceTests: XCTestCase {
         XCTAssertLessThanOrEqual(secondaryPrepared.height, smallSecondary.height)
     }
 
+    /// A width-only upsample check misses genuine upsampling whenever
+    /// Favour/Method reshape the aspect ratio: with `--favour vertical
+    /// --method crop`, the real (crop) scale factor comes from the HEIGHT
+    /// axis, which can exceed 1 even while the width ratio stays <= 1.
+    func testFormatFullFrameReferenceUsesRealCropScaleNotWidthRatio() throws {
+        let secondary = Self.makeSolidImage(width: 1200, height: 900)  // 4:3
+
+        var settings = ImagePreparationSettings()
+        settings.sizingFavor = .vertical  // forces target aspect <= 3:4
+        settings.sizingMethod = .crop
+        settings.megapixelBudget = 1.0
+
+        let prepared = try ImagePreparation.formatFullFrameReference(secondary, settings: settings)
+
+        // A width-only check would see 896/1200 ~= 0.75 <= 1 and render
+        // straight to the full (upsampled) target height of ~1184 — genuine
+        // upsampling past the native 900px height. The real crop scale
+        // (max of the x/y axis scales) is what actually exceeds 1 here, and
+        // must trigger the native-resolution cap.
+        XCTAssertLessThanOrEqual(prepared.width, secondary.width)
+        XCTAssertLessThanOrEqual(prepared.height, secondary.height)
+    }
+
     private static func makeSolidImage(width: Int, height: Int) -> CGImage {
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -229,6 +229,39 @@ flux2 i2i <prompt> --images <img1> --images <img2> [--images <img3>] [options]
 | `--text-quant` | | `8bit` | Text encoder quantization |
 | `--transformer-quant` | | `qint8` | Transformer quantization |
 
+### Image Preparation (barn-door Live Area + megapixel budget)
+
+An alternative to `--width`/`--height` (incompatible with them — see below): format the reference to the
+model's step size, optionally narrow generation to a **Live Area** sub-region
+("barn doors"), and composite the result back into the full-resolution
+original. See [docs/ImagePreparation.md](ImagePreparation.md) for the full
+model — what Live Area is (and isn't), how the megapixel budget interacts
+with it, and worked examples.
+
+Any of these flags enables the prepared pipeline (or pass `--prepared` alone
+for just the formatting step):
+
+| Option | Description |
+|--------|-------------|
+| `--prepared` | Enable Image Preparation with default settings (crop, original aspect, 1.0 MP budget) |
+| `--favour <original\|horizontal\|vertical>` | Bias crop/pad toward the source aspect, or force wide/tall |
+| `--method <crop\|pad>` | Fit to step size by cropping or letterbox-padding |
+| `--prep-scale <0.1-1.0>` | Fine-tune how aggressively the image is scaled before crop/pad |
+| `--megapixels <0.25-4.0>` | Total pixel budget for generation (default `1.0`) |
+| `--live-area <x,y,w,h>` | Normalized barn-door rect — what the model sees and where the result pastes back |
+| `--process-area <x,y,w,h>` | Normalized sub-rect of the Live Area actually regenerated (advanced; defaults to the whole Live Area) |
+| `--no-composite` | Output the generated canvas as-is instead of pasting back into the original |
+
+```bash
+# Format a wide photo to the model's step size, favouring a squarer crop
+flux2 i2i "warm afternoon light" -i photo.jpg -o edited.png \
+  --prepared --method crop --favour horizontal --megapixels 1.5
+
+# Narrow generation to a room in the frame (barn doors), paste back on a hard edge
+flux2 i2i "add a reading lamp on the side table" -i room.jpg -o edited.png \
+  --live-area 0.15,0.1,0.7,0.85 --megapixels 1.0
+```
+
 ### Understanding Strength
 
 The `--strength` parameter controls how much of the original image is preserved:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -238,8 +238,14 @@ original. See [docs/ImagePreparation.md](ImagePreparation.md) for the full
 model — what Live Area is (and isn't), how the megapixel budget interacts
 with it, and worked examples.
 
-Any of these flags enables the prepared pipeline (or pass `--prepared` alone
-for just the formatting step):
+Any of `--prepared`/`--favour`/`--method`/`--prep-scale`/`--megapixels`/
+`--live-area`/`--process-area` enables the prepared pipeline (`--prepared`
+alone just runs the formatting step with defaults). `--no-composite` only
+has an effect combined with one of those — on its own it's a no-op, since
+the legacy path has no composite-back step to skip.
+
+Live Area / `--process-area` are only applied to the **first** `--images`
+reference; additional references are formatted full-frame regardless.
 
 | Option | Description |
 |--------|-------------|
@@ -248,9 +254,9 @@ for just the formatting step):
 | `--method <crop\|pad>` | Fit to step size by cropping or letterbox-padding |
 | `--prep-scale <0.1-1.0>` | Fine-tune how aggressively the image is scaled before crop/pad |
 | `--megapixels <0.25-4.0>` | Total pixel budget for generation (default `1.0`) |
-| `--live-area <x,y,w,h>` | Normalized barn-door rect — what the model sees and where the result pastes back |
-| `--process-area <x,y,w,h>` | Normalized sub-rect of the Live Area actually regenerated (advanced; defaults to the whole Live Area) |
-| `--no-composite` | Output the generated canvas as-is instead of pasting back into the original |
+| `--live-area <x,y,w,h>` | Normalized barn-door rect (against the full original image) — what the model sees and where the result pastes back |
+| `--process-area <x,y,w,h>` | Normalized rect, **in the same full-image coordinate space as `--live-area`** (not relative to it) — the region actually regenerated; must overlap `--live-area`, or the command errors. Advanced; defaults to the whole Live Area |
+| `--no-composite` | Skip pasting the generated canvas back into the original (only meaningful alongside another prep flag) |
 
 ```bash
 # Format a wide photo to the model's step size, favouring a squarer crop

--- a/docs/ImagePreparation.md
+++ b/docs/ImagePreparation.md
@@ -1,0 +1,92 @@
+# Image Preparation
+
+Barn-door **Live Area** editing and megapixel-budget formatting for I2I —
+contributed by Bill Evans ([@realnotsteve](https://github.com/realnotsteve))
+in [PR #99](https://github.com/VincentGourbin/flux-2-swift-mlx/pull/99), carved
+down to the Core formatting/Live Area/composite workflow for this merge (see
+that PR's history for the fuller fork, including a Generative Fill mode and
+Flux2App project-file UI, not part of this scope).
+
+## Step 1 — Image Formatting (mandatory)
+
+Before generation, the reference image is fit to the **optimal step size**
+for the model (FLUX.2 snaps to a 32-pixel grid).
+
+| Control | What it does |
+|---|---|
+| **Favour** (`--favour`) | Bias toward original aspect, horizontal, or vertical when choosing crop geometry |
+| **Method** (`--method`) | **Crop** discards pixels outside the target frame; **Pad** letterboxes to preserve the full image |
+| **Scale** (`--prep-scale`) | Fine-tune how aggressively the image is scaled before crop/pad |
+
+Image Formatting always runs once any prep flag is set — the model needs
+correctly dimensioned input.
+
+## Step 2 — Live Area (optional)
+
+After formatting, generation can be narrowed to a **sub-region** of the image
+via `--live-area x,y,width,height` (normalized `0…1`, top-left origin).
+
+**What Live Area is**
+
+- Defines what the model **sees** for conditioning (context for inferring
+  lighting, materials, geometry, etc.)
+- Defines where the **generated result is rendered and pasted back**
+
+**What Live Area is not**
+
+- Not a brush mask — anything outside the Live Area on the full-resolution
+  image stays effectively bit-exact original (the compositing round-trip
+  through the generation-resolution canvas can shift the paste-back edge by
+  a pixel or two); inside, the whole crop is reinterpreted toward the prompt
+  and pasted back on a hard edge.
+- Not object referents for the prompt ("these three women") — the **text
+  prompt** carries the edit; Live Area carries scene volume and megapixel
+  economics.
+
+**Why bother**
+
+- **Megapixel economics** — exclude parts of the frame irrelevant to
+  inference so the megapixel budget is spent on the scene that matters.
+- **Raise effective resolution** — pair Live Area with the budget so a
+  smaller geographic slice still generates at full output size.
+- **Reframe aspect ratio** — on a very wide master, draw a region closer to
+  square instead of forcing a long skinny crop through the budget.
+
+**Operator intent.** Draw generously: big enough for the model to infer
+lighting, geometry, and relationships, and big enough for the composite to
+land knock-on effects (e.g. shadows on a far wall), while dropping dead
+weight that will never change. If a shadow or reflection should differ after
+the edit, that surface must be *inside* the Live Area — pixels outside never
+update.
+
+## Megapixel Budget (`--megapixels`)
+
+Separate from Live Area, but they work together. The budget is the maximum
+total pixel count for generation (`0.25`–`4.0` MP, default `1.0`). Live Area
+sets the **aspect ratio**; the budget sets **how many pixels** fill that
+ratio — a small live region with a 1 MP budget still generates at ~1 MP in
+that aspect (the conditioning crop is upscaled to hit the budget), giving
+local editing without throwing away output resolution.
+
+## End-to-end flow
+
+1. Load reference image
+2. **Image Formatting** — crop/pad to model step size
+3. **Live Area** (optional) — narrow to a sub-region
+4. Set prompt, steps, guidance, megapixel budget
+5. Generate
+6. Composite the result back into the original at the Live Area (skipped for
+   a full-frame edit, or with `--no-composite`)
+
+## Flux2CLI
+
+```bash
+flux2 i2i "cyan studio backdrop" -i photo.jpg -o edited.png \
+  --prepared --method pad --favour original --megapixels 1.0
+
+flux2 i2i "warmer light, add a lamp" -i room.jpg -o edited.png \
+  --live-area 0.15,0.1,0.7,0.85 --megapixels 1.5
+```
+
+See `flux2 i2i --help` for the full flag list, or
+[docs/CLI.md](CLI.md#image-preparation-barn-door-live-area--megapixel-budget).

--- a/docs/ImagePreparation.md
+++ b/docs/ImagePreparation.md
@@ -21,10 +21,16 @@ for the model (FLUX.2 snaps to a 32-pixel grid).
 Image Formatting always runs once any prep flag is set — the model needs
 correctly dimensioned input.
 
+With multiple `--images`, Live Area and `--process-area` only apply to the
+**first** reference; every additional reference is formatted full-frame
+regardless of a Live Area on the first.
+
 ## Step 2 — Live Area (optional)
 
 After formatting, generation can be narrowed to a **sub-region** of the image
-via `--live-area x,y,width,height` (normalized `0…1`, top-left origin).
+via `--live-area x,y,width,height` (normalized `0…1`, top-left origin, against
+the full original image). `--process-area` uses that same coordinate space
+(not relative to the Live Area) and must overlap it.
 
 **What Live Area is**
 
@@ -37,8 +43,10 @@ via `--live-area x,y,width,height` (normalized `0…1`, top-left origin).
 - Not a brush mask — anything outside the Live Area on the full-resolution
   image stays effectively bit-exact original (the compositing round-trip
   through the generation-resolution canvas can shift the paste-back edge by
-  a pixel or two); inside, the whole crop is reinterpreted toward the prompt
-  and pasted back on a hard edge.
+  a few pixels — more for a Live Area drawn much larger than the megapixel
+  budget, since the round-trip rounding error scales with that ratio);
+  inside, the whole crop is reinterpreted toward the prompt and pasted back
+  on a hard edge.
 - Not object referents for the prompt ("these three women") — the **text
   prompt** carries the edit; Live Area carries scene volume and megapixel
   economics.
@@ -63,10 +71,17 @@ update.
 
 Separate from Live Area, but they work together. The budget is the maximum
 total pixel count for generation (`0.25`–`4.0` MP, default `1.0`). Live Area
-sets the **aspect ratio**; the budget sets **how many pixels** fill that
-ratio — a small live region with a 1 MP budget still generates at ~1 MP in
-that aspect (the conditioning crop is upscaled to hit the budget), giving
-local editing without throwing away output resolution.
+sets the **aspect ratio**; the budget sets **how many pixels** the model
+*generates* — a small live region with a 1 MP budget still generates at ~1 MP
+in that aspect, giving local editing without throwing away output
+resolution.
+
+That's the generation canvas, not the reference the VAE encodes: the
+reference is deliberately never upsampled past its native resolution (an
+interpolated, upsampled JPEG smears into fuzzy gradients FLUX.2 reads as
+real structure) — it's rendered at native scale and the model enlarges it
+generatively to fill the budget, rather than the framework enlarging the
+pixels first.
 
 ## End-to-end flow
 


### PR DESCRIPTION
## Summary

A narrow carve-out of #99 (Bill Evans / @realnotsteve, `mix/v2.4.0`): just the **Image Preparation** core discussed and agreed in that PR's review thread — format the reference to the model's step size, an optional barn-door **Live Area** sub-region, a megapixel budget, and paste-back compositing — as `flux2 i2i --prepared` and related flags. Everything else in #99's much larger scope (Generative Fill, Flux2App UI, project-file bundles, image save service, Upsize, SCUNet, Circus/VM-smoke plumbing) is out of scope here by design; see #99 (closed in favor of this PR) and its `docs/PR99-Update-Since-Review.md` for that history. The legacy plain-reference `i2i` path is byte-for-byte unchanged when no prep flag is set.

Original credit: **Bill Evans (@realnotsteve)**. `Sources/Flux2Core/ImagePreparation.swift`/`ImagePreparationTypes.swift`/`ImageCoordinateMapper.swift` are ported from the fork's tip with the Generative-Fill-only VLM-context-area functions trimmed off.

## Hardened across three local review rounds

**Correctness / data-loss class:**
- `--megapixels nan` (a plain typo) crashed the whole process — rejected explicitly at CLI parse time; Core-level clamps sanitize NaN as defense in depth.
- A completed, possibly multi-minute generation was discarded if `composite()` threw on an empty-intersection `--process-area`/`--live-area` combination — `ImagePreparation.validateComposable` now checks the (fully pre-known) geometry before any network/GPU work.
- `integralProcessRect` silently substituted the whole Live Area when `--process-area` didn't overlap it, instead of erroring — a typo'd, non-overlapping pair regenerated the wrong region with no diagnostic. Now throws.
- The secondary-reference "never upsample" check used a width-only ratio instead of the real crop/pad transform scale, missing genuine upsampling whenever `--favour`/`--method` reshape the aspect (e.g. `--favour vertical --method crop`) — silently reintroducing the interpolation-smear artifact the primary reference's own cap exists to prevent, on ordinary documented usage.

**Silent-surprise class:**
- `--megapixels` had no effect on actual VAE conditioning fidelity — silently re-capped by the unrelated `--max-reference-megapixels` default. Now follows the prepared budget unless overridden explicitly.
- `--width`/`--height` were silently discarded the instant any prep flag was set — rejected explicitly instead.
- `--no-composite` alone silently activated the entire prepared pipeline (unrequested cropping/resizing) despite its name only suggesting "skip paste-back" — now a no-op unless combined with another prep flag.
- `parseNormalizedRect`'s default `split()` silently absorbed a stray double comma into 4 (wrong) parts instead of rejecting malformed input.
- `referenceMatchedSize` truncated instead of rounding, undershooting the budget by a full 32px step on some combinations; `integralPixelRect`'s null-intersection fallback returned a degenerate 1×1 rect instead of full image bounds.

**Docs corrected to match the actual code:** `--process-area`'s coordinate space (full-image, not Live-Area-relative, and must overlap it), Live Area/`--process-area` only applying to the first reference image, the megapixel-budget section's contradiction of the deliberate never-upsample-the-VAE-reference design, and the paste-back edge tolerance (can exceed "a pixel or two" for a generously-drawn Live Area).

## Test plan
- [x] New/updated tests across three rounds: NaN handling, `validateComposable`, composite size-mismatch rejection, rounding, secondary-reference upsample cap (two distinct regressions — naive-ratio and real-crop-scale), process-area/live-area overlap rejection.
- [x] `xcodebuild test -scheme Flux2Swift-Package -destination 'platform=macOS' -skipPackagePluginValidation -only-testing:Flux2CoreTests` — **436 tests, 0 failures**; full package builds clean.
- [x] Manually verified against a real 1200×900/1500×1000 PNG and the built CLI binary: correct budget-clamped output sizing, composite-back logging, and all four new `ValidationError`/`Flux2Error` rejection paths (NaN, width+prep conflict, non-overlapping process-area) — clean errors, no crash, no residue.
- [x] Reviewed locally via `/code-review` (Sonnet), three passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)